### PR TITLE
Add CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,5 +36,3 @@ script:
   - cargo test --all -- --nocapture
   # Validate benches still work.
   - cargo bench --all -- --test
-  # Because failpoints inject failure in code path, which will affect all concurrently running tests, Hence they need to be synchronized, which make tests slow.
-  - cargo test --tests --features failpoint -- --nocapture

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,40 @@
+branches:
+  only:
+    # This is where pull requests from "bors r+" are built.
+    - staging
+    # This is where pull requests from "bors try" are built.
+    - trying
+    # Enable building pull requests.
+    - master
+
+language: rust
+sudo: false
+env:
+  global:
+    - RUST_BACKTRACE=1
+    - RUSTFLAGS="-D warnings"
+cache: cargo
+
+rust:
+
+matrix:
+  include:
+  # This build uses stable and checks rustfmt and clippy.
+  # We don't check them on nightly since their lints and formatting may differ.
+  - rust: stable
+    install:
+      - rustup component add rustfmt-preview
+      - rustup component add clippy-preview
+    before_script:
+      - cargo fmt --all -- --check
+      - cargo clippy --all -- -D clippy
+  # Since many users will use nightlies, also test that.
+  - rust: nightly
+
+
+script:
+  - cargo test --all -- --nocapture
+  # Validate benches still work.
+  - cargo bench --all -- --test
+  # Because failpoints inject failure in code path, which will affect all concurrently running tests, Hence they need to be synchronized, which make tests slow.
+  - cargo test --tests --features failpoint -- --nocapture

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,32 @@
+branches:
+  only:
+    # This is where pull requests from "bors r+" are built.
+    - staging
+    # This is where pull requests from "bors try" are built.
+    - trying
+    # Enable building pull requests.
+    - master
+
+environment:
+  matrix:
+    - TARGET: x86_64-pc-windows-gnu
+      RUST_VERSION: stable
+    - TARGET: x86_64-pc-windows-gnu
+      RUST_VERSION: nightly
+
+install:
+  - curl -sSf -o rustup-init.exe https://win.rustup.rs/
+  - rustup-init.exe -y --default-host %TARGET% --default-toolchain %RUST_VERSION%
+  - set PATH=%PATH%;C:\Users\appveyor\.cargo\bin
+  - rustc -Vv
+  - cargo -V
+
+# Building is done in the test phase, so we disable Appveyor's build phase.
+build: false
+
+cache:
+  - C:\Users\appveyor\.cargo\registry
+  - target
+
+test_script:
+  - cargo test


### PR DESCRIPTION
(This is based off #3, since it will become `master` shortly.)

Adds the CI scripts from Raft. These may require some future improvements, but they're a good place to start from.

# Post Merge

* [ ] Enable Travis CI
* [ ] Enable AppVeyor CI