### PR TITLE
Use failure for error management

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ name = "tikv_client"
 futures = "0.1"
 serde = "1.0"
 serde_derive = "1.0"
-quick-error = "1.2"
 grpcio = { version = "0.4", features = [ "secure" ] }
 protobuf = "~2.0"
 tokio-core = "0.1"
@@ -23,6 +22,7 @@ tokio-timer = "0.2"
 fxhash = "0.2"
 lazy_static = "0.2.1"
 log = "0.3.9"
+failure = "0.1"
 
 [dependencies.kvproto]
 git = "https://github.com/pingcap/kvproto.git"

--- a/examples/raw.rs
+++ b/examples/raw.rs
@@ -70,10 +70,8 @@ fn main() -> Result<()> {
         .expect("Could not delete value");
     println!("Key: {:?} deleted", key);
 
-    client
-        .get(key)
-        .wait()
-        .expect_err("Get returned value for not existing key");
+    // Get returns None for non-existing key
+    assert!(client.get(key).wait()?.is_none());
 
     let pairs: Vec<KvPair> = (1..3)
         .map(|i| KvPair::from((Key::from(format!("k{}", i)), Value::from(format!("v{}", i)))))

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -10,125 +10,135 @@
 // distributed under the License is distributed on an "AS IS" BASIS,
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
+use failure::{Backtrace, Context, Fail};
 use grpcio;
-use quick_error::quick_error;
-use std::{error, result};
+use std::fmt::{self, Display};
+use std::result;
 
-quick_error! {
-    /// An error originating from the TiKV client or dependencies.
-    ///
-    /// This client currently uses [`quick_error`](https://docs.rs/quick-error/1.2.2/quick_error/)
-    /// for errors. *This may change in future versions.*
-    #[derive(Debug)]
-    pub enum Error {
-        /// Wraps a `std::io::Error`.
-        Io(err: ::std::io::Error) {
-            from()
-            cause(err)
-            description(err.description())
+#[derive(Debug)]
+pub struct Error {
+    inner: Context<ErrorKind>,
+}
+
+/// An error originating from the TiKV client or dependencies.
+#[derive(Debug, Fail)]
+pub enum ErrorKind {
+    /// Wraps a `std::io::Error`.
+    #[fail(display = "IO error: {}", _0)]
+    Io(#[fail(cause)] std::io::Error),
+    /// Wraps a `grpcio::Error`.
+    #[fail(display = "gRPC error: {}", _0)]
+    Grpc(#[fail(cause)] grpcio::Error),
+    /// Represents that a futures oneshot channel was cancelled.
+    #[fail(display = "A futures oneshot channel was canceled. {}", _0)]
+    Canceled(#[fail(cause)] futures::sync::oneshot::Canceled),
+    /// Feature is not implemented.
+    #[fail(display = "Unimplemented feature")]
+    Unimplemented,
+    // No region is found for the given key.
+    #[fail(display = "Region is not found for key: {:?}", key)]
+    RegionForKeyNotFound { key: Vec<u8> },
+    /// The peer is not the leader for the region.
+    #[fail(display = "Peer is not leader for region {}. {}", region_id, message)]
+    NotLeader { region_id: u64, message: String },
+    /// Stale epoch
+    #[fail(display = "Stale epoch. {}", message)]
+    StaleEpoch { message: String },
+    /// No region is found for the given id.
+    #[fail(display = "Region {} is not found. {}", region_id, message)]
+    RegionNotFound { region_id: u64, message: String },
+    /// Invalid key range to scan. Only left bounded intervals are supported.
+    #[fail(display = "Only left bounded intervals are supported")]
+    InvalidKeyRange,
+    /// No such key
+    #[fail(display = "Key does not exist")]
+    NoSuchKey,
+    /// Cannot set an empty value
+    #[fail(display = "Cannot set an empty value")]
+    EmptyValue,
+    /// Scan limit exceeds the maximum
+    #[fail(display = "Limit {} exceeds max scan limit {}", limit, max_limit)]
+    MaxScanLimitExceeded { limit: u32, max_limit: u32 },
+    /// Wraps `kvproto::kvrpcpb::KeyError`
+    #[fail(display = "{:?}", _0)]
+    KeyError(kvproto::kvrpcpb::KeyError),
+    /// A string error returned by TiKV server
+    #[fail(display = "Kv error. {}", message)]
+    KvError { message: String },
+    /// Reconstructed `kvproto::errorpb::KeyNotInRegion`
+    #[fail(
+        display = "Key {:?} is not in region {}: [{:?}, {:?})",
+        key, region_id, start_key, end_key
+    )]
+    KeyNotInRegion {
+        key: Vec<u8>,
+        region_id: u64,
+        start_key: Vec<u8>,
+        end_key: Vec<u8>,
+    },
+    /// Reconstructed `kvproto::errorpb::ServerIsBusy`
+    #[fail(display = "Server is busy: {}. Backoff {} ms", reason, backoff_ms)]
+    ServerIsBusy { reason: String, backoff_ms: u64 },
+    /// Reconstructed `kvproto::errorpb::StaleCommand`
+    #[fail(display = "Stale command. {}", message)]
+    StaleCommand { message: String },
+    /// Reconstructed `kvproto::errorpb::StoreNotMatch`
+    #[fail(
+        display = "Requesting store {} when actual store is {}. {}",
+        request_store_id, actual_store_id, message
+    )]
+    StoreNotMatch {
+        request_store_id: u64,
+        actual_store_id: u64,
+        message: String,
+    },
+    /// Reconstructed `kvproto::errorpb::RaftEntryTooLarge`
+    #[fail(
+        display = "{} bytes raft entry of region {} is too large. {}",
+        entry_size, region_id, message
+    )]
+    RaftEntryTooLarge {
+        region_id: u64,
+        entry_size: u64,
+        message: String,
+    },
+    #[fail(display = "{}", message)]
+    InternalError { message: String },
+}
+
+impl Fail for Error {
+    fn cause(&self) -> Option<&Fail> {
+        self.inner.cause()
+    }
+
+    fn backtrace(&self) -> Option<&Backtrace> {
+        self.inner.backtrace()
+    }
+}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        Display::fmt(&self.inner, f)
+    }
+}
+
+impl Error {
+    pub fn kind(&self) -> &ErrorKind {
+        self.inner.get_context()
+    }
+}
+
+impl From<ErrorKind> for Error {
+    fn from(kind: ErrorKind) -> Error {
+        Error {
+            inner: Context::new(kind),
         }
-        /// Wraps a `grpcio::Error`.
-        Grpc(err: grpcio::Error) {
-            from()
-            cause(err)
-            description(err.description())
-        }
-        /// Represents that a futures oneshot channel was cancelled.
-        Canceled(err: ::futures::sync::oneshot::Canceled) {
-            from()
-            cause(err)
-            description(err.description())
-        }
-        /// An unknown error.
-        ///
-        /// Generally, this is not an expected error. Please report it if encountered.
-        Other(err: Box<error::Error + Sync + Send>) {
-            from()
-            cause(err.as_ref())
-            description(err.description())
-            display("unknown error {:?}", err)
-        }
-        /// A region was not found for the given key.
-        RegionForKeyNotFound(key: Vec<u8>) {
-            description("region is not found")
-            display("region is not found for key {:?}", key)
-        }
-        /// A region was not found.
-        RegionNotFound(region_id: u64, message: Option<String>) {
-            description("region is not found")
-            display("region {:?} is not found. {}", region_id, message.as_ref().unwrap_or(&"".to_owned()))
-        }
-        /// The peer is not a leader of the given region.
-        NotLeader(region_id: u64, message: Option<String>) {
-            description("peer is not leader")
-            display("peer is not leader for region {}. {}", region_id, message.as_ref().unwrap_or(&"".to_owned()))
-        }
-        /// The store does not match.
-        StoreNotMatch(request_store_id: u64, actual_store_id: u64, message: String) {
-            description("store not match")
-            display("requesting store '{}' when actual store is '{}'. {}", request_store_id, actual_store_id, message)
-        }
-        /// The given key is not within the given region.
-        KeyNotInRegion(key: Vec<u8>, region_id: u64, start_key: Vec<u8>, end_key: Vec<u8>) {
-            description("region is not found")
-            display("key {:?} is not in region {:?}: [{:?}, {:?})", key, region_id, start_key, end_key)
-        }
-        /// A stale epoch.
-        StaleEpoch(message: Option<String>) {
-            description("stale epoch")
-            display("{}", message.as_ref().unwrap_or(&"".to_owned()))
-        }
-        StaleCommand(message: String) {
-            description("stale command")
-            display("{}", message)
-        }
-        /// The server is too busy.
-        ServerIsBusy(reason: String, backoff: u64) {
-            description("server is busy")
-            display("server is busy: {:?}. Backoff {} ms", reason, backoff)
-        }
-        /// The given raft entry is too large for the region.
-        RaftEntryTooLarge(region_id: u64, entry_size: u64, message: String) {
-            description("raft entry too large")
-            display("{:?} bytes raft entry of region {:?} is too large. {}", entry_size, region_id, message)
-        }
-        KeyError(message: String) {
-            description("key error")
-            display("{}", message)
-        }
-        KVError(message: String) {
-            description("kv error")
-            display("{}", message)
-        }
-        InternalError(message: String) {
-           description("internal error")
-           display("{}", message)
-        }
-        InvalidKeyRange {
-            description("invalid key range")
-            display("Only left closed intervals are supported")
-        }
-        Unimplemented {
-            description("unimplemented feature")
-            display("Unimplemented feature")
-        }
-        EmptyValue {
-            description("can not set empty value")
-            display("Can not set empty value")
-        }
-        NoSuchKey {
-            description("key does not exist")
-            display("Key doest not exist")
-        }
-        InvalidOverlappingRanges {
-            description("ranges can not be overlapping")
-            display("Ranges can not be overlapping")
-        }
-        MaxScanLimitExceeded(limit: u32, max_limit: u32) {
-            description("limit exceeds max scan limit")
-            display("Limit {} excceds max scan limit {}", limit, max_limit)
-        }
+    }
+}
+
+impl From<Context<ErrorKind>> for Error {
+    fn from(inner: Context<ErrorKind>) -> Error {
+        Error { inner }
     }
 }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -50,9 +50,6 @@ pub enum ErrorKind {
     /// Invalid key range to scan. Only left bounded intervals are supported.
     #[fail(display = "Only left bounded intervals are supported")]
     InvalidKeyRange,
-    /// No such key
-    #[fail(display = "Key does not exist")]
-    NoSuchKey,
     /// Cannot set an empty value
     #[fail(display = "Cannot set an empty value")]
     EmptyValue,
@@ -157,10 +154,6 @@ impl Error {
 
     pub(crate) fn invalid_key_range() -> Self {
         Error::from(ErrorKind::InvalidKeyRange)
-    }
-
-    pub(crate) fn no_such_key() -> Self {
-        Error::from(ErrorKind::NoSuchKey)
     }
 
     pub(crate) fn empty_value() -> Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,8 +10,9 @@
 // distributed under the License is distributed on an "AS IS" BASIS,
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#![recursion_limit = "128"]
-#![type_length_limit = "1572864"]
+
+// Long and nested future chains can quickly result in large generic types.
+#![type_length_limit = "16777216"]
 
 use futures::Future;
 use serde_derive::*;
@@ -32,6 +33,8 @@ pub mod transaction;
 
 #[doc(inline)]
 pub use crate::errors::Error;
+#[doc(inline)]
+pub use crate::errors::ErrorKind;
 #[doc(inline)]
 pub use crate::errors::Result;
 
@@ -462,7 +465,7 @@ fn range_to_keys(range: (Bound<Key>, Bound<Key>)) -> Result<(Key, Option<Key>)> 
             }
             v
         }
-        Bound::Unbounded => return Err(Error::InvalidKeyRange),
+        Bound::Unbounded => Err(ErrorKind::InvalidKeyRange)?,
     };
     let end = match range.1 {
         Bound::Included(v) => Some(v),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -465,7 +465,7 @@ fn range_to_keys(range: (Bound<Key>, Bound<Key>)) -> Result<(Key, Option<Key>)> 
             }
             v
         }
-        Bound::Unbounded => Err(ErrorKind::InvalidKeyRange)?,
+        Bound::Unbounded => Err(Error::invalid_key_range())?,
     };
     let end = match range.1 {
         Bound::Included(v) => Some(v),

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -20,7 +20,9 @@
 ///
 /// **Warning:** It is not advisible to use the both raw and transactional functionality in the same keyspace.
 ///
-use crate::{rpc::RpcClient, Config, Error, Key, KeyRange, KvFuture, KvPair, Result, Value};
+use crate::{
+    rpc::RpcClient, Config, Error, ErrorKind, Key, KeyRange, KvFuture, KvPair, Result, Value,
+};
 use futures::{future, Async, Future, Poll};
 use std::{
     ops::{Bound, Deref},
@@ -679,10 +681,13 @@ impl RequestInner for ScanInner {
 
     fn execute(self, client: Arc<RpcClient>, cf: Option<ColumnFamily>) -> KvFuture<Self::Resp> {
         if self.limit > MAX_RAW_KV_SCAN_LIMIT {
-            Box::new(future::err(Error::MaxScanLimitExceeded(
-                self.limit,
-                MAX_RAW_KV_SCAN_LIMIT,
-            )))
+            Box::new(future::err(
+                ErrorKind::MaxScanLimitExceeded {
+                    limit: self.limit,
+                    max_limit: MAX_RAW_KV_SCAN_LIMIT,
+                }
+                .into(),
+            ))
         } else {
             let keys = match self.range.into_keys() {
                 Err(e) => return Box::new(future::err(e)),
@@ -751,13 +756,16 @@ impl RequestInner for BatchScanInner {
 
     fn execute(self, client: Arc<RpcClient>, cf: Option<ColumnFamily>) -> KvFuture<Self::Resp> {
         if self.each_limit > MAX_RAW_KV_SCAN_LIMIT {
-            Box::new(future::err(Error::MaxScanLimitExceeded(
-                self.each_limit,
-                MAX_RAW_KV_SCAN_LIMIT,
-            )))
+            Box::new(future::err(
+                ErrorKind::MaxScanLimitExceeded {
+                    limit: self.each_limit,
+                    max_limit: MAX_RAW_KV_SCAN_LIMIT,
+                }
+                .into(),
+            ))
         } else if self.ranges.iter().any(Result::is_err) {
             // All errors must be InvalidKeyRange so we can simply return a new InvalidKeyRange
-            Box::new(future::err(Error::InvalidKeyRange))
+            Box::new(future::err(ErrorKind::InvalidKeyRange.into()))
         } else {
             Box::new(client.raw_batch_scan(
                 self.ranges.into_iter().map(Result::unwrap).collect(),

--- a/src/rpc/client.rs
+++ b/src/rpc/client.rs
@@ -35,7 +35,7 @@ use crate::{
         tikv::KvClient,
         util::HandyRwLock,
     },
-    Config, Error, ErrorKind, Key, KvPair, Result, Value,
+    Config, Error, Key, KvPair, Result, Value,
 };
 
 const CQ_COUNT: usize = 1;
@@ -253,7 +253,7 @@ impl RpcClient {
             .and_then(move |context| context.client().raw_get(context, key))
             .and_then(move |value| {
                 if value.is_empty() {
-                    Err(ErrorKind::NoSuchKey)?
+                    Err(Error::no_such_key())?
                 } else {
                     Ok(value)
                 }
@@ -292,7 +292,7 @@ impl RpcClient {
         cf: Option<ColumnFamily>,
     ) -> impl Future<Item = (), Error = Error> {
         if value.is_empty() {
-            Either::A(future::err(ErrorKind::EmptyValue.into()))
+            Either::A(future::err(Error::empty_value()))
         } else {
             Either::B(
                 Self::raw(self.inner(), &key, cf)
@@ -307,7 +307,7 @@ impl RpcClient {
         cf: Option<ColumnFamily>,
     ) -> impl Future<Item = (), Error = Error> {
         if pairs.iter().any(|p| p.value().is_empty()) {
-            Either::A(future::err(ErrorKind::EmptyValue.into()))
+            Either::A(future::err(Error::empty_value()))
         } else {
             let inner = self.inner();
             Either::B(
@@ -427,7 +427,7 @@ impl RpcClient {
     ) -> impl Future<Item = Vec<KvPair>, Error = Error> {
         drop(ranges);
         drop(cf);
-        future::err(ErrorKind::Unimplemented.into())
+        future::err(Error::unimplemented())
     }
 
     pub fn raw_delete_range(

--- a/src/rpc/client.rs
+++ b/src/rpc/client.rs
@@ -285,7 +285,7 @@ impl RpcClient {
         cf: Option<ColumnFamily>,
     ) -> impl Future<Item = (), Error = Error> {
         if value.is_empty() {
-            Either::A(future::err(Error::EmptyValue))
+            Either::A(future::err(Error::empty_value()))
         } else {
             Either::B(
                 Self::raw(self.inner(), &key, cf)
@@ -300,7 +300,7 @@ impl RpcClient {
         cf: Option<ColumnFamily>,
     ) -> impl Future<Item = (), Error = Error> {
         if pairs.iter().any(|p| p.value().is_empty()) {
-            Either::A(future::err(Error::EmptyValue))
+            Either::A(future::err(Error::empty_value()))
         } else {
             let inner = self.inner();
             Either::B(
@@ -416,7 +416,7 @@ impl RpcClient {
     ) -> impl Future<Item = Vec<KvPair>, Error = Error> {
         drop(ranges);
         drop(cf);
-        future::err(Error::Unimplemented)
+        future::err(Error::unimplemented())
     }
 
     pub fn raw_delete_range(

--- a/src/rpc/client.rs
+++ b/src/rpc/client.rs
@@ -35,7 +35,7 @@ use crate::{
         tikv::KvClient,
         util::HandyRwLock,
     },
-    Config, Error, Key, KvPair, Result, Value,
+    Config, Error, ErrorKind, Key, KvPair, Result, Value,
 };
 
 const CQ_COUNT: usize = 1;
@@ -253,7 +253,7 @@ impl RpcClient {
             .and_then(move |context| context.client().raw_get(context, key))
             .and_then(move |value| {
                 if value.is_empty() {
-                    Err(Error::NoSuchKey)
+                    Err(ErrorKind::NoSuchKey)?
                 } else {
                     Ok(value)
                 }
@@ -292,7 +292,7 @@ impl RpcClient {
         cf: Option<ColumnFamily>,
     ) -> impl Future<Item = (), Error = Error> {
         if value.is_empty() {
-            Either::A(future::err(Error::EmptyValue))
+            Either::A(future::err(ErrorKind::EmptyValue.into()))
         } else {
             Either::B(
                 Self::raw(self.inner(), &key, cf)
@@ -307,7 +307,7 @@ impl RpcClient {
         cf: Option<ColumnFamily>,
     ) -> impl Future<Item = (), Error = Error> {
         if pairs.iter().any(|p| p.value().is_empty()) {
-            Either::A(future::err(Error::EmptyValue))
+            Either::A(future::err(ErrorKind::EmptyValue.into()))
         } else {
             let inner = self.inner();
             Either::B(
@@ -427,7 +427,7 @@ impl RpcClient {
     ) -> impl Future<Item = Vec<KvPair>, Error = Error> {
         drop(ranges);
         drop(cf);
-        future::err(Error::Unimplemented)
+        future::err(ErrorKind::Unimplemented.into())
     }
 
     pub fn raw_delete_range(

--- a/src/rpc/pd/client.rs
+++ b/src/rpc/pd/client.rs
@@ -32,7 +32,7 @@ use crate::{
         security::SecurityManager,
         util::HandyRwLock,
     },
-    Error, ErrorKind, Result,
+    Error, Result,
 };
 
 const LEADER_CHANGE_RETRY: usize = 10;
@@ -102,7 +102,7 @@ impl PdClient {
             let region = if resp.has_region() {
                 resp.take_region()
             } else {
-                Err(ErrorKind::RegionForKeyNotFound { key })?
+                Err(Error::region_for_key_not_found(key))?
             };
             let leader = if resp.has_leader() {
                 Some(resp.take_leader())
@@ -128,10 +128,7 @@ impl PdClient {
             let region = if resp.has_region() {
                 resp.take_region()
             } else {
-                Err(ErrorKind::RegionNotFound {
-                    region_id,
-                    message: String::default(),
-                })?
+                Err(Error::region_not_found(region_id, None))?
             };
             let leader = if resp.has_leader() {
                 Some(resp.take_leader())
@@ -158,7 +155,7 @@ impl PdClient {
             let cli = &cli.rl().client;
             executor(cli, option)
                 .unwrap()
-                .map_err(|e| ErrorKind::Grpc(e).into())
+                .map_err(Into::into)
                 .and_then(|r| {
                     {
                         let header = r.header();

--- a/src/rpc/pd/leader.rs
+++ b/src/rpc/pd/leader.rs
@@ -39,7 +39,7 @@ use crate::{
         security::SecurityManager,
         util::HandyRwLock,
     },
-    Error, Result,
+    Error, ErrorKind, Result,
 };
 
 macro_rules! pd_request {
@@ -139,12 +139,12 @@ impl PdReactor {
         let (tx, rx) = client.wl().client.tso().unwrap();
         let tso_rx = client.wl().reactor.tso_rx.take().unwrap();
         handle.spawn(
-            tx.sink_map_err(Error::Grpc)
+            tx.sink_map_err(|e| ErrorKind::Grpc(e).into())
                 .send_all(tso_rx.then(|r| match r {
                     Ok(r) => Ok((r, WriteFlags::default())),
                     Err(()) => Err(internal_err!("failed to recv tso requests")),
                 }))
-                .then(|r| match r {
+                .then(|r: Result<_>| match r {
                     Ok((mut sender, _)) => {
                         sender.get_mut().cancel();
                         Ok(())
@@ -220,7 +220,8 @@ impl PdReactor {
             // Schedule tso request to run.
             self.schedule(PdTask::Request);
         }
-        rx.map_err(Error::Canceled).then(move |r| context.done(r))
+        rx.map_err(|e| ErrorKind::Canceled(e).into())
+            .then(move |r| context.done(r))
     }
 }
 
@@ -362,10 +363,10 @@ fn connect(
 ) -> Result<(pdpb_grpc::PdClient, pdpb::GetMembersResponse)> {
     let client = security_mgr.connect(env, addr, pdpb_grpc::PdClient::new)?;
     let option = CallOption::default().timeout(timeout);
-    match client.get_members_opt(&pdpb::GetMembersRequest::new(), option) {
-        Ok(resp) => Ok((client, resp)),
-        Err(e) => Err(Error::Grpc(e)),
-    }
+    let resp = client
+        .get_members_opt(&pdpb::GetMembersRequest::new(), option)
+        .map_err(ErrorKind::Grpc)?;
+    Ok((client, resp))
 }
 
 fn try_connect(

--- a/src/rpc/pd/mod.rs
+++ b/src/rpc/pd/mod.rs
@@ -16,7 +16,7 @@ use std::ops::{Deref, DerefMut};
 use kvproto::{kvrpcpb, metapb};
 
 pub use crate::rpc::pd::client::PdClient;
-use crate::{ErrorKind, Key, Result};
+use crate::{Error, Key, Result};
 
 #[macro_use]
 mod leader;
@@ -76,13 +76,7 @@ impl Region {
     pub fn context(&self) -> Result<kvrpcpb::Context> {
         self.leader
             .as_ref()
-            .ok_or_else(|| {
-                ErrorKind::NotLeader {
-                    region_id: self.region.get_id(),
-                    message: String::default(),
-                }
-                .into()
-            })
+            .ok_or_else(|| Error::not_leader(self.region.get_id(), None))
             .map(|l| {
                 let mut ctx = kvrpcpb::Context::default();
                 ctx.set_region_id(self.region.get_id());
@@ -119,12 +113,7 @@ impl Region {
             .as_ref()
             .map(Clone::clone)
             .map(Into::into)
-            .ok_or_else(|| {
-                ErrorKind::StaleEpoch {
-                    message: String::default(),
-                }
-                .into()
-            })
+            .ok_or_else(|| Error::stale_epoch(None))
     }
 
     pub fn meta(&self) -> metapb::Region {

--- a/src/rpc/util.rs
+++ b/src/rpc/util.rs
@@ -22,7 +22,10 @@ use tokio_timer::{self, timer::Handle};
 
 macro_rules! internal_err {
     ($e:expr) => ({
-        $crate::Error::InternalError(format!("[{}:{}]: {}", file!(), line!(),  $e))
+        let kind = $crate::ErrorKind::InternalError {
+            message: format!("[{}:{}]: {}", file!(), line!(),  $e)
+        };
+        $crate::Error::from(kind)
     });
     ($f:tt, $($arg:expr),+) => ({
         internal_err!(format!($f, $($arg),+))

--- a/src/rpc/util.rs
+++ b/src/rpc/util.rs
@@ -22,9 +22,9 @@ use tokio_timer::{self, timer::Handle};
 
 macro_rules! internal_err {
     ($e:expr) => ({
-        let kind = $crate::ErrorKind::InternalError {
-            message: format!("[{}:{}]: {}", file!(), line!(),  $e)
-        };
+        let kind = $crate::Error::internal_error(
+            format!("[{}:{}]: {}", file!(), line!(),  $e)
+        );
         $crate::Error::from(kind)
     });
     ($f:tt, $($arg:expr),+) => ({


### PR DESCRIPTION
As mentioned in #10, we are going to use failure for error management.

This PR is almost a mechanical transformation of @sunxiaoguang 's previous work, leaving furthur questions to other PRs.

Questions about current errors:

* Should `ErrorKind` be public to users? Currently, I think the caller can do nothing effective at runtime when receiving an Error (except `NoSuchKey`, discussed below). The caller can just log the error and try again. Therefore, it seems useless to expose `ErrorKind` to users. Keeping it private helps with forward compatibility, however we may not need that.

* Should we treat `NoSuchKey` as an error? People might need to know whether a key exists. Now, they have to match from the error variants and see if it is a `NoSuchKey`.  IMO `Option<Value>` is a better option for the get api. 

* `InternalError` looks like a box for all uncategorized errors. Those which relate to PD should have their own error variants in the future.

* Inconsistency with errors from kvproto. `KeyError` is just a wrapper of the original error, and the others extracts the inner fields.