### PR TITLE
Bump Kvproto

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ log = "0.3.9"
 
 [dependencies.kvproto]
 git = "https://github.com/pingcap/kvproto.git"
+rev  = "f9b9e7d362c7cc2c90202fc7c300b2e466cbfbf2"
 
 [dependencies.prometheus]
 version = "0.4.2"

--- a/src/rpc/tikv/client.rs
+++ b/src/rpc/tikv/client.rs
@@ -55,11 +55,11 @@ impl From<errorpb::Error> for Error {
                 e.take_start_key(),
                 e.take_end_key(),
             )
-        } else if e.has_stale_epoch() {
+        } else if e.has_epoch_not_match() {
             Error::StaleEpoch(Some(format!(
                 "{}. New epoch: {:?}",
                 message,
-                e.get_stale_epoch().get_new_regions()
+                e.get_epoch_not_match().get_current_regions()
             )))
         } else if e.has_server_is_busy() {
             let mut e = e.take_server_is_busy();


### PR DESCRIPTION
Bumps KVproto to latest master as it broke our build in a recent commit. This also locks us to a particular revision for the time being.

@siddontang we need to consider if we will publish kvproto. This lib cannot be published unless its dependencies are.