### PR TITLE
Add simple unit tests for our KeyRange implementations.

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -47,9 +47,6 @@ pub enum ErrorKind {
     /// No region is found for the given id.
     #[fail(display = "Region {} is not found. {}", region_id, message)]
     RegionNotFound { region_id: u64, message: String },
-    /// Invalid key range to scan. Only left bounded intervals are supported.
-    #[fail(display = "Only left bounded intervals are supported")]
-    InvalidKeyRange,
     /// Cannot set an empty value
     #[fail(display = "Cannot set an empty value")]
     EmptyValue,
@@ -150,10 +147,6 @@ impl Error {
             region_id,
             message: message.unwrap_or_default(),
         })
-    }
-
-    pub(crate) fn invalid_key_range() -> Self {
-        Error::from(ErrorKind::InvalidKeyRange)
     }
 
     pub(crate) fn empty_value() -> Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -641,43 +641,16 @@ impl<T: Into<Key>> KeyRange for Range<T> {
     }
 }
 
-#[test]
-fn test_range() -> Result<()> {
-    let input = vec![0]..vec![10];
-    let output = input.into_keys()?;
-    let expected = (Key::from(vec![0]), Some(Key::from(vec![9])));
-    assert_eq!(output, expected);
-    Ok(())
-}
-
 impl<T: Into<Key>> KeyRange for RangeFrom<T> {
     fn into_bounds(self) -> (Bound<Key>, Bound<Key>) {
         (Bound::Included(self.start.into()), Bound::Unbounded)
     }
 }
 
-#[test]
-fn test_range_from() -> Result<()> {
-    let input = vec![0]..;
-    let output = input.into_keys()?;
-    let expected = (Key::from(vec![0]), None);
-    assert_eq!(output, expected);
-    Ok(())
-}
-
 impl KeyRange for RangeFull {
     fn into_bounds(self) -> (Bound<Key>, Bound<Key>) {
         (Bound::Unbounded, Bound::Unbounded)
     }
-}
-
-#[test]
-fn test_range_full() -> Result<()> {
-    let input = ..;
-    let output = input.into_keys()?;
-    let expected = (Key::from(vec![0]), None);
-    assert_eq!(output, expected);
-    Ok(())
 }
 
 impl<T: Into<Key>> KeyRange for RangeInclusive<T> {
@@ -687,28 +660,10 @@ impl<T: Into<Key>> KeyRange for RangeInclusive<T> {
     }
 }
 
-#[test]
-fn test_range_inclusive() -> Result<()> {
-    let input = vec![0]..=vec![10];
-    let output = input.into_keys()?;
-    let expected = (Key::from(vec![0]), Some(Key::from(vec![10])));
-    assert_eq!(output, expected);
-    Ok(())
-}
-
 impl<T: Into<Key>> KeyRange for RangeTo<T> {
     fn into_bounds(self) -> (Bound<Key>, Bound<Key>) {
         (Bound::Unbounded, Bound::Excluded(self.end.into()))
     }
-}
-
-#[test]
-fn test_range_to() -> Result<()> {
-    let input = ..vec![10];
-    let output = input.into_keys()?;
-    let expected = (Key::from(vec![0]), Some(Key::from(vec![9])));
-    assert_eq!(output, expected);
-    Ok(())
 }
 
 impl<T: Into<Key>> KeyRange for RangeToInclusive<T> {
@@ -717,28 +672,10 @@ impl<T: Into<Key>> KeyRange for RangeToInclusive<T> {
     }
 }
 
-#[test]
-fn test_range_to_inclusive() -> Result<()> {
-    let input = ..=vec![10];
-    let output = input.into_keys()?;
-    let expected = (Key::from(vec![0]), Some(Key::from(vec![10])));
-    assert_eq!(output, expected);
-    Ok(())
-}
-
 impl<T: Into<Key>> KeyRange for (Bound<T>, Bound<T>) {
     fn into_bounds(self) -> (Bound<Key>, Bound<Key>) {
         (convert_to_bound_key(self.0), convert_to_bound_key(self.1))
     }
-}
-
-#[test]
-fn test_bound_bound() -> Result<()> {
-    let input = (Bound::Included(vec![0]), Bound::Included(vec![10]));
-    let output = input.into_keys()?;
-    let expected = (Key::from(vec![0]), Some(Key::from(vec![10])));
-    assert_eq!(output, expected);
-    Ok(())
 }
 
 fn convert_to_bound_key<K>(b: Bound<K>) -> Bound<Key>
@@ -750,5 +687,72 @@ where
         Included(k) => Included(k.into()),
         Excluded(k) => Excluded(k.into()),
         Unbounded => Unbounded,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Bound, Key, KeyRange, Result};
+    #[test]
+    fn test_range() -> Result<()> {
+        let input = vec![0]..vec![10];
+        let output = input.into_keys()?;
+        let expected = (Key::from(vec![0]), Some(Key::from(vec![9])));
+        assert_eq!(output, expected);
+        Ok(())
+    }
+
+    #[test]
+    fn test_range_from() -> Result<()> {
+        let input = vec![0]..;
+        let output = input.into_keys()?;
+        let expected = (Key::from(vec![0]), None);
+        assert_eq!(output, expected);
+        Ok(())
+    }
+
+    #[test]
+    fn test_range_full() -> Result<()> {
+        let input = ..;
+        let output = input.into_keys()?;
+        let expected = (Key::from(vec![0]), None);
+        assert_eq!(output, expected);
+        Ok(())
+    }
+
+    #[test]
+    fn test_range_inclusive() -> Result<()> {
+        let input = vec![0]..=vec![10];
+        let output = input.into_keys()?;
+        let expected = (Key::from(vec![0]), Some(Key::from(vec![10])));
+        assert_eq!(output, expected);
+        Ok(())
+    }
+
+    #[test]
+    fn test_range_to() -> Result<()> {
+        let input = ..vec![10];
+        let output = input.into_keys()?;
+        let expected = (Key::from(vec![0]), Some(Key::from(vec![9])));
+        assert_eq!(output, expected);
+        Ok(())
+    }
+
+    #[test]
+    fn test_range_to_inclusive() -> Result<()> {
+        let input = ..=vec![10];
+        let output = input.into_keys()?;
+        let expected = (Key::from(vec![0]), Some(Key::from(vec![10])));
+        assert_eq!(output, expected);
+        Ok(())
+    }
+
+    #[test]
+    fn test_bound_bound() -> Result<()> {
+        let input = (Bound::Included(vec![0]), Bound::Included(vec![10]));
+        let output = input.into_keys()?;
+        let expected = (Key::from(vec![0]), Some(Key::from(vec![10])));
+        assert_eq!(output, expected);
+        Ok(())
     }
 }

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -755,9 +755,6 @@ impl RequestInner for BatchScanInner {
                 self.each_limit,
                 MAX_RAW_KV_SCAN_LIMIT,
             )))
-        } else if self.ranges.iter().any(Result::is_err) {
-            // All errors must be InvalidKeyRange so we can simply return a new InvalidKeyRange
-            Box::new(future::err(Error::invalid_key_range()))
         } else {
             Box::new(client.raw_batch_scan(
                 self.ranges.into_iter().map(Result::unwrap).collect(),


### PR DESCRIPTION
Adds some unit tests for KeyRange to check their validity.

Also sets the behavior of `..x` to go from `[0]` to whatever x is, instead of erroring.