### PR TITLE
Use new kvproto raft branch update

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,10 +21,10 @@ name = "tikv_client"
 failure = "0.1"
 futures = "0.1"
 fxhash = "0.2"
-grpcio = { version = "0.4", features = [ "secure" ] }
+grpcio = { version = "0.5.0-alpha", features = [ "secure", "prost-codec" ], default-features = false }
 lazy_static = "0.2.1"
 log = "0.3.9"
-protobuf = "~2.0"
+protobuf = "2"
 serde = "1.0"
 serde_derive = "1.0"
 tokio-core = "0.1"

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -22,6 +22,7 @@ pub struct Error {
 
 /// An error originating from the TiKV client or dependencies.
 #[derive(Debug, Fail)]
+#[allow(clippy::large_enum_variant)]
 pub enum ErrorKind {
     /// Wraps a `std::io::Error`.
     #[fail(display = "IO error: {}", _0)]

--- a/src/rpc/client.rs
+++ b/src/rpc/client.rs
@@ -28,6 +28,7 @@ use futures::{
 };
 use grpcio::{EnvBuilder, Environment};
 use kvproto::kvrpcpb;
+use protobuf::Message;
 use log::*;
 
 use crate::{

--- a/src/rpc/client.rs
+++ b/src/rpc/client.rs
@@ -28,8 +28,8 @@ use futures::{
 };
 use grpcio::{EnvBuilder, Environment};
 use kvproto::kvrpcpb;
-use protobuf::Message;
 use log::*;
+use protobuf::Message;
 
 use crate::{
     raw::ColumnFamily,

--- a/src/rpc/pd/client.rs
+++ b/src/rpc/pd/client.rs
@@ -19,7 +19,7 @@ use std::{
 
 use futures::Future;
 use grpcio::{CallOption, Environment};
-use kvproto::{metapb, pdpb, pdpb_grpc::PdClient as RpcClient};
+use kvproto::{metapb, pdpb, pdpb::PdClient as RpcClient};
 
 use crate::{
     rpc::{
@@ -117,7 +117,7 @@ impl PdClient {
         &self,
         region_id: u64,
     ) -> impl Future<Item = (metapb::Region, Option<metapb::Peer>), Error = Error> {
-        let mut req = pd_request!(self.cluster_id, pdpb::GetRegionByIDRequest);
+        let mut req = pd_request!(self.cluster_id, pdpb::GetRegionByIdRequest);
         req.set_region_id(region_id);
 
         self.execute(request_context(

--- a/src/rpc/pd/leader.rs
+++ b/src/rpc/pd/leader.rs
@@ -27,8 +27,8 @@ use futures::{
 use fxhash::FxHashSet as HashSet;
 use grpcio::{CallOption, Environment, WriteFlags};
 use kvproto::pdpb;
-use protobuf::Message;
 use log::*;
+use protobuf::Message;
 use tokio_core::reactor::{Core, Handle as OtherHandle};
 
 use crate::{


### PR DESCRIPTION
Use the new version of kvproto on the branch we're depending on (raft update https://github.com/pingcap/kvproto/pull/357) so that we can build properly still.
