### PR TITLE
Use an enum for `ColumnFamily`

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -70,6 +70,9 @@ pub enum ErrorKind {
     /// Represents `kvproto::errorpb::StaleCommand` with additional error message
     #[fail(display = "Stale command. {}", message)]
     StaleCommand { message: String },
+    /// Represents `kvproto::errorpb::StaleCommand` with additional error message
+    #[fail(display = "Invalid value for column family: {}", supplied)]
+    InvalidColumnFamily { supplied: String },
     /// Represents `kvproto::errorpb::StoreNotMatch` with additional error message
     #[fail(
         display = "Requesting store {} when actual store is {}. {}",

--- a/src/rpc/tikv/client.rs
+++ b/src/rpc/tikv/client.rs
@@ -165,7 +165,7 @@ macro_rules! raw_request {
         let (region, cf) = $context.into_inner();
         req.set_context(region.into());
         if let Some(cf) = cf {
-            req.set_cf(cf.into_inner());
+            req.set_cf(cf.to_string());
         }
         req
     }};


### PR DESCRIPTION
Means we have proper typing rather than stringly typing.

PTAL @Hoverbear 