### PR TITLE
Satisfy a newly rigorous compiler warning

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -95,7 +95,7 @@ pub enum ErrorKind {
 }
 
 impl Fail for Error {
-    fn cause(&self) -> Option<&Fail> {
+    fn cause(&self) -> Option<&dyn Fail> {
         self.inner.cause()
     }
 


### PR DESCRIPTION
Currently causing CI to fail, e.g., https://travis-ci.org/tikv/client-rust/jobs/539510352