### PR TITLE
Rename Client::new to connect

### DIFF
--- a/examples/raw.rs
+++ b/examples/raw.rs
@@ -26,7 +26,7 @@ async fn main() -> Result<()> {
 
     // When we first create a client we receive a `Connect` structure which must be resolved before
     // the client is actually connected and usable.
-    let unconnnected_client = Client::new(config);
+    let unconnnected_client = Client::connect(config);
     let client = unconnnected_client.await?;
 
     // Requests are created from the connected client. These calls return structures which

--- a/examples/transaction.rs
+++ b/examples/transaction.rs
@@ -83,7 +83,7 @@ async fn main() {
         Config::new(args.pd)
     };
 
-    let txn = Client::new(config)
+    let txn = Client::connect(config)
         .await
         .expect("Could not connect to tikv");
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,7 @@
 //! ]).with_security("root.ca", "internal.cert", "internal.key");
 //!
 //! // Get an unresolved connection.
-//! let connect = Client::new(config);
+//! let connect = Client::connect(config);
 //!
 //! // Resolve the connection into a client.
 //! let client = connect.into_future().await;

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -28,12 +28,11 @@ impl Client {
     /// # use tikv_client::{Config, raw::Client};
     /// # use futures::prelude::*;
     /// # futures::executor::block_on(async {
-    /// let connect = Client::new(Config::default());
+    /// let connect = Client::connect(Config::default());
     /// let client = connect.await.unwrap();
     /// # });
     /// ```
-    #[allow(clippy::new_ret_no_self)]
-    pub fn new(config: Config) -> Connect {
+    pub fn connect(config: Config) -> Connect {
         Connect::new(config)
     }
 
@@ -52,7 +51,7 @@ impl Client {
     /// # use tikv_client::{Value, Config, raw::Client};
     /// # use futures::prelude::*;
     /// # futures::executor::block_on(async {
-    /// # let connecting_client = Client::new(Config::new(vec!["192.168.0.100", "192.168.0.101"]));
+    /// # let connecting_client = Client::connect(Config::new(vec!["192.168.0.100", "192.168.0.101"]));
     /// # let connected_client = connecting_client.await.unwrap();
     /// let key = "TiKV";
     /// let req = connected_client.get(key);
@@ -73,7 +72,7 @@ impl Client {
     /// # use tikv_client::{KvPair, Config, raw::Client};
     /// # use futures::prelude::*;
     /// # futures::executor::block_on(async {
-    /// # let connecting_client = Client::new(Config::new(vec!["192.168.0.100", "192.168.0.101"]));
+    /// # let connecting_client = Client::connect(Config::new(vec!["192.168.0.100", "192.168.0.101"]));
     /// # let connected_client = connecting_client.await.unwrap();
     /// let keys = vec!["TiKV", "TiDB"];
     /// let req = connected_client.batch_get(keys);
@@ -96,7 +95,7 @@ impl Client {
     /// # use tikv_client::{Key, Value, Config, raw::Client};
     /// # use futures::prelude::*;
     /// # futures::executor::block_on(async {
-    /// # let connecting_client = Client::new(Config::new(vec!["192.168.0.100", "192.168.0.101"]));
+    /// # let connecting_client = Client::connect(Config::new(vec!["192.168.0.100", "192.168.0.101"]));
     /// # let connected_client = connecting_client.await.unwrap();
     /// let key = "TiKV";
     /// let val = "TiKV";
@@ -117,7 +116,7 @@ impl Client {
     /// # use tikv_client::{Error, Result, KvPair, Key, Value, Config, raw::Client};
     /// # use futures::prelude::*;
     /// # futures::executor::block_on(async {
-    /// # let connecting_client = Client::new(Config::new(vec!["192.168.0.100", "192.168.0.101"]));
+    /// # let connecting_client = Client::connect(Config::new(vec!["192.168.0.100", "192.168.0.101"]));
     /// # let connected_client = connecting_client.await.unwrap();
     /// let kvpair1 = ("PD", "Go");
     /// let kvpair2 = ("TiKV", "Rust");
@@ -142,7 +141,7 @@ impl Client {
     /// # use tikv_client::{Key, Config, raw::Client};
     /// # use futures::prelude::*;
     /// # futures::executor::block_on(async {
-    /// # let connecting_client = Client::new(Config::new(vec!["192.168.0.100", "192.168.0.101"]));
+    /// # let connecting_client = Client::connect(Config::new(vec!["192.168.0.100", "192.168.0.101"]));
     /// # let connected_client = connecting_client.await.unwrap();
     /// let key = "TiKV";
     /// let req = connected_client.delete(key);
@@ -162,7 +161,7 @@ impl Client {
     /// # use tikv_client::{Config, raw::Client};
     /// # use futures::prelude::*;
     /// # futures::executor::block_on(async {
-    /// # let connecting_client = Client::new(Config::new(vec!["192.168.0.100", "192.168.0.101"]));
+    /// # let connecting_client = Client::connect(Config::new(vec!["192.168.0.100", "192.168.0.101"]));
     /// # let connected_client = connecting_client.await.unwrap();
     /// let keys = vec!["TiKV", "TiDB"];
     /// let req = connected_client.batch_delete(keys);
@@ -185,7 +184,7 @@ impl Client {
     /// # use tikv_client::{KvPair, Config, raw::Client};
     /// # use futures::prelude::*;
     /// # futures::executor::block_on(async {
-    /// # let connecting_client = Client::new(Config::new(vec!["192.168.0.100", "192.168.0.101"]));
+    /// # let connecting_client = Client::connect(Config::new(vec!["192.168.0.100", "192.168.0.101"]));
     /// # let connected_client = connecting_client.await.unwrap();
     /// let inclusive_range = "TiKV"..="TiDB";
     /// let req = connected_client.scan(inclusive_range, 2);
@@ -205,7 +204,7 @@ impl Client {
     /// # use tikv_client::{Key, Config, raw::Client};
     /// # use futures::prelude::*;
     /// # futures::executor::block_on(async {
-    /// # let connecting_client = Client::new(Config::new(vec!["192.168.0.100", "192.168.0.101"]));
+    /// # let connecting_client = Client::connect(Config::new(vec!["192.168.0.100", "192.168.0.101"]));
     /// # let connected_client = connecting_client.await.unwrap();
     /// let inclusive_range1 = "TiDB"..="TiKV";
     /// let inclusive_range2 = "TiKV"..="TiSpark";
@@ -237,7 +236,7 @@ impl Client {
     /// # use tikv_client::{Key, Config, raw::Client};
     /// # use futures::prelude::*;
     /// # futures::executor::block_on(async {
-    /// # let connecting_client = Client::new(Config::new(vec!["192.168.0.100", "192.168.0.101"]));
+    /// # let connecting_client = Client::connect(Config::new(vec!["192.168.0.100", "192.168.0.101"]));
     /// # let connected_client = connecting_client.await.unwrap();
     /// let inclusive_range = "TiKV"..="TiDB";
     /// let req = connected_client.delete_range(inclusive_range);
@@ -259,7 +258,7 @@ impl Client {
 /// use futures::prelude::*;
 ///
 /// # futures::executor::block_on(async {
-/// let connect: Connect = Client::new(Config::default());
+/// let connect: Connect = Client::connect(Config::default());
 /// let client: Client = connect.await.unwrap();
 /// # });
 /// ```

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -25,12 +25,11 @@ impl Client {
     /// use tikv_client::{Config, transaction::Client};
     /// use futures::prelude::*;
     /// # futures::executor::block_on(async {
-    /// let connect = Client::new(Config::default());
+    /// let connect = Client::connect(Config::default());
     /// let client = connect.await.unwrap();
     /// # });
     /// ```
-    #[allow(clippy::new_ret_no_self)]
-    pub fn new(config: Config) -> Connect {
+    pub fn connect(config: Config) -> Connect {
         Connect::new(config)
     }
 
@@ -43,7 +42,7 @@ impl Client {
     /// use tikv_client::{Config, transaction::Client};
     /// use futures::prelude::*;
     /// # futures::executor::block_on(async {
-    /// let connect = Client::new(Config::default());
+    /// let connect = Client::connect(Config::default());
     /// let client = connect.await.unwrap();
     /// let transaction = client.begin();
     /// // ... Issue some commands.
@@ -62,7 +61,7 @@ impl Client {
     /// use tikv_client::{Config, transaction::Client};
     /// use futures::prelude::*;
     /// # futures::executor::block_on(async {
-    /// let connect = Client::new(Config::default());
+    /// let connect = Client::connect(Config::default());
     /// let client = connect.await.unwrap();
     /// let timestamp = client.current_timestamp();
     /// let transaction = client.begin_with_timestamp(timestamp);
@@ -82,7 +81,7 @@ impl Client {
     /// use tikv_client::{Config, transaction::Client};
     /// use futures::prelude::*;
     /// # futures::executor::block_on(async {
-    /// let connect = Client::new(Config::default());
+    /// let connect = Client::connect(Config::default());
     /// let client = connect.await.unwrap();
     /// let snapshot = client.snapshot();
     /// // ... Issue some commands.
@@ -99,7 +98,7 @@ impl Client {
     /// use tikv_client::{Config, transaction::Client};
     /// use futures::prelude::*;
     /// # futures::executor::block_on(async {
-    /// let connect = Client::new(Config::default());
+    /// let connect = Client::connect(Config::default());
     /// let client = connect.await.unwrap();
     /// let timestamp = client.current_timestamp();
     /// # });
@@ -119,7 +118,7 @@ impl Client {
 /// use futures::prelude::*;
 ///
 /// # futures::executor::block_on(async {
-/// let connect: Connect = Client::new(Config::default());
+/// let connect: Connect = Client::connect(Config::default());
 /// let client: Client = connect.await.unwrap();
 /// # });
 /// ```
@@ -196,7 +195,7 @@ impl Transaction {
     /// use tikv_client::{Config, transaction::Client};
     /// use futures::prelude::*;
     /// # futures::executor::block_on(async {
-    /// let connect = Client::new(Config::default());
+    /// let connect = Client::connect(Config::default());
     /// let client = connect.await.unwrap();
     /// let txn = client.begin();
     /// # });
@@ -214,7 +213,7 @@ impl Transaction {
     /// # use tikv_client::{Config, transaction::Client};
     /// # use futures::prelude::*;
     /// # futures::executor::block_on(async {
-    /// # let connect = Client::new(Config::default());
+    /// # let connect = Client::connect(Config::default());
     /// # let connected_client = connect.await.unwrap();
     /// let txn = connected_client.begin();
     /// // ... Do some actions.
@@ -233,7 +232,7 @@ impl Transaction {
     /// # use tikv_client::{Config, transaction::Client};
     /// # use futures::prelude::*;
     /// # futures::executor::block_on(async {
-    /// # let connect = Client::new(Config::default());
+    /// # let connect = Client::connect(Config::default());
     /// # let connected_client = connect.await.unwrap();
     /// let txn = connected_client.begin();
     /// // ... Do some actions.
@@ -252,7 +251,7 @@ impl Transaction {
     /// # use tikv_client::{Config, transaction::Client};
     /// # use futures::prelude::*;
     /// # futures::executor::block_on(async {
-    /// # let connect = Client::new(Config::default());
+    /// # let connect = Client::connect(Config::default());
     /// # let connected_client = connect.await.unwrap();
     /// let mut txn = connected_client.begin();
     /// // ... Do some actions.
@@ -275,7 +274,7 @@ impl Transaction {
     /// # use tikv_client::{Config, transaction::{Client, Timestamp}};
     /// # use futures::prelude::*;
     /// # futures::executor::block_on(async {
-    /// # let connect = Client::new(Config::default());
+    /// # let connect = Client::connect(Config::default());
     /// # let connected_client = connect.await.unwrap();
     /// let txn = connected_client.begin();
     /// // ... Do some actions.
@@ -293,7 +292,7 @@ impl Transaction {
     /// # use tikv_client::{Config, transaction::{Client, Snapshot}};
     /// # use futures::prelude::*;
     /// # futures::executor::block_on(async {
-    /// # let connect = Client::new(Config::default());
+    /// # let connect = Client::connect(Config::default());
     /// # let connected_client = connect.await.unwrap();
     /// let txn = connected_client.begin();
     /// // ... Do some actions.
@@ -311,7 +310,7 @@ impl Transaction {
     /// # use tikv_client::{Config, transaction::{Client, IsolationLevel}};
     /// # use futures::prelude::*;
     /// # futures::executor::block_on(async {
-    /// # let connect = Client::new(Config::default());
+    /// # let connect = Client::connect(Config::default());
     /// # let connected_client = connect.await.unwrap();
     /// let mut txn = connected_client.begin();
     /// txn.set_isolation_level(IsolationLevel::SnapshotIsolation);
@@ -331,7 +330,7 @@ impl Transaction {
     /// # use tikv_client::{Value, Config, transaction::Client};
     /// # use futures::prelude::*;
     /// # futures::executor::block_on(async {
-    /// # let connecting_client = Client::new(Config::new(vec!["192.168.0.100", "192.168.0.101"]));
+    /// # let connecting_client = Client::connect(Config::new(vec!["192.168.0.100", "192.168.0.101"]));
     /// # let connected_client = connecting_client.await.unwrap();
     /// let mut txn = connected_client.begin();
     /// let key = "TiKV";
@@ -355,7 +354,7 @@ impl Transaction {
     /// # use tikv_client::{KvPair, Config, transaction::Client};
     /// # use futures::prelude::*;
     /// # futures::executor::block_on(async {
-    /// # let connecting_client = Client::new(Config::new(vec!["192.168.0.100", "192.168.0.101"]));
+    /// # let connecting_client = Client::connect(Config::new(vec!["192.168.0.100", "192.168.0.101"]));
     /// # let connected_client = connecting_client.await.unwrap();
     /// let mut txn = connected_client.begin();
     /// let keys = vec!["TiKV", "TiDB"];
@@ -386,7 +385,7 @@ impl Transaction {
     /// # use tikv_client::{Key, Value, Config, transaction::Client};
     /// # use futures::prelude::*;
     /// # futures::executor::block_on(async {
-    /// # let connecting_client = Client::new(Config::new(vec!["192.168.0.100", "192.168.0.101"]));
+    /// # let connecting_client = Client::connect(Config::new(vec!["192.168.0.100", "192.168.0.101"]));
     /// # let connected_client = connecting_client.await.unwrap();
     /// let mut txn = connected_client.begin();
     /// let key = "TiKV";
@@ -410,7 +409,7 @@ impl Transaction {
     /// # use tikv_client::{Key, Config, transaction::Client};
     /// # use futures::prelude::*;
     /// # futures::executor::block_on(async {
-    /// # let connecting_client = Client::new(Config::new(vec!["192.168.0.100", "192.168.0.101"]));
+    /// # let connecting_client = Client::connect(Config::new(vec!["192.168.0.100", "192.168.0.101"]));
     /// # let connected_client = connecting_client.await.unwrap();
     /// let mut txn = connected_client.begin();
     /// let key = "TiKV";

--- a/tests/integration_tests/raw.rs
+++ b/tests/integration_tests/raw.rs
@@ -22,7 +22,7 @@ async fn wipe_all(client: &Client) {
 }
 
 async fn connect() -> Client {
-    let client = Client::new(Config::new(pd_addr()))
+    let client = Client::connect(Config::new(pd_addr()))
         .await
         .expect("Could not connect to tikv");
     wipe_all(&client).await;


### PR DESCRIPTION
Because there is a strong convention in Rust that `Foo::new` returns a `Foo` (or worst-case `Result<Foo>` or similar) with minimal side effects. Plus I think this version reads better - we are starting a connection, not just creating a new object.

PTAL @Hoverbear 