### PR TITLE
Reorganise futures imports

### DIFF
--- a/examples/transaction.rs
+++ b/examples/transaction.rs
@@ -5,11 +5,7 @@
 mod common;
 
 use crate::common::parse_args;
-use futures::{
-    future,
-    prelude::{StreamExt, TryStreamExt},
-    stream, TryFutureExt,
-};
+use futures::prelude::*;
 use std::ops::RangeBounds;
 use tikv_client::{
     transaction::{Client, IsolationLevel},

--- a/src/compat.rs
+++ b/src/compat.rs
@@ -3,8 +3,7 @@
 //! This module contains utility types and functions for making the transition
 //! from futures 0.1 to 1.0 easier.
 
-use futures::prelude::{Future, Sink, Stream, StreamExt};
-use futures::stream::Fuse;
+use futures::prelude::*;
 use futures::task::{Context, Poll};
 use futures::try_ready;
 use std::pin::Pin;
@@ -85,7 +84,7 @@ where
     St: Stream + Unpin,
 {
     sink: Option<Si>,
-    stream: Option<Fuse<St>>,
+    stream: Option<stream::Fuse<St>>,
     buffered: Option<St::Item>,
 }
 
@@ -118,7 +117,7 @@ where
         )
     }
 
-    fn stream_mut(&mut self) -> Pin<&mut Fuse<St>> {
+    fn stream_mut(&mut self) -> Pin<&mut stream::Fuse<St>> {
         Pin::new(
             self.stream
                 .as_mut()

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -10,7 +10,8 @@
 //! **Warning:** It is not advisable to use both raw and transactional functionality in the same keyspace.
 //!
 use crate::{rpc::RpcClient, Config, Error, Key, KeyRange, KvPair, Result, Value};
-use futures::{future, task::Context, Future, Poll};
+use futures::prelude::*;
+use futures::task::{Context, Poll};
 use std::{fmt, ops::Bound, pin::Pin, sync::Arc, u32};
 
 const MAX_RAW_KV_SCAN_LIMIT: u32 = 10240;

--- a/src/rpc/pd/client.rs
+++ b/src/rpc/pd/client.rs
@@ -7,8 +7,7 @@ use std::{
 };
 
 use futures::compat::Compat01As03;
-use futures::future::{ready, Future};
-use futures::prelude::{FutureExt, TryFutureExt};
+use futures::prelude::*;
 use grpcio::{CallOption, Environment};
 use kvproto::{metapb, pdpb, pdpb::PdClient as RpcClient};
 
@@ -93,14 +92,14 @@ impl PdClient {
             let region = if resp.has_region() {
                 resp.take_region()
             } else {
-                return ready(Err(Error::region_for_key_not_found(key)));
+                return future::ready(Err(Error::region_for_key_not_found(key)));
             };
             let leader = if resp.has_leader() {
                 Some(resp.take_leader())
             } else {
                 None
             };
-            ready(Ok((region, leader)))
+            future::ready(Ok((region, leader)))
         })
     }
 
@@ -122,14 +121,14 @@ impl PdClient {
             let region = if resp.has_region() {
                 resp.take_region()
             } else {
-                return ready(Err(Error::region_not_found(region_id, None)));
+                return future::ready(Err(Error::region_not_found(region_id, None)));
             };
             let leader = if resp.has_leader() {
                 Some(resp.take_leader())
             } else {
                 None
             };
-            ready(Ok((region, leader)))
+            future::ready(Ok((region, leader)))
         })
     }
 

--- a/src/rpc/tikv/client.rs
+++ b/src/rpc/tikv/client.rs
@@ -6,8 +6,7 @@
 use std::{fmt, sync::Arc, time::Duration};
 
 use futures::compat::Compat01As03;
-use futures::future::Future;
-use futures::prelude::{FutureExt, TryFutureExt};
+use futures::prelude::*;
 use grpcio::{CallOption, Environment};
 use kvproto::{errorpb, kvrpcpb, tikvpb::TikvClient};
 

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -10,7 +10,9 @@
 //!
 
 use crate::{Config, Error, Key, KvPair, Value};
-use futures::{task::Context, Future, Poll, Stream};
+
+use futures::prelude::*;
+use futures::task::{Context, Poll};
 use std::ops::RangeBounds;
 use std::pin::Pin;
 


### PR DESCRIPTION
This is very basic refactoring - just changing the nature of some imports and imported names.

PTAL @brson 