### PR TITLE
Refactor KvRange

### DIFF
--- a/src/kv.rs
+++ b/src/kv.rs
@@ -389,7 +389,8 @@ impl fmt::Debug for KvPair {
 /// );
 /// ```
 ///
-/// **But, you should not need to worry about all this:** Many functions accept a `impl Into<BoundRange>`
+/// **But, you should not need to worry about all this:** Most functions which operate
+/// on ranges will accept any types  which implement `Into<BoundRange>`.
 /// which means all of the above types can be passed directly to those functions.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct BoundRange {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,4 +91,4 @@ pub use crate::errors::ErrorKind;
 #[doc(inline)]
 pub use crate::errors::Result;
 #[doc(inline)]
-pub use crate::kv::{Key, KeyRange, KvPair, Value};
+pub use crate::kv::{BoundRange, Key, KvPair, Value};

--- a/src/rpc/client.rs
+++ b/src/rpc/client.rs
@@ -17,6 +17,7 @@ use log::*;
 
 use crate::{
     compat::{loop_fn, Loop},
+    kv::BoundRange,
     raw::ColumnFamily,
     rpc::{
         pd::{PdClient, PdTimestamp, Region, RegionId, RegionVerId, Store, StoreId},
@@ -346,7 +347,7 @@ impl RpcClient {
 
     pub fn raw_scan(
         &self,
-        range: (Key, Option<Key>),
+        range: BoundRange,
         limit: u32,
         key_only: bool,
         cf: Option<ColumnFamily>,
@@ -373,14 +374,14 @@ impl RpcClient {
                     .map_ok(|(region, client)| {
                         (scan, region.range(), RawContext::new(region, client, cf))
                     })
-                    .and_then(|(mut scan, region_range, context)| {
-                        let (start_key, end_key) = scan.range();
+                    .and_then(|(scan, region_range, context)| {
+                        let (ref start_key, ref end_key) = scan.range;
                         context
                             .client()
                             .raw_scan(
                                 context,
-                                start_key,
-                                end_key,
+                                Some(start_key.clone()),
+                                end_key.clone(),
                                 scan.state.limit,
                                 scan.state.key_only,
                             )
@@ -404,7 +405,7 @@ impl RpcClient {
 
     pub fn raw_batch_scan(
         &self,
-        ranges: Vec<(Key, Option<Key>)>,
+        ranges: Vec<BoundRange>,
         _each_limit: u32,
         _key_only: bool,
         cf: Option<ColumnFamily>,
@@ -416,7 +417,7 @@ impl RpcClient {
 
     pub fn raw_delete_range(
         &self,
-        range: (Key, Option<Key>),
+        range: BoundRange,
         cf: Option<ColumnFamily>,
     ) -> impl Future<Output = Result<()>> {
         let scan: ScanRegionsContext<(), Option<ColumnFamily>> = ScanRegionsContext::new(range, cf);
@@ -429,10 +430,10 @@ impl RpcClient {
                     .map_ok(|(region, client)| {
                         (scan, region.range(), RawContext::new(region, client, cf))
                     })
-                    .and_then(|(mut scan, region_range, context)| {
-                        let (start_key, end_key) = scan.range();
-                        let start_key = start_key.expect("start key must be specified");
-                        let end_key = end_key.expect("end key must be specified");
+                    .and_then(|(scan, region_range, context)| {
+                        let (ref start_key, ref end_key) = scan.range;
+                        let start_key = start_key.clone();
+                        let end_key = end_key.clone().expect("end key must be specified");
                         context
                             .client()
                             .raw_delete_range(context, start_key, end_key)
@@ -589,8 +590,7 @@ where
     Res: Default,
     State: Sized,
 {
-    start_key: Option<Key>,
-    end_key: Option<Key>,
+    range: (Key, Option<Key>),
     result: Res,
     state: State,
 }
@@ -600,25 +600,20 @@ where
     Res: Default,
     State: Sized,
 {
-    fn new(range: (Key, Option<Key>), state: State) -> Self {
+    fn new(range: BoundRange, state: State) -> Self {
         ScanRegionsContext {
-            start_key: Some(range.0),
-            end_key: range.1,
+            range: range.into_keys(),
             result: Res::default(),
             state,
         }
     }
 
-    fn range(&mut self) -> (Option<Key>, Option<Key>) {
-        (self.start_key.take(), self.end_key.clone())
-    }
-
     fn start_key(&self) -> &Key {
-        self.start_key.as_ref().unwrap()
+        &self.range.0
     }
 
     fn end_key(&self) -> Option<&Key> {
-        self.end_key.as_ref()
+        self.range.1.as_ref()
     }
 
     fn next(&mut self, region_range: (Key, Key)) -> ScanRegionsStatus {
@@ -628,7 +623,7 @@ where
                 return ScanRegionsStatus::Break;
             }
         }
-        self.start_key = Some(region_range.1);
+        self.range.0 = region_range.1;
         ScanRegionsStatus::Continue
     }
 


### PR DESCRIPTION
The end result is a concrete type `BoundRange` and using `Into<BoundRange>`
where functions previously took `KeyRange`. This refactoring means that errors
with invalid ranges are found earlier (in fact, they are mostly prevented statically,
where they can still occur, they do so when ranges are created, not when used)
and there is less conversion between range types in some cases. Hopefully,
code is simplified somewhat too.

PTAL @Hoverbear @brson @sunxiaoguang 