### PR TITLE
[DNM] Correct transaction interfaces

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ os:
   # - windows # TODO: https://github.com/pingcap/kvproto/issues/355
   - osx
 rust:
-  # Requires nightly for now, stable can be re-enabled when 1.36 is stable.
+  # Requires nightly for now, stable can be re-enabled when async/await is stable.
   # - stable
   - nightly
 env:

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This is an open source (Apache 2) project hosted by the Cloud Native Computing F
 
 ## Using the client
 
-The TiKV client is a Rust library (crate). It requires version 1.36 of the compiler and standard libraries (which will be stable from the 4th July 2019, see below for ensuring compatibility).
+The TiKV client is a Rust library (crate). It requires a nightly Rust compiler with async/await support.
 
 To use this crate in your project, add it as a dependency in your `Cargo.toml`:
 
@@ -27,8 +27,6 @@ tikv-client = { git = "https://github.com/tikv/client-rust.git" }
 The client requires a Git dependency until we can [publish it](https://github.com/tikv/client-rust/issues/32).
 
 There are [examples](examples) which show how to use the client in a Rust program.
-
-The examples and documentation use async/await syntax. This is a new feature in Rust and is currently unstable. To use async/await you'll need to add the feature flag `#![async_await]` to your crate and use a nightly compiler (see below).
 
 ## Access the documentation
 
@@ -52,7 +50,7 @@ To check what version of Rust you are using, run
 rustc --version
 ```
 
-You'll see something like `rustc 1.36.0-nightly (a784a8022 2019-05-09)` where the `1.36.0` is the toolchain version, and `nightly` is the channel (stable/beta/nightly). To install another toolchain use
+You'll see something like `rustc 1.38.0-nightly (4b65a86eb 2019-07-15)` where the `1.38.0` is the toolchain version, and `nightly` is the channel (stable/beta/nightly). To install another toolchain use
 
 ```bash
 rustup toolchain install nightly

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 // Long and nested future chains can quickly result in large generic types.
 #![type_length_limit = "16777216"]
 #![allow(clippy::redundant_closure)]
+#![feature(async_await)]
 
 //! This crate provides a clean, ready to use client for [TiKV](https://github.com/tikv/tikv), a
 //! distributed transactional Key-Value database written in Rust.

--- a/src/rpc/client.rs
+++ b/src/rpc/client.rs
@@ -20,7 +20,7 @@ use crate::{
     kv::BoundRange,
     raw::ColumnFamily,
     rpc::{
-        pd::{PdClient, Region, RegionId, RetryClient, StoreId},
+        pd::{PdClient, Region, RegionId, RetryClient, StoreId, Timestamp},
         security::SecurityManager,
         tikv::KvClient,
         Address, RawContext, Store, TxnContext,
@@ -223,6 +223,10 @@ impl<PdC: PdClient> RpcClient<PdC> {
         _cf: Option<ColumnFamily>,
     ) -> impl Future<Output = Result<Vec<KvPair>>> {
         future::err(Error::unimplemented())
+    }
+
+    pub fn get_timestamp(self: Arc<Self>) -> impl Future<Output = Result<Timestamp>> {
+        Arc::clone(&self.pd).get_timestamp()
     }
 
     // Returns a Steam which iterates over the contexts for each region covered by range.

--- a/src/rpc/pd/mod.rs
+++ b/src/rpc/pd/mod.rs
@@ -87,7 +87,7 @@ impl Region {
     }
 }
 
-#[derive(Eq, PartialEq, Debug)]
+#[derive(Eq, PartialEq, Debug, Clone, Copy)]
 pub struct Timestamp {
     pub physical: i64,
     pub logical: i64,

--- a/src/transaction/client.rs
+++ b/src/transaction/client.rs
@@ -78,7 +78,7 @@ impl Client {
     /// # futures::executor::block_on(async {
     /// let connect = Client::connect(Config::default());
     /// let client = connect.await.unwrap();
-    /// let timestamp = Timestamp { physical: 1564474902, logical: 1 };
+    /// let timestamp = Timestamp { physical: 1564481750172, logical: 1 };
     /// let snapshot = client.snapshot_at(timestamp);
     /// // ... Issue some commands.
     /// # });
@@ -127,7 +127,10 @@ impl Future for Connect {
     type Output = Result<Client>;
 
     fn poll(self: Pin<&mut Self>, _cx: &mut Context) -> Poll<Self::Output> {
-        let _config = &self.config;
-        unimplemented!()
+        let config = &self.config;
+        // TODO: RpcClient::connect currently uses a blocking implementation.
+        //       Make it asynchronous later.
+        let rpc = Arc::new(RpcClient::connect(config)?);
+        Poll::Ready(Ok(Client { rpc }))
     }
 }

--- a/src/transaction/client.rs
+++ b/src/transaction/client.rs
@@ -42,14 +42,15 @@ impl Client {
     /// # futures::executor::block_on(async {
     /// let connect = Client::connect(Config::default());
     /// let client = connect.await.unwrap();
-    /// let transaction = client.begin().await.unwrap();
+    /// let mut transaction = client.begin().await.unwrap();
     /// // ... Issue some commands.
     /// let commit = transaction.commit();
     /// let result: () = commit.await.unwrap();
     /// # });
     /// ```
     pub async fn begin(&self) -> Result<Transaction> {
-        unimplemented!()
+        let snapshot = self.snapshot().await?;
+        Ok(Transaction::new(snapshot))
     }
 
     /// Gets the latest [`Snapshot`](Snapshot).
@@ -66,7 +67,8 @@ impl Client {
     /// # });
     /// ```
     pub async fn snapshot(&self) -> Result<Snapshot> {
-        unimplemented!()
+        let timestamp = self.current_timestamp().await?;
+        self.snapshot_at(timestamp).await
     }
 
     /// Gets a [`Snapshot`](Snapshot) at the given point in time.
@@ -83,8 +85,8 @@ impl Client {
     /// // ... Issue some commands.
     /// # });
     /// ```
-    pub async fn snapshot_at(&self, _timestamp: Timestamp) -> Result<Snapshot> {
-        unimplemented!()
+    pub async fn snapshot_at(&self, timestamp: Timestamp) -> Result<Snapshot> {
+        Ok(Snapshot::new(timestamp))
     }
 
     /// Retrieves the current [`Timestamp`](Timestamp).

--- a/src/transaction/mod.rs
+++ b/src/transaction/mod.rs
@@ -10,8 +10,8 @@
 //!
 
 pub use self::client::{Client, Connect};
-pub use self::requests::{BatchGet, Commit, Delete, Get, LockKeys, Rollback, Scanner, Set};
-pub use self::transaction::{IsolationLevel, Snapshot, Transaction, TxnInfo};
+pub use self::requests::Scanner;
+pub use self::transaction::{Snapshot, Transaction, TxnInfo};
 pub use super::rpc::Timestamp;
 
 use crate::{Key, Value};

--- a/src/transaction/requests.rs
+++ b/src/transaction/requests.rs
@@ -1,9 +1,7 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
-use super::Transaction;
-use crate::{Error, Key, KvPair, Value};
+use crate::{Error, KvPair};
 
-use derive_new::new;
 use futures::prelude::*;
 use futures::task::{Context, Poll};
 use std::pin::Pin;
@@ -17,130 +15,6 @@ impl Stream for Scanner {
     type Item = Result<KvPair, Error>;
 
     fn poll_next(self: Pin<&mut Self>, _cx: &mut Context) -> Poll<Option<Self::Item>> {
-        unimplemented!()
-    }
-}
-
-/// An unresolved [`Transaction::get`](Transaction::get) request.
-///
-/// Once resolved this request will result in the fetching of the value associated with the given
-/// key.
-#[derive(new)]
-pub struct Get {
-    key: Key,
-}
-
-impl Future for Get {
-    type Output = Result<Value, Error>;
-
-    fn poll(self: Pin<&mut Self>, _cx: &mut Context) -> Poll<Self::Output> {
-        let _key = &self.key;
-        unimplemented!()
-    }
-}
-
-/// An unresolved [`Transaction::batch_get`](Transaction::batch_get) request.
-///
-/// Once resolved this request will result in the fetching of the values associated with the given
-/// keys.
-#[derive(new)]
-pub struct BatchGet {
-    keys: Vec<Key>,
-}
-
-impl Future for BatchGet {
-    type Output = Result<Vec<KvPair>, Error>;
-
-    fn poll(self: Pin<&mut Self>, _cx: &mut Context) -> Poll<Self::Output> {
-        let _keys = &self.keys;
-        unimplemented!()
-    }
-}
-
-/// An unresolved [`Transaction::commit`](Transaction::commit) request.
-///
-/// Once resolved this request will result in the committing of the transaction.
-#[derive(new)]
-pub struct Commit {
-    txn: Transaction,
-}
-
-impl Future for Commit {
-    type Output = Result<(), Error>;
-
-    fn poll(self: Pin<&mut Self>, _cx: &mut Context) -> Poll<Self::Output> {
-        let _txn = &self.txn;
-        unimplemented!()
-    }
-}
-
-/// An unresolved [`Transaction::rollback`](Transaction::rollback) request.
-///
-/// Once resolved this request will result in the rolling back of the transaction.
-#[derive(new)]
-pub struct Rollback {
-    txn: Transaction,
-}
-
-impl Future for Rollback {
-    type Output = Result<(), Error>;
-
-    fn poll(self: Pin<&mut Self>, _cx: &mut Context) -> Poll<Self::Output> {
-        let _txn = &self.txn;
-        unimplemented!()
-    }
-}
-
-/// An unresolved [`Transaction::lock_keys`](Transaction::lock_keys) request.
-///
-/// Once resolved this request will result in the locking of the given keys.
-#[derive(new)]
-pub struct LockKeys {
-    keys: Vec<Key>,
-}
-
-impl Future for LockKeys {
-    type Output = Result<(), Error>;
-
-    fn poll(self: Pin<&mut Self>, _cx: &mut Context) -> Poll<Self::Output> {
-        let _keys = &self.keys;
-        unimplemented!()
-    }
-}
-
-/// An unresolved [`Transaction::set`](Transaction::set) request.
-///
-/// Once resolved this request will result in the setting of the value associated with the given
-/// key.
-#[derive(new)]
-pub struct Set {
-    key: Key,
-    value: Value,
-}
-
-impl Future for Set {
-    type Output = Result<(), Error>;
-
-    fn poll(self: Pin<&mut Self>, _cx: &mut Context) -> Poll<Self::Output> {
-        let _key = &self.key;
-        let _value = &self.value;
-        unimplemented!()
-    }
-}
-
-/// An unresolved [`Transaction::delete`](Transaction::delete) request.
-///
-/// Once resolved this request will result in the deletion of the given key.
-#[derive(new)]
-pub struct Delete {
-    key: Key,
-}
-
-impl Future for Delete {
-    type Output = Result<(), Error>;
-
-    fn poll(self: Pin<&mut Self>, _cx: &mut Context) -> Poll<Self::Output> {
-        let _key = &self.key;
         unimplemented!()
     }
 }

--- a/src/transaction/transaction.rs
+++ b/src/transaction/transaction.rs
@@ -22,7 +22,7 @@ use std::ops::RangeBounds;
 /// # futures::executor::block_on(async {
 /// let connect = Client::connect(Config::default());
 /// let client = connect.await.unwrap();
-/// let txn = client.begin();
+/// let txn = client.begin().await.unwrap();
 /// # });
 /// ```
 #[derive(new)]
@@ -42,7 +42,7 @@ impl Transaction {
     /// # futures::executor::block_on(async {
     /// # let connect = Client::connect(Config::default());
     /// # let connected_client = connect.await.unwrap();
-    /// let txn = connected_client.begin();
+    /// let txn = connected_client.begin().await.unwrap();
     /// // ... Do some actions.
     /// let req = txn.commit();
     /// let result: () = req.await.unwrap();
@@ -61,7 +61,7 @@ impl Transaction {
     /// # futures::executor::block_on(async {
     /// # let connect = Client::connect(Config::default());
     /// # let connected_client = connect.await.unwrap();
-    /// let txn = connected_client.begin();
+    /// let txn = connected_client.begin().await.unwrap();
     /// // ... Do some actions.
     /// let req = txn.rollback();
     /// let result: () = req.await.unwrap();
@@ -80,7 +80,7 @@ impl Transaction {
     /// # futures::executor::block_on(async {
     /// # let connect = Client::connect(Config::default());
     /// # let connected_client = connect.await.unwrap();
-    /// let mut txn = connected_client.begin();
+    /// let mut txn = connected_client.begin().await.unwrap();
     /// // ... Do some actions.
     /// let req = txn.lock_keys(vec!["TiKV".to_owned(), "Rust".to_owned()]);
     /// let result: () = req.await.unwrap();
@@ -103,7 +103,7 @@ impl Transaction {
     /// # futures::executor::block_on(async {
     /// # let connect = Client::connect(Config::default());
     /// # let connected_client = connect.await.unwrap();
-    /// let txn = connected_client.begin();
+    /// let txn = connected_client.begin().await.unwrap();
     /// // ... Do some actions.
     /// let ts: Timestamp = txn.start_ts();
     /// # });
@@ -121,7 +121,7 @@ impl Transaction {
     /// # futures::executor::block_on(async {
     /// # let connect = Client::connect(Config::default());
     /// # let connected_client = connect.await.unwrap();
-    /// let txn = connected_client.begin();
+    /// let txn = connected_client.begin().await.unwrap();
     /// // ... Do some actions.
     /// let snap: Snapshot = txn.snapshot();
     /// # });
@@ -139,7 +139,7 @@ impl Transaction {
     /// # futures::executor::block_on(async {
     /// # let connect = Client::connect(Config::default());
     /// # let connected_client = connect.await.unwrap();
-    /// let mut txn = connected_client.begin();
+    /// let mut txn = connected_client.begin().await.unwrap();
     /// txn.set_isolation_level(IsolationLevel::SnapshotIsolation);
     /// # });
     /// ```
@@ -159,7 +159,7 @@ impl Transaction {
     /// # futures::executor::block_on(async {
     /// # let connecting_client = Client::connect(Config::new(vec!["192.168.0.100", "192.168.0.101"]));
     /// # let connected_client = connecting_client.await.unwrap();
-    /// let mut txn = connected_client.begin();
+    /// let mut txn = connected_client.begin().await.unwrap();
     /// let key = "TiKV".to_owned();
     /// let req = txn.get(key);
     /// let result: Value = req.await.unwrap();
@@ -183,7 +183,7 @@ impl Transaction {
     /// # futures::executor::block_on(async {
     /// # let connecting_client = Client::connect(Config::new(vec!["192.168.0.100", "192.168.0.101"]));
     /// # let connected_client = connecting_client.await.unwrap();
-    /// let mut txn = connected_client.begin();
+    /// let mut txn = connected_client.begin().await.unwrap();
     /// let keys = vec!["TiKV".to_owned(), "TiDB".to_owned()];
     /// let req = txn.batch_get(keys);
     /// let result: Vec<KvPair> = req.await.unwrap();
@@ -214,7 +214,7 @@ impl Transaction {
     /// # futures::executor::block_on(async {
     /// # let connecting_client = Client::connect(Config::new(vec!["192.168.0.100", "192.168.0.101"]));
     /// # let connected_client = connecting_client.await.unwrap();
-    /// let mut txn = connected_client.begin();
+    /// let mut txn = connected_client.begin().await.unwrap();
     /// let key = "TiKV".to_owned();
     /// let val = "TiKV".to_owned();
     /// let req = txn.set(key, val);
@@ -238,7 +238,7 @@ impl Transaction {
     /// # futures::executor::block_on(async {
     /// # let connecting_client = Client::connect(Config::new(vec!["192.168.0.100", "192.168.0.101"]));
     /// # let connected_client = connecting_client.await.unwrap();
-    /// let mut txn = connected_client.begin();
+    /// let mut txn = connected_client.begin().await.unwrap();
     /// let key = "TiKV".to_owned();
     /// let req = txn.delete(key);
     /// let result: () = req.await.unwrap();

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,0 +1,41 @@
+#![cfg(feature = "integration-tests")]
+#![feature(async_await)]
+
+use failure::Fallible;
+use futures::executor::ThreadPool;
+use futures::prelude::*;
+use std::env;
+use tikv_client::{transaction::*, Config, Result};
+
+#[test]
+fn get_timestamp() -> Fallible<()> {
+    const COUNT: usize = 1 << 12;
+    let mut pool = ThreadPool::new()?;
+    let config = Config::new(pd_addrs());
+    let fut = async {
+        let client = Client::connect(config).await?;
+        Result::Ok(future::join_all((0..COUNT).map(|_| client.current_timestamp())).await)
+    };
+    // Calculate each version of retrieved timestamp
+    let mut versions = pool
+        .run(fut)?
+        .into_iter()
+        .map(|res| res.map(|ts| ts.physical << 18 + ts.logical))
+        .collect::<Result<Vec<_>>>()?;
+
+    // Each version should be unique
+    versions.sort_unstable();
+    versions.dedup();
+    assert_eq!(versions.len(), COUNT);
+    Ok(())
+}
+
+const ENV_PD_ADDRS: &str = "PD_ADDRS";
+
+fn pd_addrs() -> Vec<String> {
+    env::var(ENV_PD_ADDRS)
+        .expect(&format!("Expected {}:", ENV_PD_ADDRS))
+        .split(",")
+        .map(From::from)
+        .collect()
+}


### PR DESCRIPTION
1. Remove invalid interfaces such as
- rollback: an optimistic transaction doesn't need it
- set_isolation_level: we don't support various isolation levels now (pessimistic transaction, which we will possibly support later, assumes RR but it should not be configurable either)
2. Use async/await
3. Fix some documents. Operations like set and delete should not be a `Future` which needs to be resolved later. They are just buffered in memory.