### PR TITLE
Implement 2PC

### DIFF
--- a/examples/transaction.rs
+++ b/examples/transaction.rs
@@ -11,7 +11,7 @@ async fn puts(client: &Client, pairs: impl IntoIterator<Item = impl Into<KvPair>
     let mut txn = client.begin().await.expect("Could not begin a transaction");
     for pair in pairs {
         let (key, value) = pair.into().into();
-        txn.set(key, value);
+        txn.set(key, value).await.expect("Could not set key value");
     }
     txn.commit().await.expect("Could not commit transaction");
 }
@@ -43,7 +43,7 @@ async fn scan(client: &Client, range: impl RangeBounds<Key>, mut limit: usize) {
 async fn dels(client: &Client, keys: impl IntoIterator<Item = Key>) {
     let mut txn = client.begin().await.expect("Could not begin a transaction");
     for key in keys {
-        txn.delete(key);
+        txn.delete(key).await.expect("Could not delete the key");
     }
     txn.commit().await.expect("Could not commit transaction");
 }

--- a/examples/transaction.rs
+++ b/examples/transaction.rs
@@ -62,7 +62,7 @@ async fn main() {
         Config::new(args.pd)
     };
 
-    let txn = Client::connect(config)
+    let txn = Client::new(config)
         .await
         .expect("Could not connect to tikv");
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -129,10 +129,6 @@ impl Error {
     pub(crate) fn undetermined_error(error: Error) -> Self {
         Error::from(ErrorKind::UndeterminedError(error))
     }
-
-    pub(crate) fn multiple_errors(errors: Vec<Error>) -> Self {
-        Error::from(ErrorKind::MultipleErrors(errors))
-    }
 }
 
 impl From<ErrorKind> for Error {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -129,6 +129,10 @@ impl Error {
     pub(crate) fn undetermined_error(error: Error) -> Self {
         Error::from(ErrorKind::UndeterminedError(error))
     }
+
+    pub(crate) fn multiple_errors(errors: Vec<Error>) -> Self {
+        Error::from(ErrorKind::MultipleErrors(errors))
+    }
 }
 
 impl From<ErrorKind> for Error {

--- a/src/kv/key.rs
+++ b/src/kv/key.rs
@@ -40,6 +40,7 @@ use std::{fmt, u8};
 /// functions.
 #[derive(Default, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 #[cfg_attr(test, derive(Arbitrary))]
+#[repr(transparent)]
 pub struct Key(
     #[cfg_attr(
         test,
@@ -114,6 +115,12 @@ impl<'a> Into<&'a [u8]> for &'a Key {
 impl AsRef<Key> for Key {
     fn as_ref(&self) -> &Key {
         self
+    }
+}
+
+impl AsRef<Key> for Vec<u8> {
+    fn as_ref(&self) -> &Key {
+        unsafe { std::mem::transmute(&self) }
     }
 }
 

--- a/src/kv/key.rs
+++ b/src/kv/key.rs
@@ -120,7 +120,7 @@ impl AsRef<Key> for Key {
 
 impl AsRef<Key> for Vec<u8> {
     fn as_ref(&self) -> &Key {
-        unsafe { std::mem::transmute(self) }
+        unsafe { &*(self as *const Vec<u8> as *const Key) }
     }
 }
 

--- a/src/kv/key.rs
+++ b/src/kv/key.rs
@@ -120,7 +120,7 @@ impl AsRef<Key> for Key {
 
 impl AsRef<Key> for Vec<u8> {
     fn as_ref(&self) -> &Key {
-        unsafe { std::mem::transmute(&self) }
+        unsafe { std::mem::transmute(self) }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,7 @@
 //! Regardless of which API you choose, you'll need to connect your client
 //! ([raw](raw::Client), [transactional](transaction::Client)).
 //!
-//! ```rust
+//! ```rust,no_run
 //! # use tikv_client::*;
 //! # use futures::prelude::*;
 //!
@@ -65,11 +65,8 @@
 //!     "192.168.0.101:2379",
 //! ]).with_security("root.ca", "internal.cert", "internal.key");
 //!
-//! // Get an unresolved connection.
-//! let connect = TransactionClient::connect(config);
-//!
-//! // Resolve the connection into a client.
-//! let client = connect.into_future().await;
+//! // Get a transactional client.
+//! let client = TransactionClient::new(config).await.unwrap();
 //! # });
 //! ```
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,6 +116,4 @@ pub use crate::kv::{BoundRange, Key, KvPair, ToOwnedRange, Value};
 #[doc(inline)]
 pub use crate::raw::{Client as RawClient, ColumnFamily};
 #[doc(inline)]
-pub use crate::transaction::{
-    Client as TransactionClient, Connect, Snapshot, Timestamp, Transaction,
-};
+pub use crate::transaction::{Client as TransactionClient, Snapshot, Timestamp, Transaction};

--- a/src/raw/requests.rs
+++ b/src/raw/requests.rs
@@ -5,6 +5,7 @@ use crate::{
     kv_client::{KvClient, RpcFnType, Store},
     pd::PdClient,
     request::{store_stream_for_key, store_stream_for_keys, store_stream_for_range, KvRequest},
+    transaction::HasLocks,
     BoundRange, ColumnFamily, Error, Key, KvPair, Result, Value,
 };
 
@@ -482,15 +483,15 @@ impl_raw_rpc_request!(RawScanRequest);
 impl_raw_rpc_request!(RawBatchScanRequest);
 impl_raw_rpc_request!(RawDeleteRangeRequest);
 
-dummy_impl_has_locks!(RawGetResponse);
-dummy_impl_has_locks!(RawBatchGetResponse);
-dummy_impl_has_locks!(RawPutResponse);
-dummy_impl_has_locks!(RawBatchPutResponse);
-dummy_impl_has_locks!(RawDeleteResponse);
-dummy_impl_has_locks!(RawBatchDeleteResponse);
-dummy_impl_has_locks!(RawScanResponse);
-dummy_impl_has_locks!(RawBatchScanResponse);
-dummy_impl_has_locks!(RawDeleteRangeResponse);
+impl HasLocks for kvrpcpb::RawGetResponse {}
+impl HasLocks for kvrpcpb::RawBatchGetResponse {}
+impl HasLocks for kvrpcpb::RawPutResponse {}
+impl HasLocks for kvrpcpb::RawBatchPutResponse {}
+impl HasLocks for kvrpcpb::RawDeleteResponse {}
+impl HasLocks for kvrpcpb::RawBatchDeleteResponse {}
+impl HasLocks for kvrpcpb::RawScanResponse {}
+impl HasLocks for kvrpcpb::RawBatchScanResponse {}
+impl HasLocks for kvrpcpb::RawDeleteRangeResponse {}
 
 #[cfg(test)]
 mod test {

--- a/src/transaction/buffer.rs
+++ b/src/transaction/buffer.rs
@@ -99,6 +99,16 @@ impl Buffer {
         self.mutations.lock().unwrap().insert(key, Mutation::Del);
     }
 
+    /// Converts the buffered mutations to the proto buffer version
+    pub fn to_proto_mutations(&self) -> Vec<kvrpcpb::Mutation> {
+        self.mutations
+            .lock()
+            .unwrap()
+            .iter()
+            .flat_map(|(key, mutation)| mutation.to_proto_with_key(key))
+            .collect()
+    }
+
     fn get_from_mutations(&self, key: &Key) -> MutationValue {
         self.mutations
             .lock()
@@ -111,7 +121,7 @@ impl Buffer {
 
 // The state of a value in the buffer.
 #[derive(Debug, Clone)]
-enum Mutation {
+pub enum Mutation {
     // The value has been read from the server. None means there is no entry.
     Cached(Option<Value>),
     // Value has been written.
@@ -123,21 +133,18 @@ enum Mutation {
 }
 
 impl Mutation {
-    #[allow(dead_code)]
-    fn into_proto_with_key(self, key: Key) -> Option<kvrpcpb::Mutation> {
-        let mut pb = kvrpcpb::Mutation {
-            key: key.into(),
-            ..Default::default()
-        };
+    fn to_proto_with_key(&self, key: &Key) -> Option<kvrpcpb::Mutation> {
+        let mut pb = kvrpcpb::Mutation::default();
         match self {
             Mutation::Cached(_) => return None,
             Mutation::Put(v) => {
                 pb.set_op(kvrpcpb::Op::Put);
-                pb.set_value(v.into());
+                pb.set_value(v.clone().into());
             }
             Mutation::Del => pb.set_op(kvrpcpb::Op::Del),
             Mutation::Lock => pb.set_op(kvrpcpb::Op::Lock),
         };
+        pb.set_key(key.clone().into());
         Some(pb)
     }
 

--- a/src/transaction/buffer.rs
+++ b/src/transaction/buffer.rs
@@ -121,7 +121,7 @@ impl Buffer {
 
 // The state of a value in the buffer.
 #[derive(Debug, Clone)]
-pub enum Mutation {
+enum Mutation {
     // The value has been read from the server. None means there is no entry.
     Cached(Option<Value>),
     // Value has been written.

--- a/src/transaction/buffer.rs
+++ b/src/transaction/buffer.rs
@@ -105,7 +105,7 @@ impl Buffer {
             .lock()
             .unwrap()
             .iter()
-            .flat_map(|(key, mutation)| mutation.to_proto_with_key(key))
+            .filter_map(|(key, mutation)| mutation.to_proto_with_key(key))
             .collect()
     }
 

--- a/src/transaction/client.rs
+++ b/src/transaction/client.rs
@@ -24,7 +24,7 @@ impl Client {
     /// use tikv_client::{Config, TransactionClient};
     /// use futures::prelude::*;
     /// # futures::executor::block_on(async {
-    /// let client = TransactionClient::new(Config::default()).await.unwrap;
+    /// let client = TransactionClient::new(Config::default()).await.unwrap();
     /// # });
     /// ```
     pub async fn new(config: Config) -> Result<Client> {
@@ -43,8 +43,7 @@ impl Client {
     /// use tikv_client::{Config, TransactionClient};
     /// use futures::prelude::*;
     /// # futures::executor::block_on(async {
-    /// let connect = TransactionClient::connect(Config::default());
-    /// let client = connect.await.unwrap();
+    /// let client = TransactionClient::new(Config::default()).await.unwrap();
     /// let mut transaction = client.begin().await.unwrap();
     /// // ... Issue some commands.
     /// let commit = transaction.commit();
@@ -67,8 +66,7 @@ impl Client {
     /// use tikv_client::{Config, TransactionClient};
     /// use futures::prelude::*;
     /// # futures::executor::block_on(async {
-    /// let connect = TransactionClient::connect(Config::default());
-    /// let client = connect.await.unwrap();
+    /// let client = TransactionClient::new(Config::default()).await.unwrap();
     /// let timestamp = client.current_timestamp().await.unwrap();
     /// # });
     /// ```

--- a/src/transaction/client.rs
+++ b/src/transaction/client.rs
@@ -6,15 +6,15 @@ use crate::{
     Config, Result,
 };
 
-use derive_new::new;
-use futures::prelude::*;
-use futures::task::{Context, Poll};
-use std::pin::Pin;
+use futures::executor::ThreadPool;
 use std::sync::Arc;
 
 /// The TiKV transactional `Client` is used to issue requests to the TiKV server and PD cluster.
 pub struct Client {
     pd: Arc<PdRpcClient>,
+    /// The thread pool for background tasks including committing secondary keys and failed
+    /// transaction cleanups.
+    bg_worker: ThreadPool,
 }
 
 impl Client {
@@ -24,12 +24,15 @@ impl Client {
     /// use tikv_client::{Config, TransactionClient};
     /// use futures::prelude::*;
     /// # futures::executor::block_on(async {
-    /// let connect = TransactionClient::connect(Config::default());
-    /// let client = connect.await.unwrap();
+    /// let client = TransactionClient::new(Config::default()).await.unwrap;
     /// # });
     /// ```
-    pub fn connect(config: Config) -> Connect {
-        Connect::new(config)
+    pub async fn new(config: Config) -> Result<Client> {
+        let bg_worker = ThreadPool::new()?;
+        // TODO: PdRpcClient::connect currently uses a blocking implementation.
+        //       Make it asynchronous later.
+        let pd = Arc::new(PdRpcClient::connect(&config)?);
+        Ok(Client { pd, bg_worker })
     }
 
     /// Creates a new [`Transaction`](Transaction).
@@ -50,12 +53,12 @@ impl Client {
     /// ```
     pub async fn begin(&self) -> Result<Transaction> {
         let timestamp = self.current_timestamp().await?;
-        Ok(Transaction::new(timestamp, self.pd.clone()))
+        Ok(self.new_transaction(timestamp))
     }
 
     /// Creates a new [`Snapshot`](Snapshot) at the given time.
     pub fn snapshot(&self, timestamp: Timestamp) -> Snapshot {
-        Snapshot::new(Transaction::new(timestamp, self.pd.clone()))
+        Snapshot::new(self.new_transaction(timestamp))
     }
 
     /// Retrieves the current [`Timestamp`](Timestamp).
@@ -72,34 +75,8 @@ impl Client {
     pub async fn current_timestamp(&self) -> Result<Timestamp> {
         self.pd.clone().get_timestamp().await
     }
-}
 
-/// An unresolved [`Client`](Client) connection to a TiKV cluster.
-///
-/// Once resolved it will result in a connected [`Client`](Client).
-///
-/// ```rust,no_run
-/// use tikv_client::{Config, TransactionClient, Connect};
-/// use futures::prelude::*;
-///
-/// # futures::executor::block_on(async {
-/// let connect: Connect = TransactionClient::connect(Config::default());
-/// let client: TransactionClient = connect.await.unwrap();
-/// # });
-/// ```
-#[derive(new)]
-pub struct Connect {
-    config: Config,
-}
-
-impl Future for Connect {
-    type Output = Result<Client>;
-
-    fn poll(self: Pin<&mut Self>, _cx: &mut Context) -> Poll<Self::Output> {
-        let config = &self.config;
-        // TODO: PdRpcClient::connect currently uses a blocking implementation.
-        //       Make it asynchronous later.
-        let pd = Arc::new(PdRpcClient::connect(config)?);
-        Poll::Ready(Ok(Client { pd }))
+    fn new_transaction(&self, timestamp: Timestamp) -> Transaction {
+        Transaction::new(timestamp, self.bg_worker.clone(), self.pd.clone())
     }
 }

--- a/src/transaction/lock.rs
+++ b/src/transaction/lock.rs
@@ -111,17 +111,9 @@ async fn resolve_lock_with_retry(
 }
 
 pub trait HasLocks {
-    fn take_locks(&mut self) -> Vec<kvrpcpb::LockInfo>;
-}
-
-macro_rules! dummy_impl_has_locks {
-    ($t: tt) => {
-        impl crate::transaction::HasLocks for kvrpcpb::$t {
-            fn take_locks(&mut self) -> Vec<kvrpcpb::LockInfo> {
-                Vec::new()
-            }
-        }
-    };
+    fn take_locks(&mut self) -> Vec<kvrpcpb::LockInfo> {
+        Vec::new()
+    }
 }
 
 #[cfg(test)]

--- a/src/transaction/mod.rs
+++ b/src/transaction/mod.rs
@@ -9,7 +9,7 @@
 //! **Warning:** It is not advisable to use both raw and transactional functionality in the same keyspace.
 //!
 
-pub use client::{Client, Connect};
+pub use client::Client;
 pub use lock::{resolve_locks, HasLocks};
 pub use snapshot::Snapshot;
 pub use transaction::Transaction;

--- a/src/transaction/requests.rs
+++ b/src/transaction/requests.rs
@@ -352,6 +352,15 @@ impl KvRequest for kvrpcpb::PrewriteRequest {
     }
 }
 
+impl HasLocks for kvrpcpb::PrewriteResponse {
+    fn take_locks(&mut self) -> Vec<kvrpcpb::LockInfo> {
+        self.errors
+            .iter_mut()
+            .filter_map(|error| error.locked.take())
+            .collect()
+    }
+}
+
 pub fn new_prewrite_request(
     mutations: Vec<kvrpcpb::Mutation>,
     primary_lock: Key,
@@ -482,7 +491,6 @@ pub fn new_batch_rollback_request(
     req
 }
 
-dummy_impl_has_locks!(PrewriteResponse);
 dummy_impl_has_locks!(CommitResponse);
 dummy_impl_has_locks!(CleanupResponse);
 dummy_impl_has_locks!(BatchRollbackResponse);

--- a/src/transaction/requests.rs
+++ b/src/transaction/requests.rs
@@ -328,16 +328,7 @@ impl KvRequest for kvrpcpb::PrewriteRequest {
         pd_client: Arc<PdC>,
     ) -> BoxStream<'static, Result<(Self::KeyData, Store<PdC::KvClient>)>> {
         let mutations = mem::replace(&mut self.mutations, Vec::default());
-        pd_client
-            .clone()
-            .group_keys_by_region(mutations.into_iter())
-            .and_then(move |(region_id, mutations)| {
-                pd_client
-                    .clone()
-                    .store_for_id(region_id)
-                    .map_ok(move |store| (mutations, store))
-            })
-            .boxed()
+        store_stream_for_keys(mutations, pd_client)
     }
 
     fn map_result(_: Self::RpcResponse) -> Self::Result {}
@@ -399,16 +390,7 @@ impl KvRequest for kvrpcpb::CommitRequest {
         pd_client: Arc<PdC>,
     ) -> BoxStream<'static, Result<(Self::KeyData, Store<PdC::KvClient>)>> {
         let keys = mem::replace(&mut self.keys, Vec::default());
-        pd_client
-            .clone()
-            .group_keys_by_region(keys.into_iter())
-            .and_then(move |(region_id, keys)| {
-                pd_client
-                    .clone()
-                    .store_for_id(region_id)
-                    .map_ok(move |store| (keys, store))
-            })
-            .boxed()
+        store_stream_for_keys(keys, pd_client)
     }
 
     fn map_result(_: Self::RpcResponse) -> Self::Result {}
@@ -456,16 +438,7 @@ impl KvRequest for kvrpcpb::BatchRollbackRequest {
         pd_client: Arc<PdC>,
     ) -> BoxStream<'static, Result<(Self::KeyData, Store<PdC::KvClient>)>> {
         let keys = mem::replace(&mut self.keys, Vec::default());
-        pd_client
-            .clone()
-            .group_keys_by_region(keys.into_iter())
-            .and_then(move |(region_id, keys)| {
-                pd_client
-                    .clone()
-                    .store_for_id(region_id)
-                    .map_ok(move |store| (keys, store))
-            })
-            .boxed()
+        store_stream_for_keys(keys, pd_client)
     }
 
     fn map_result(_: Self::RpcResponse) -> Self::Result {}

--- a/src/transaction/requests.rs
+++ b/src/transaction/requests.rs
@@ -357,14 +357,14 @@ pub fn new_prewrite_request(
     primary_lock: Key,
     start_version: u64,
     lock_ttl: u64,
-    txn_size: u64,
 ) -> kvrpcpb::PrewriteRequest {
     let mut req = kvrpcpb::PrewriteRequest::default();
     req.set_mutations(mutations);
     req.set_primary_lock(primary_lock.into());
     req.set_start_version(start_version);
     req.set_lock_ttl(lock_ttl);
-    req.set_txn_size(txn_size);
+    // TODO: Lite resolve lock is currently disabled
+    req.set_txn_size(std::u64::MAX);
 
     req
 }

--- a/src/transaction/requests.rs
+++ b/src/transaction/requests.rs
@@ -464,7 +464,7 @@ pub fn new_batch_rollback_request(
     req
 }
 
-dummy_impl_has_locks!(CommitResponse);
-dummy_impl_has_locks!(CleanupResponse);
-dummy_impl_has_locks!(BatchRollbackResponse);
-dummy_impl_has_locks!(ResolveLockResponse);
+impl HasLocks for kvrpcpb::CommitResponse {}
+impl HasLocks for kvrpcpb::CleanupResponse {}
+impl HasLocks for kvrpcpb::BatchRollbackResponse {}
+impl HasLocks for kvrpcpb::ResolveLockResponse {}

--- a/src/transaction/requests.rs
+++ b/src/transaction/requests.rs
@@ -294,6 +294,139 @@ pub fn new_cleanup_request(key: impl Into<Key>, start_version: u64) -> kvrpcpb::
     req
 }
 
+impl AsRef<Key> for kvrpcpb::Mutation {
+    fn as_ref(&self) -> &Key {
+        self.key.as_ref()
+    }
+}
+
+impl KvRequest for kvrpcpb::PrewriteRequest {
+    type Result = ();
+    type RpcResponse = kvrpcpb::PrewriteResponse;
+    type KeyData = Vec<kvrpcpb::Mutation>;
+    const REQUEST_NAME: &'static str = "kv_prewrite";
+    const RPC_FN: RpcFnType<Self, Self::RpcResponse> = TikvClient::kv_prewrite_async_opt;
+
+    fn make_rpc_request<KvC: KvClient>(
+        &self,
+        mutations: Self::KeyData,
+        store: &Store<KvC>,
+    ) -> Self {
+        let mut req = store.request::<Self>();
+        req.set_mutations(mutations);
+        req.set_primary_lock(self.primary_lock.clone());
+        req.set_start_version(self.start_version);
+        req.set_lock_ttl(self.lock_ttl);
+        req.set_skip_constraint_check(self.skip_constraint_check);
+        req.set_txn_size(self.txn_size);
+
+        req
+    }
+
+    fn store_stream<PdC: PdClient>(
+        &mut self,
+        pd_client: Arc<PdC>,
+    ) -> BoxStream<'static, Result<(Self::KeyData, Store<PdC::KvClient>)>> {
+        let mutations = mem::replace(&mut self.mutations, Vec::default());
+        pd_client
+            .clone()
+            .group_keys_by_region(mutations.into_iter())
+            .and_then(move |(region_id, mutations)| {
+                pd_client
+                    .clone()
+                    .store_for_id(region_id)
+                    .map_ok(move |store| (mutations, store))
+            })
+            .boxed()
+    }
+
+    fn map_result(_: Self::RpcResponse) -> Self::Result {}
+
+    fn reduce(
+        results: BoxStream<'static, Result<Self::Result>>,
+    ) -> BoxFuture<'static, Result<Self::Result>> {
+        results
+            .into_future()
+            .map(|(f, _)| f.expect("no results should be impossible"))
+            .boxed()
+    }
+}
+
+pub fn new_prewrite_request(
+    mutations: Vec<kvrpcpb::Mutation>,
+    primary_lock: Key,
+    start_version: u64,
+    lock_ttl: u64,
+    txn_size: u64,
+) -> kvrpcpb::PrewriteRequest {
+    let mut req = kvrpcpb::PrewriteRequest::default();
+    req.set_mutations(mutations);
+    req.set_primary_lock(primary_lock.into());
+    req.set_start_version(start_version);
+    req.set_lock_ttl(lock_ttl);
+    req.set_txn_size(txn_size);
+
+    req
+}
+
+impl KvRequest for kvrpcpb::CommitRequest {
+    type Result = ();
+    type RpcResponse = kvrpcpb::CommitResponse;
+    type KeyData = Vec<Vec<u8>>;
+    const REQUEST_NAME: &'static str = "kv_commit";
+    const RPC_FN: RpcFnType<Self, Self::RpcResponse> = TikvClient::kv_commit_async_opt;
+
+    fn make_rpc_request<KvC: KvClient>(&self, keys: Self::KeyData, store: &Store<KvC>) -> Self {
+        let mut req = store.request::<Self>();
+        req.set_keys(keys);
+        req.set_start_version(self.start_version);
+        req.set_commit_version(self.commit_version);
+
+        req
+    }
+
+    fn store_stream<PdC: PdClient>(
+        &mut self,
+        pd_client: Arc<PdC>,
+    ) -> BoxStream<'static, Result<(Self::KeyData, Store<PdC::KvClient>)>> {
+        let keys = mem::replace(&mut self.keys, Vec::default());
+        pd_client
+            .clone()
+            .group_keys_by_region(keys.into_iter())
+            .and_then(move |(region_id, keys)| {
+                pd_client
+                    .clone()
+                    .store_for_id(region_id)
+                    .map_ok(move |store| (keys, store))
+            })
+            .boxed()
+    }
+
+    fn map_result(_: Self::RpcResponse) -> Self::Result {}
+
+    fn reduce(
+        results: BoxStream<'static, Result<Self::Result>>,
+    ) -> BoxFuture<'static, Result<Self::Result>> {
+        results
+            .into_future()
+            .map(|(f, _)| f.expect("no results should be impossible"))
+            .boxed()
+    }
+}
+
+pub fn new_commit_request(
+    keys: Vec<Key>,
+    start_version: u64,
+    commit_version: u64,
+) -> kvrpcpb::CommitRequest {
+    let mut req = kvrpcpb::CommitRequest::default();
+    req.set_keys(keys.into_iter().map(Into::into).collect());
+    req.set_start_version(start_version);
+    req.set_commit_version(commit_version);
+
+    req
+}
+
 dummy_impl_has_locks!(PrewriteResponse);
 dummy_impl_has_locks!(CommitResponse);
 dummy_impl_has_locks!(CleanupResponse);

--- a/src/transaction/transaction.rs
+++ b/src/transaction/transaction.rs
@@ -132,8 +132,9 @@ impl Transaction {
     /// txn.commit().await.unwrap();
     /// # });
     /// ```
-    pub fn set(&self, key: impl Into<Key>, value: impl Into<Value>) {
+    pub async fn set(&self, key: impl Into<Key>, value: impl Into<Value>) -> Result<()> {
         self.buffer.put(key.into(), value.into());
+        Ok(())
     }
 
     /// Deletes the given key.
@@ -150,8 +151,9 @@ impl Transaction {
     /// txn.commit().await.unwrap();
     /// # });
     /// ```
-    pub async fn delete(&self, key: impl Into<Key>) {
+    pub async fn delete(&self, key: impl Into<Key>) -> Result<()> {
         self.buffer.delete(key.into());
+        Ok(())
     }
 
     /// Locks the given keys.
@@ -167,10 +169,11 @@ impl Transaction {
     /// txn.commit().await.unwrap();
     /// # });
     /// ```
-    pub async fn lock_keys(&self, keys: impl IntoIterator<Item = impl Into<Key>>) {
+    pub async fn lock_keys(&self, keys: impl IntoIterator<Item = impl Into<Key>>) -> Result<()> {
         for key in keys {
             self.buffer.lock(key.into());
         }
+        Ok(())
     }
 
     /// Commits the actions of the transaction.

--- a/src/transaction/transaction.rs
+++ b/src/transaction/transaction.rs
@@ -264,6 +264,11 @@ impl TwoPhaseCommitter {
 
     async fn commit_secondary(mut self, commit_version: u64) -> Result<()> {
         let mutations = mem::replace(&mut self.mutations, Vec::default());
+        // No need to commit secondary keys when there is only one key
+        if mutations.len() == 1 {
+            return Ok(());
+        }
+
         let keys = mutations
             .into_iter()
             .skip(1) // skip primary key

--- a/src/transaction/transaction.rs
+++ b/src/transaction/transaction.rs
@@ -29,8 +29,7 @@ use std::sync::Arc;
 /// use tikv_client::{Config, TransactionClient};
 /// use futures::prelude::*;
 /// # futures::executor::block_on(async {
-/// let connect = TransactionClient::connect(Config::default());
-/// let client = connect.await.unwrap();
+/// let client = TransactionClient::new(Config::default()).await.unwrap();
 /// let txn = client.begin().await.unwrap();
 /// # });
 /// ```
@@ -50,9 +49,8 @@ impl Transaction {
     /// # use tikv_client::{Value, Config, transaction::Client};
     /// # use futures::prelude::*;
     /// # futures::executor::block_on(async {
-    /// # let connecting_client = Client::connect(Config::new(vec!["192.168.0.100", "192.168.0.101"]));
-    /// # let connected_client = connecting_client.await.unwrap();
-    /// let mut txn = connected_client.begin().await.unwrap();
+    /// # let client = Client::new(Config::new(vec!["192.168.0.100", "192.168.0.101"])).await.unwrap();
+    /// let mut txn = client.begin().await.unwrap();
     /// let key = "TiKV".to_owned();
     /// let result: Option<Value> = txn.get(key).await.unwrap();
     /// // Finish the transaction...
@@ -75,9 +73,8 @@ impl Transaction {
     /// # use futures::prelude::*;
     /// # use std::collections::HashMap;
     /// # futures::executor::block_on(async {
-    /// # let connecting_client = Client::connect(Config::new(vec!["192.168.0.100", "192.168.0.101"]));
-    /// # let connected_client = connecting_client.await.unwrap();
-    /// let mut txn = connected_client.begin().await.unwrap();
+    /// # let client = Client::new(Config::new(vec!["192.168.0.100", "192.168.0.101"])).await.unwrap();
+    /// let mut txn = client.begin().await.unwrap();
     /// let keys = vec!["TiKV".to_owned(), "TiDB".to_owned()];
     /// let result: HashMap<Key, Value> = txn
     ///     .batch_get(keys)
@@ -115,9 +112,8 @@ impl Transaction {
     /// # use tikv_client::{Key, Value, Config, transaction::Client};
     /// # use futures::prelude::*;
     /// # futures::executor::block_on(async {
-    /// # let connecting_client = Client::connect(Config::new(vec!["192.168.0.100", "192.168.0.101"]));
-    /// # let connected_client = connecting_client.await.unwrap();
-    /// let mut txn = connected_client.begin().await.unwrap();
+    /// # let client = Client::new(Config::new(vec!["192.168.0.100", "192.168.0.101"])).await.unwrap();
+    /// let mut txn = client.begin().await.unwrap();
     /// let key = "TiKV".to_owned();
     /// let val = "TiKV".to_owned();
     /// txn.set(key, val);
@@ -135,9 +131,8 @@ impl Transaction {
     /// # use tikv_client::{Key, Config, transaction::Client};
     /// # use futures::prelude::*;
     /// # futures::executor::block_on(async {
-    /// # let connecting_client = Client::connect(Config::new(vec!["192.168.0.100", "192.168.0.101"]));
-    /// # let connected_client = connecting_client.await.unwrap();
-    /// let mut txn = connected_client.begin().await.unwrap();
+    /// # let client = Client::new(Config::new(vec!["192.168.0.100", "192.168.0.101"])).await.unwrap();
+    /// let mut txn = client.begin().await.unwrap();
     /// let key = "TiKV".to_owned();
     /// txn.delete(key);
     /// // Finish the transaction...
@@ -154,9 +149,8 @@ impl Transaction {
     /// # use tikv_client::{Config, transaction::Client};
     /// # use futures::prelude::*;
     /// # futures::executor::block_on(async {
-    /// # let connect = Client::connect(Config::default());
-    /// # let connected_client = connect.await.unwrap();
-    /// let mut txn = connected_client.begin().await.unwrap();
+    /// # let client = Client::new(Config::default()).await.unwrap();
+    /// let mut txn = client.begin().await.unwrap();
     /// txn.lock_keys(vec!["TiKV".to_owned(), "Rust".to_owned()]);
     /// // ... Do some actions.
     /// txn.commit().await.unwrap();
@@ -174,9 +168,8 @@ impl Transaction {
     /// # use tikv_client::{Config, transaction::Client};
     /// # use futures::prelude::*;
     /// # futures::executor::block_on(async {
-    /// # let connect = Client::connect(Config::default());
-    /// # let connected_client = connect.await.unwrap();
-    /// let mut txn = connected_client.begin().await.unwrap();
+    /// # let client = Client::new(Config::default()).await.unwrap();
+    /// let mut txn = client.begin().await.unwrap();
     /// // ... Do some actions.
     /// let req = txn.commit();
     /// let result: () = req.await.unwrap();

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -12,7 +12,7 @@ fn get_timestamp() -> Fallible<()> {
     let mut pool = ThreadPool::new()?;
     let config = Config::new(pd_addrs());
     let fut = async {
-        let client = TransactionClient::connect(config).await?;
+        let client = TransactionClient::new(config).await?;
         Result::Ok(future::join_all((0..COUNT).map(|_| client.current_timestamp())).await)
     };
     // Calculate each version of retrieved timestamp

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,10 +1,11 @@
 #![cfg(feature = "integration-tests")]
 
 use failure::Fallible;
-use futures::executor::ThreadPool;
+use futures::executor::{block_on, ThreadPool};
 use futures::prelude::*;
+use std::collections::HashMap;
 use std::env;
-use tikv_client::{Config, Result, TransactionClient};
+use tikv_client::{Config, Key, Result, TransactionClient, Value};
 
 #[test]
 fn get_timestamp() -> Fallible<()> {
@@ -27,6 +28,66 @@ fn get_timestamp() -> Fallible<()> {
     versions.dedup();
     assert_eq!(versions.len(), COUNT);
     Ok(())
+}
+
+#[test]
+fn crud() -> Fallible<()> {
+    let config = Config::new(pd_addrs());
+    block_on(async move {
+        let client = TransactionClient::new(config).await?;
+        let mut txn = client.begin().await?;
+        // Get non-existent keys
+        assert!(txn.get("foo".to_owned()).await?.is_none());
+        assert_eq!(
+            txn.batch_get(vec!["foo".to_owned(), "bar".to_owned()])
+                .await?
+                .count(),
+            0
+        );
+
+        txn.set("foo".to_owned(), "bar".to_owned()).await?;
+        txn.set("bar".to_owned(), "foo".to_owned()).await?;
+        // Read buffered values
+        assert_eq!(
+            txn.get("foo".to_owned()).await?,
+            Some("bar".to_owned().into())
+        );
+        let batch_get_res: HashMap<Key, Value> = txn
+            .batch_get(vec!["foo".to_owned(), "bar".to_owned()])
+            .await?
+            .filter_map(|(k, v)| v.map(|v| (k, v)))
+            .collect();
+        assert_eq!(
+            batch_get_res.get(&Key::from("foo".to_owned())),
+            Some(Value::from("bar".to_owned())).as_ref()
+        );
+        assert_eq!(
+            batch_get_res.get(&Key::from("bar".to_owned())),
+            Some(Value::from("foo".to_owned())).as_ref()
+        );
+        txn.commit().await?;
+
+        // Read again from TiKV
+        let txn = client.begin().await?;
+        assert_eq!(
+            txn.get("foo".to_owned()).await?,
+            Some("bar".to_owned().into())
+        );
+        let batch_get_res: HashMap<Key, Value> = txn
+            .batch_get(vec!["foo".to_owned(), "bar".to_owned()])
+            .await?
+            .filter_map(|(k, v)| v.map(|v| (k, v)))
+            .collect();
+        assert_eq!(
+            batch_get_res.get(&Key::from("foo".to_owned())),
+            Some(Value::from("bar".to_owned())).as_ref()
+        );
+        assert_eq!(
+            batch_get_res.get(&Key::from("bar".to_owned())),
+            Some(Value::from("foo".to_owned())).as_ref()
+        );
+        Fallible::Ok(())
+    })
 }
 
 const ENV_PD_ADDRS: &str = "PD_ADDRS";

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -41,6 +41,7 @@ fn crud() -> Fallible<()> {
         assert_eq!(
             txn.batch_get(vec!["foo".to_owned(), "bar".to_owned()])
                 .await?
+                .filter(|(_, v)| v.is_some())
                 .count(),
             0
         );


### PR DESCRIPTION
- [x] Merge #112 first

This PR implements two-phase commit. It is a very initial implementation but should work well.

After this PR, the transaction part is barely enough to be functional.

For the added part of this PR, there are some todos (will update to issues when the pr gets merged):
- When committing the primary key, also carry some other keys. (split requests by size)
- Increase the lock TTL for big transactions
- Enable transactional API integration test
- Add as many unit tests as possible (to be discussed about how to do this)