### PR TITLE
Replace tokio-timer with futures_timer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,6 @@ log = "0.3.9"
 regex = "1"
 serde = "1.0"
 serde_derive = "1.0"
-tokio-timer = "0.2"
 futures-timer = "0.3"
 
 [dependencies.prometheus]

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,7 +1,6 @@
 // Copyright 2018 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::{sync::mpsc, thread, time::Duration};
-use tokio_timer::{self, timer::Handle};
+use std::{thread, time::Duration};
 
 macro_rules! internal_err {
     ($e:expr) => ({
@@ -37,38 +36,4 @@ pub fn duration_to_sec(d: Duration) -> f64 {
     let nanos = f64::from(d.subsec_nanos());
     // In most cases, we can't have so large Duration, so here just panic if overflow now.
     d.as_secs() as f64 + (nanos / 1_000_000_000.0)
-}
-
-lazy_static! {
-    pub static ref GLOBAL_TIMER_HANDLE: Handle = start_global_timer();
-}
-
-fn start_global_timer() -> Handle {
-    let (tx, rx) = mpsc::channel();
-    thread::Builder::new()
-        .name(thread_name!("timer"))
-        .spawn(move || {
-            let mut timer = tokio_timer::Timer::default();
-            tx.send(timer.handle()).unwrap();
-            loop {
-                timer.turn(None).unwrap();
-            }
-        })
-        .unwrap();
-    rx.recv().unwrap()
-}
-
-#[cfg(test)]
-mod tests {
-    use futures::compat::Compat01As03;
-
-    #[test]
-    fn test_global_timer() {
-        let handle = super::GLOBAL_TIMER_HANDLE.clone();
-        let delay =
-            handle.delay(::std::time::Instant::now() + ::std::time::Duration::from_millis(100));
-        let timer = ::std::time::Instant::now();
-        futures::executor::block_on(Compat01As03::new(delay)).unwrap();
-        assert!(timer.elapsed() >= ::std::time::Duration::from_millis(100));
-    }
 }


### PR DESCRIPTION
With futures_timer, we don't need to maintain a timer thread ourselves. I think #105 will be fixed too.