### PR TITLE
Document fully qualified `into()` for keys and values

### DIFF
--- a/src/kv/key.rs
+++ b/src/kv/key.rs
@@ -34,15 +34,17 @@ use std::{fmt, u8};
 /// let from_bytes = Key::from(bytes);
 /// assert_eq!(from_static_str, from_bytes);
 /// ```
-/// 
-/// In order to get the wrapped value you can use `to_inner`:
-/// 
+///
+/// While `.into()` is usually sufficient for obtaining the buffer itself, sometimes type inference
+/// isn't able to determine the correct type. Notably in the `assert_eq!()` and `==` cases. In
+/// these cases using the fully-qualified-syntax is useful:
+///
 /// ```rust
 /// use tikv_client::Key;
-/// 
+///
 /// let buf = "TiKV".as_bytes().to_owned();
 /// let key = Key::from(buf.clone());
-/// assert_eq!(key.to_inner(), buf);
+/// assert_eq!(Into::<Vec<u8>>::into(key), buf);
 /// ```
 ///
 /// Many functions which accept a `Key` accept an `Into<Key>`, which means all of the above types
@@ -93,12 +95,6 @@ impl Key {
         } else {
             Bound::Excluded(self)
         }
-    }
-        
-    /// Unwrap the key into the byte vector contained within.
-    #[inline]
-    pub fn to_inner(self) -> Vec<u8> {
-        self.0
     }
 }
 

--- a/src/kv/key.rs
+++ b/src/kv/key.rs
@@ -34,10 +34,19 @@ use std::{fmt, u8};
 /// let from_bytes = Key::from(bytes);
 /// assert_eq!(from_static_str, from_bytes);
 /// ```
+/// 
+/// In order to get the wrapped value you can use `to_inner`:
+/// 
+/// ```rust
+/// use tikv_client::Key;
+/// 
+/// let buf = "TiKV".as_bytes().to_owned();
+/// let key = Key::from(buf.clone());
+/// assert_eq!(key.to_inner(), buf);
+/// ```
 ///
-/// **But, you should not need to worry about all this:** Many functions which accept a `Key`
-/// accept an `Into<Key>`, which means all of the above types can be passed directly to those
-/// functions.
+/// Many functions which accept a `Key` accept an `Into<Key>`, which means all of the above types
+/// can be passed directly to those functions.
 #[derive(Default, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 #[cfg_attr(test, derive(Arbitrary))]
 pub struct Key(
@@ -84,6 +93,12 @@ impl Key {
         } else {
             Bound::Excluded(self)
         }
+    }
+        
+    /// Unwrap the key into the byte vector contained within.
+    #[inline]
+    pub fn to_inner(self) -> Vec<u8> {
+        self.0
     }
 }
 

--- a/src/kv/value.rs
+++ b/src/kv/value.rs
@@ -34,14 +34,16 @@ use std::{fmt, str, u8};
 /// assert_eq!(from_static_str, from_bytes);
 /// ```
 ///
-/// In order to get the wrapped value you can use `to_inner`:
-/// 
+/// While `.into()` is usually sufficient for obtaining the buffer itself, sometimes type inference
+/// isn't able to determine the correct type. Notably in the `assert_eq!()` and `==` cases. In
+/// these cases using the fully-qualified-syntax is useful:
+///
 /// ```rust
 /// use tikv_client::Value;
-/// 
+///
 /// let buf = "TiKV".as_bytes().to_owned();
 /// let value = Value::from(buf.clone());
-/// assert_eq!(value.to_inner(), buf);
+/// assert_eq!(Into::<Vec<u8>>::into(value), buf);
 /// ```
 ///
 /// Many functions which accept a `Value` accept an `Into<Value>`, which means all of the above types
@@ -62,12 +64,6 @@ impl Value {
     #[inline]
     pub fn is_empty(&self) -> bool {
         self.0.is_empty()
-    }
-    
-    /// Unwrap the value into the byte vector contained within.
-    #[inline]
-    pub fn to_inner(self) -> Vec<u8> {
-        self.0
     }
 }
 

--- a/src/kv/value.rs
+++ b/src/kv/value.rs
@@ -34,9 +34,18 @@ use std::{fmt, str, u8};
 /// assert_eq!(from_static_str, from_bytes);
 /// ```
 ///
-/// **But, you should not need to worry about all this:** Many functions which accept a `Value`
-/// accept an `Into<Value>`, which means all of the above types can be passed directly to those
-/// functions.
+/// In order to get the wrapped value you can use `to_inner`:
+/// 
+/// ```rust
+/// use tikv_client::Value;
+/// 
+/// let buf = "TiKV".as_bytes().to_owned();
+/// let value = Value::from(buf.clone());
+/// assert_eq!(value.to_inner(), buf);
+/// ```
+///
+/// Many functions which accept a `Value` accept an `Into<Value>`, which means all of the above types
+/// can be passed directly to those functions.
 #[derive(Default, Clone, Eq, PartialEq, Hash)]
 #[cfg_attr(test, derive(Arbitrary))]
 pub struct Value(
@@ -53,6 +62,12 @@ impl Value {
     #[inline]
     pub fn is_empty(&self) -> bool {
         self.0.is_empty()
+    }
+    
+    /// Unwrap the value into the byte vector contained within.
+    #[inline]
+    pub fn to_inner(self) -> Vec<u8> {
+        self.0
     }
 }
 


### PR DESCRIPTION
This adds the ability for downstreams to access contained values as `Vec<u8>`. It was previously allowed but removed in #77 .