### PR TITLE
Replace the retry implementation.

### DIFF
--- a/src/pd/client.rs
+++ b/src/pd/client.rs
@@ -142,11 +142,12 @@ impl<KvC: KvConnect + Send + Sync + 'static> PdClient for PdRpcClient<KvC> {
     }
 
     fn region_for_key(&self, key: &Key) -> BoxFuture<'static, Result<Region>> {
-        self.pd.clone().get_region(key.into()).boxed()
+        let key: &[u8] = key.into();
+        self.pd.clone().get_region(key.to_owned()).boxed()
     }
 
     fn get_timestamp(self: Arc<Self>) -> BoxFuture<'static, Result<Timestamp>> {
-        self.pd.clone().get_timestamp()
+        self.pd.clone().get_timestamp().boxed()
     }
 }
 

--- a/src/pd/retry.rs
+++ b/src/pd/retry.rs
@@ -8,14 +8,10 @@ use std::{
     time::Duration,
 };
 
-use futures::future::BoxFuture;
 use futures::prelude::*;
-use futures::ready;
-use futures::task::{Context, Poll};
 use futures_timer::Delay;
 use grpcio::Environment;
 use kvproto::metapb;
-use std::pin::Pin;
 
 use crate::{
     pd::{
@@ -27,6 +23,8 @@ use crate::{
     Result,
 };
 
+// FIXME: these numbers and how they are used are all just cargo-culted in, there
+// may be more optimal values.
 const RECONNECT_INTERVAL_SEC: u64 = 1;
 const MAX_REQUEST_COUNT: usize = 3;
 const LEADER_CHANGE_RETRY: usize = 10;
@@ -72,53 +70,33 @@ impl RetryClient<Cluster> {
     }
 
     // These get_* functions will try multiple times to make a request, reconnecting as necessary.
-    pub fn get_region(self: Arc<Self>, key: &[u8]) -> BoxFuture<'static, Result<Region>> {
-        let key = key.to_owned();
+    pub async fn get_region(self: Arc<Self>, key: Vec<u8>) -> Result<Region> {
         let timeout = self.timeout;
-        Box::pin(retry_request(self, move |cluster| {
+        retry_request(self, move |cluster| {
             cluster.get_region(key.clone(), timeout)
-        }))
+        })
+        .await
     }
 
-    pub fn get_region_by_id(self: Arc<Self>, id: RegionId) -> BoxFuture<'static, Result<Region>> {
+    pub async fn get_region_by_id(self: Arc<Self>, id: RegionId) -> Result<Region> {
         let timeout = self.timeout;
-        Box::pin(retry_request(self, move |cluster| {
-            cluster.get_region_by_id(id, timeout)
-        }))
+        retry_request(self, move |cluster| cluster.get_region_by_id(id, timeout)).await
     }
 
-    pub fn get_store(self: Arc<Self>, id: StoreId) -> BoxFuture<'static, Result<metapb::Store>> {
+    pub async fn get_store(self: Arc<Self>, id: StoreId) -> Result<metapb::Store> {
         let timeout = self.timeout;
-        Box::pin(retry_request(self, move |cluster| {
-            cluster.get_store(id, timeout)
-        }))
-    }
-
-    pub fn reconnect(&self, interval: u64) -> Result<()> {
-        if let Some(cluster) =
-            self.connection
-                .reconnect(&self.cluster.read().unwrap(), interval, self.timeout)?
-        {
-            *self.cluster.write().unwrap() = cluster;
-        }
-        Ok(())
-    }
-
-    pub fn with_cluster<T, F: Fn(&Cluster) -> T>(&self, f: F) -> T {
-        f(&self.cluster.read().unwrap())
+        retry_request(self, move |cluster| cluster.get_store(id, timeout)).await
     }
 
     #[allow(dead_code)]
-    pub fn get_all_stores(self: Arc<Self>) -> BoxFuture<'static, Result<Vec<metapb::Store>>> {
+    pub async fn get_all_stores(self: Arc<Self>) -> Result<Vec<metapb::Store>> {
         let timeout = self.timeout;
-        Box::pin(retry_request(self, move |cluster| {
-            cluster.get_all_stores(timeout)
-        }))
+        retry_request(self, move |cluster| cluster.get_all_stores(timeout)).await
     }
 
-    pub fn get_timestamp(self: Arc<Self>) -> BoxFuture<'static, Result<Timestamp>> {
+    pub async fn get_timestamp(self: Arc<Self>) -> Result<Timestamp> {
         // FIXME: retry or reconnect on error
-        Box::pin(self.cluster.read().unwrap().get_timestamp())
+        self.cluster.read().unwrap().get_timestamp().await
     }
 }
 
@@ -131,99 +109,158 @@ impl fmt::Debug for RetryClient {
     }
 }
 
-fn retry_request<Resp, Func, RespFuture>(
-    client: Arc<RetryClient>,
-    func: Func,
-) -> RetryRequest<impl Future<Output = Result<Resp>>>
+// A node-like thing that can be connected to.
+trait Reconnect {
+    type Cl;
+    fn reconnect(&self, interval: u64) -> Result<()>;
+    fn with_cluster<T, F: Fn(&Self::Cl) -> T>(&self, f: F) -> T;
+}
+
+impl Reconnect for RetryClient<Cluster> {
+    type Cl = Cluster;
+
+    fn reconnect(&self, interval: u64) -> Result<()> {
+        if let Some(cluster) =
+            self.connection
+                .reconnect(&self.cluster.read().unwrap(), interval, self.timeout)?
+        {
+            *self.cluster.write().unwrap() = cluster;
+        }
+        Ok(())
+    }
+
+    fn with_cluster<T, F: Fn(&Cluster) -> T>(&self, f: F) -> T {
+        f(&self.cluster.read().unwrap())
+    }
+}
+
+async fn retry_request<Rc, Resp, Func, RespFuture>(client: Arc<Rc>, func: Func) -> Result<Resp>
 where
+    Rc: Reconnect,
     Resp: Send + 'static,
-    Func: Fn(&Cluster) -> RespFuture + Send + 'static,
+    Func: Fn(&Rc::Cl) -> RespFuture,
     RespFuture: Future<Output = Result<Resp>> + Send + 'static,
 {
-    let mut req = Request::new(func, client);
-    RetryRequest {
-        reconnect_count: LEADER_CHANGE_RETRY,
-        future: req
-            .reconnect_if_needed()
-            .map_err(|_| internal_err!("failed to reconnect"))
-            .and_then(move |_| req.send_and_receive()),
+    let mut last_err = Ok(());
+    for _ in 0..LEADER_CHANGE_RETRY {
+        let fut = client.with_cluster(&func);
+        match fut.await {
+            Ok(r) => return Ok(r),
+            Err(e) => last_err = Err(e),
+        }
+
+        // Reconnect.
+        let mut reconnect_count = MAX_REQUEST_COUNT;
+        while let Err(e) = client.reconnect(RECONNECT_INTERVAL_SEC) {
+            reconnect_count -= 1;
+            if reconnect_count == 0 {
+                return Err(e);
+            }
+            Delay::new(Duration::from_secs(RECONNECT_INTERVAL_SEC)).await?;
+        }
     }
+
+    last_err?;
+    unreachable!();
 }
 
-/// A future which will retry a request up to `reconnect_count` times or until it
-/// succeeds.
-struct RetryRequest<Fut> {
-    reconnect_count: usize,
-    future: Fut,
-}
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::Error;
+    use futures::executor;
+    use futures::future::ready;
+    use std::sync::Mutex;
 
-struct Request<Func> {
-    // We keep track of requests sent and after `MAX_REQUEST_COUNT` we reconnect.
-    request_sent: usize,
+    #[test]
+    fn test_reconnect() {
+        struct MockClient {
+            reconnect_count: Mutex<usize>,
+        }
 
-    client: Arc<RetryClient>,
+        impl Reconnect for MockClient {
+            type Cl = ();
 
-    // A function which makes an async request.
-    func: Func,
-}
-
-impl<Resp, Fut> Future for RetryRequest<Fut>
-where
-    Resp: Send + 'static,
-    Fut: Future<Output = Result<Resp>> + Send + 'static,
-{
-    type Output = Result<Resp>;
-
-    fn poll(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<Resp>> {
-        unsafe {
-            let this = Pin::get_unchecked_mut(self);
-            if this.reconnect_count == 0 {
-                return Poll::Ready(Err(internal_err!("failed to send request")));
+            fn reconnect(&self, _: u64) -> Result<()> {
+                *self.reconnect_count.lock().unwrap() += 1;
+                // Not actually unimplemented, we just don't care about the error.
+                Err(Error::unimplemented())
             }
 
-            debug!("reconnect remains: {}", this.reconnect_count);
-            this.reconnect_count -= 1;
-            let resp = ready!(Pin::new_unchecked(&mut this.future).poll(cx))?;
-            Poll::Ready(Ok(resp))
-        }
-    }
-}
-
-impl<Resp, Func, RespFuture> Request<Func>
-where
-    Resp: Send + 'static,
-    Func: Fn(&Cluster) -> RespFuture + Send + 'static,
-    RespFuture: Future<Output = Result<Resp>> + Send + 'static,
-{
-    fn new(func: Func, client: Arc<RetryClient>) -> Self {
-        Request {
-            request_sent: 0,
-            client,
-            func,
-        }
-    }
-
-    fn reconnect_if_needed(&mut self) -> impl Future<Output = std::result::Result<(), ()>> + Send {
-        if self.request_sent < MAX_REQUEST_COUNT {
-            return future::Either::Left(future::ok(()));
-        }
-
-        // FIXME: should not block the core.
-        match self.client.reconnect(RECONNECT_INTERVAL_SEC) {
-            Ok(_) => {
-                self.request_sent = 0;
-                future::Either::Left(future::ok(()))
+            fn with_cluster<T, F: Fn(&()) -> T>(&self, f: F) -> T {
+                f(&())
             }
-            Err(_) => future::Either::Right(
-                Delay::new(Duration::from_secs(RECONNECT_INTERVAL_SEC)).map(|_| Err(())),
-            ),
         }
+
+        let client = Arc::new(MockClient {
+            reconnect_count: Mutex::new(0),
+        });
+
+        fn ready_err(_: &()) -> impl Future<Output = Result<()>> + Send + 'static {
+            ready(Err(internal_err!("whoops")))
+        }
+
+        let result = executor::block_on(retry_request(client.clone(), ready_err));
+        assert!(result.is_err());
+        assert_eq!(*client.reconnect_count.lock().unwrap(), MAX_REQUEST_COUNT);
+
+        *client.reconnect_count.lock().unwrap() = 0;
+        let result = executor::block_on(retry_request(client.clone(), |_| ready(Ok(()))));
+        assert!(result.is_ok());
+        assert_eq!(*client.reconnect_count.lock().unwrap(), 0);
     }
 
-    fn send_and_receive(&mut self) -> impl Future<Output = Result<Resp>> + Send {
-        self.request_sent += 1;
-        debug!("request sent: {}", self.request_sent);
+    #[test]
+    fn test_retry() {
+        struct MockClient {
+            retry_count: Mutex<usize>,
+        }
 
-        self.client.with_cluster(&self.func)
+        impl Reconnect for MockClient {
+            type Cl = ();
+
+            fn reconnect(&self, _: u64) -> Result<()> {
+                Ok(())
+            }
+
+            fn with_cluster<T, F: Fn(&()) -> T>(&self, f: F) -> T {
+                *self.retry_count.lock().unwrap() += 1;
+                f(&())
+            }
+        }
+
+        let client = Arc::new(MockClient {
+            retry_count: Mutex::new(0),
+        });
+        let max_retries = Arc::new(Mutex::new(1000));
+
+        let result = executor::block_on(retry_request(client.clone(), |_| {
+            let mut max_retries = max_retries.lock().unwrap();
+            *max_retries -= 1;
+            if *max_retries == 0 {
+                ready(Ok(()))
+            } else {
+                ready(Err(internal_err!("whoops")))
+            }
+        }));
+        assert!(result.is_err());
+        assert_eq!(*client.retry_count.lock().unwrap(), LEADER_CHANGE_RETRY);
+
+        let client = Arc::new(MockClient {
+            retry_count: Mutex::new(0),
+        });
+        let max_retries = Arc::new(Mutex::new(2));
+
+        let result = executor::block_on(retry_request(client.clone(), |_| {
+            let mut max_retries = max_retries.lock().unwrap();
+            *max_retries -= 1;
+            if *max_retries == 0 {
+                ready(Ok(()))
+            } else {
+                ready(Err(internal_err!("whoops")))
+            }
+        }));
+        assert!(result.is_ok());
+        assert_eq!(*client.retry_count.lock().unwrap(), 2);
     }
 }


### PR DESCRIPTION
The changes outside of retry.rs are to support the change from futures to async/await. It is probably easier to review the whole file rather than the diff.

PTAL @sticnarf @Hoverbear 