### PR TITLE
Retry get_timestamp

### DIFF
--- a/src/pd/retry.rs
+++ b/src/pd/retry.rs
@@ -36,8 +36,8 @@ pub struct RetryClient<Cl = Cluster> {
     timeout: Duration,
 }
 
+#[cfg(test)]
 impl<Cl> RetryClient<Cl> {
-    #[cfg(test)]
     pub fn new_with_cluster(
         env: Arc<Environment>,
         security_mgr: Arc<SecurityManager>,
@@ -95,8 +95,7 @@ impl RetryClient<Cluster> {
     }
 
     pub async fn get_timestamp(self: Arc<Self>) -> Result<Timestamp> {
-        // FIXME: retry or reconnect on error
-        self.cluster.read().unwrap().get_timestamp().await
+        retry_request(self, move |cluster| cluster.get_timestamp()).await
     }
 }
 


### PR DESCRIPTION
Supersedes #117. I think this is simpler due to my earlier refactoring of the retry mechanism, I'm not 100% sure though that I haven't missed something.

The retry stuff is already unit-tested and it is hard to test specifically `get_timestamp` without a mock PD where we can inject errors.

PTAL @sticnarf @Hoverbear 