### PR TITLE
Fix protobuf dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ derive-new = "0.5"
 failure = "0.1"
 futures = { version = "0.3.1", features = ["compat", "async-await", "thread-pool"] }
 grpcio = { version = "0.5.0-alpha", features = [ "secure", "prost-codec" ], default-features = false }
-kvproto = { git = "https://github.com/pingcap/kvproto.git", rev = "2fc6229ed6097b59dbe51525c7a65b19543a94ca", features = [ "prost-codec" ], default-features = false }
+kvproto = { git = "https://github.com/pingcap/kvproto.git", features = [ "prost-codec" ], default-features = false }
 lazy_static = "1"
 log = "0.3.9"
 regex = "1"
@@ -43,3 +43,8 @@ runtime-tokio = "0.3.0-alpha.6"
 proptest = "0.9"
 proptest-derive = "0.1.0"
 fail = { version = "0.3", features = [ "failpoints" ] }
+
+[replace]
+"protobuf:2.8.0" = { git = "https://github.com/nrc/rust-protobuf", rev="4df576feca3b10c01d55b0e7c634bfab30982087" }
+"protobuf-build:0.10.0" = { git = "https://github.com/tikv/protobuf-build", rev="42e52b9311f7fb31bbbe089fef5a24ec0392f9ce" }
+


### PR DESCRIPTION
fix https://github.com/tikv/client-rust/issues/125

the rev of protobuf is copied from kvproto,

seems the `[replace]` section takes effect for itself, but not the crates that depend it
