### PR TITLE
transaction: Implement transactional scan for #131 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,5 +46,4 @@ fail = { version = "0.3", features = [ "failpoints" ] }
 
 [replace]
 "protobuf:2.8.0" = { git = "https://github.com/nrc/rust-protobuf", rev="4df576feca3b10c01d55b0e7c634bfab30982087" }
-"protobuf-build:0.10.0" = { git = "https://github.com/tikv/protobuf-build", rev="42e52b9311f7fb31bbbe089fef5a24ec0392f9ce" }
-
+"protobuf-build:0.10.0" = { git = "https://github.com/tikv/protobuf-build", rev="1fe5d77689d9691b7917215f3a1d32968115cc02" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ name = "tikv_client"
 
 [dependencies]
 derive-new = "0.5"
-failure = "0.1"
+failure = "0.1.7"
 futures = { version = "0.3.1", features = ["compat", "async-await", "thread-pool"] }
 grpcio = { version = "0.5.0-alpha", features = [ "secure", "prost-codec" ], default-features = false }
 kvproto = { git = "https://github.com/pingcap/kvproto.git", features = [ "prost-codec" ], default-features = false }

--- a/examples/transaction.rs
+++ b/examples/transaction.rs
@@ -20,10 +20,8 @@ async fn get(client: &Client, key: Key) -> Option<Value> {
     txn.get(key).await.expect("Could not get value")
 }
 
-// Ignore a spurious warning from rustc (https://github.com/rust-lang/rust/issues/60566).
-#[allow(unused_mut)]
 async fn scan(client: &Client, range: impl Into<BoundRange>, mut limit: usize) {
-    let mut txn = client.begin().await.expect("Could not begin a transaction");
+    let txn = client.begin().await.expect("Could not begin a transaction");
     txn.scan(range)
         .into_stream()
         .take_while(move |r| {

--- a/examples/transaction.rs
+++ b/examples/transaction.rs
@@ -4,8 +4,7 @@ mod common;
 
 use crate::common::parse_args;
 use futures::prelude::*;
-use std::ops::RangeBounds;
-use tikv_client::{Config, Key, KvPair, TransactionClient as Client, Value};
+use tikv_client::{BoundRange, Config, Key, KvPair, TransactionClient as Client, Value};
 
 async fn puts(client: &Client, pairs: impl IntoIterator<Item = impl Into<KvPair>>) {
     let mut txn = client.begin().await.expect("Could not begin a transaction");
@@ -23,7 +22,7 @@ async fn get(client: &Client, key: Key) -> Option<Value> {
 
 // Ignore a spurious warning from rustc (https://github.com/rust-lang/rust/issues/60566).
 #[allow(unused_mut)]
-async fn scan(client: &Client, range: impl RangeBounds<Key>, mut limit: usize) {
+async fn scan(client: &Client, range: impl Into<BoundRange>, mut limit: usize) {
     let mut txn = client.begin().await.expect("Could not begin a transaction");
     txn.scan(range)
         .into_stream()

--- a/src/raw/requests.rs
+++ b/src/raw/requests.rs
@@ -21,6 +21,7 @@ impl KvRequest for kvrpcpb::RawGetRequest {
     type Result = Option<Value>;
     type RpcResponse = kvrpcpb::RawGetResponse;
     type KeyData = Key;
+    type Response = BoxFuture<'static, Result<Self::Result>>;
     const REQUEST_NAME: &'static str = "raw_get";
     const RPC_FN: RpcFnType<Self, Self::RpcResponse> = TikvClient::raw_get_async_opt;
 
@@ -49,9 +50,7 @@ impl KvRequest for kvrpcpb::RawGetRequest {
         }
     }
 
-    fn reduce(
-        results: BoxStream<'static, Result<Self::Result>>,
-    ) -> BoxFuture<'static, Result<Self::Result>> {
+    fn reduce(results: BoxStream<'static, Result<Self::Result>>) -> Self::Response {
         results
             .into_future()
             .map(|(f, _)| f.expect("no results should be impossible"))
@@ -74,6 +73,7 @@ impl KvRequest for kvrpcpb::RawBatchGetRequest {
     type Result = Vec<KvPair>;
     type RpcResponse = kvrpcpb::RawBatchGetResponse;
     type KeyData = Vec<Key>;
+    type Response = BoxFuture<'static, Result<Self::Result>>;
     const REQUEST_NAME: &'static str = "raw_batch_get";
     const RPC_FN: RpcFnType<Self, Self::RpcResponse> = TikvClient::raw_batch_get_async_opt;
 
@@ -97,9 +97,7 @@ impl KvRequest for kvrpcpb::RawBatchGetRequest {
         resp.take_pairs().into_iter().map(Into::into).collect()
     }
 
-    fn reduce(
-        results: BoxStream<'static, Result<Self::Result>>,
-    ) -> BoxFuture<'static, Result<Self::Result>> {
+    fn reduce(results: BoxStream<'static, Result<Self::Result>>) -> Self::Response {
         results.try_concat().boxed()
     }
 }
@@ -119,6 +117,7 @@ impl KvRequest for kvrpcpb::RawPutRequest {
     type Result = ();
     type RpcResponse = kvrpcpb::RawPutResponse;
     type KeyData = KvPair;
+    type Response = BoxFuture<'static, Result<Self::Result>>;
     const REQUEST_NAME: &'static str = "raw_put";
     const RPC_FN: RpcFnType<Self, Self::RpcResponse> = TikvClient::raw_put_async_opt;
 
@@ -143,9 +142,7 @@ impl KvRequest for kvrpcpb::RawPutRequest {
 
     fn map_result(_: Self::RpcResponse) -> Self::Result {}
 
-    fn reduce(
-        results: BoxStream<'static, Result<Self::Result>>,
-    ) -> BoxFuture<'static, Result<Self::Result>> {
+    fn reduce(results: BoxStream<'static, Result<Self::Result>>) -> Self::Response {
         results
             .into_future()
             .map(|(f, _)| f.expect("no results should be impossible"))
@@ -170,6 +167,7 @@ impl KvRequest for kvrpcpb::RawBatchPutRequest {
     type Result = ();
     type RpcResponse = kvrpcpb::RawBatchPutResponse;
     type KeyData = Vec<KvPair>;
+    type Response = BoxFuture<'static, Result<Self::Result>>;
     const REQUEST_NAME: &'static str = "raw_batch_put";
     const RPC_FN: RpcFnType<Self, Self::RpcResponse> = TikvClient::raw_batch_put_async_opt;
 
@@ -191,9 +189,7 @@ impl KvRequest for kvrpcpb::RawBatchPutRequest {
 
     fn map_result(_: Self::RpcResponse) -> Self::Result {}
 
-    fn reduce(
-        results: BoxStream<'static, Result<Self::Result>>,
-    ) -> BoxFuture<'static, Result<Self::Result>> {
+    fn reduce(results: BoxStream<'static, Result<Self::Result>>) -> Self::Response {
         results.try_collect().boxed()
     }
 }
@@ -213,6 +209,7 @@ impl KvRequest for kvrpcpb::RawDeleteRequest {
     type Result = ();
     type RpcResponse = kvrpcpb::RawDeleteResponse;
     type KeyData = Key;
+    type Response = BoxFuture<'static, Result<Self::Result>>;
     const REQUEST_NAME: &'static str = "raw_delete";
     const RPC_FN: RpcFnType<Self, Self::RpcResponse> = TikvClient::raw_delete_async_opt;
 
@@ -234,9 +231,7 @@ impl KvRequest for kvrpcpb::RawDeleteRequest {
 
     fn map_result(_: Self::RpcResponse) -> Self::Result {}
 
-    fn reduce(
-        results: BoxStream<'static, Result<Self::Result>>,
-    ) -> BoxFuture<'static, Result<Self::Result>> {
+    fn reduce(results: BoxStream<'static, Result<Self::Result>>) -> Self::Response {
         results
             .into_future()
             .map(|(f, _)| f.expect("no results should be impossible"))
@@ -259,6 +254,7 @@ impl KvRequest for kvrpcpb::RawBatchDeleteRequest {
     type Result = ();
     type RpcResponse = kvrpcpb::RawBatchDeleteResponse;
     type KeyData = Vec<Key>;
+    type Response = BoxFuture<'static, Result<Self::Result>>;
     const REQUEST_NAME: &'static str = "raw_batch_delete";
     const RPC_FN: RpcFnType<Self, Self::RpcResponse> = TikvClient::raw_batch_delete_async_opt;
 
@@ -280,9 +276,7 @@ impl KvRequest for kvrpcpb::RawBatchDeleteRequest {
 
     fn map_result(_: Self::RpcResponse) -> Self::Result {}
 
-    fn reduce(
-        results: BoxStream<'static, Result<Self::Result>>,
-    ) -> BoxFuture<'static, Result<Self::Result>> {
+    fn reduce(results: BoxStream<'static, Result<Self::Result>>) -> Self::Response {
         results.try_collect().boxed()
     }
 }
@@ -302,6 +296,7 @@ impl KvRequest for kvrpcpb::RawDeleteRangeRequest {
     type Result = ();
     type RpcResponse = kvrpcpb::RawDeleteRangeResponse;
     type KeyData = (Key, Key);
+    type Response = BoxFuture<'static, Result<Self::Result>>;
     const REQUEST_NAME: &'static str = "raw_delete_range";
     const RPC_FN: RpcFnType<Self, Self::RpcResponse> = TikvClient::raw_delete_range_async_opt;
 
@@ -330,9 +325,7 @@ impl KvRequest for kvrpcpb::RawDeleteRangeRequest {
 
     fn map_result(_: Self::RpcResponse) -> Self::Result {}
 
-    fn reduce(
-        results: BoxStream<'static, Result<Self::Result>>,
-    ) -> BoxFuture<'static, Result<Self::Result>> {
+    fn reduce(results: BoxStream<'static, Result<Self::Result>>) -> Self::Response {
         results
             .into_future()
             .map(|(f, _)| f.expect("no results should be impossible"))
@@ -357,6 +350,7 @@ impl KvRequest for kvrpcpb::RawScanRequest {
     type Result = Vec<KvPair>;
     type RpcResponse = kvrpcpb::RawScanResponse;
     type KeyData = (Key, Key);
+    type Response = BoxFuture<'static, Result<Self::Result>>;
     const REQUEST_NAME: &'static str = "raw_scan";
     const RPC_FN: RpcFnType<Self, Self::RpcResponse> = TikvClient::raw_scan_async_opt;
 
@@ -389,9 +383,7 @@ impl KvRequest for kvrpcpb::RawScanRequest {
         resp.take_kvs().into_iter().map(Into::into).collect()
     }
 
-    fn reduce(
-        results: BoxStream<'static, Result<Self::Result>>,
-    ) -> BoxFuture<'static, Result<Self::Result>> {
+    fn reduce(results: BoxStream<'static, Result<Self::Result>>) -> Self::Response {
         results.try_concat().boxed()
     }
 }
@@ -417,6 +409,7 @@ impl KvRequest for kvrpcpb::RawBatchScanRequest {
     type Result = Vec<KvPair>;
     type RpcResponse = kvrpcpb::RawBatchScanResponse;
     type KeyData = Vec<BoundRange>;
+    type Response = BoxFuture<'static, Result<Self::Result>>;
     const REQUEST_NAME: &'static str = "raw_batch_scan";
     const RPC_FN: RpcFnType<Self, Self::RpcResponse> = TikvClient::raw_batch_scan_async_opt;
 
@@ -441,9 +434,7 @@ impl KvRequest for kvrpcpb::RawBatchScanRequest {
         resp.take_kvs().into_iter().map(Into::into).collect()
     }
 
-    fn reduce(
-        results: BoxStream<'static, Result<Self::Result>>,
-    ) -> BoxFuture<'static, Result<Self::Result>> {
+    fn reduce(results: BoxStream<'static, Result<Self::Result>>) -> Self::Response {
         results.try_concat().boxed()
     }
 }

--- a/src/transaction/snapshot.rs
+++ b/src/transaction/snapshot.rs
@@ -1,9 +1,9 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
-use crate::{Key, KvPair, Result, Transaction, Value};
+use crate::{BoundRange, Key, KvPair, Result, Transaction, Value};
 
 use derive_new::new;
-use futures::stream::BoxStream;
+use futures::stream::{BoxStream, Stream};
 use std::ops::RangeBounds;
 
 /// A readonly transaction which can have a custom timestamp.
@@ -28,7 +28,7 @@ impl Snapshot {
         self.transaction.batch_get(keys).await
     }
 
-    pub fn scan(&self, range: impl RangeBounds<Key>) -> BoxStream<Result<KvPair>> {
+    pub fn scan(&self, range: impl Into<BoundRange>) -> impl Stream<Item = Result<KvPair>> {
         self.transaction.scan(range)
     }
 


### PR DESCRIPTION
UCP #131 

## What?

Implement transactional scan request for `Transaction::scan`.

## How

### Generic return type for `KvRequest::reduce` and `KvRequest::execute`

Currently (f3f3db349cf4131642baa83c3977490bcc7364c7), `Transaction::scan` returns a `BoxStream`, which is similar to go client returns an `Iter`. Due to lack of supports of async iterator in Rust, Stream seems to be a great fit for this issue.

```rust
    pub fn scan(&self, _range: impl RangeBounds<Key>) -> BoxStream<Result<KvPair>>
```

However, trait `KvRequest::reduce` returns `BoxFuture<'static, Result<Self::Result>>`, which is not match `BoxStream<Result<KvPair>>`. Therefore, a new associated item `type Response` for `KvRequest` is introduced to make the return type generic. Not quite sure if this is acceptable.

### Change `range` param type to `Into<BoundRange>`

The other issue is converting `RangeBounds<Key>` to `BoundRange`. Due to the function `RangeBounds::start_bound` returning a `Bound<&T>`, converting into `BoundRange` is not trivial. Although the conversion can be done via [`Bound::cloned`](https://doc.rust-lang.org/1.41.1/core/ops/enum.Bound.html#method.cloned), this method is still unstable. 

The current workaround is change the range param of `Transaction::scan` from `impl RangeBounds<Key>` to `impl Into<BoundRange>`.
