### PR TITLE
raw: Fix scan range in raw scan request

### DIFF
--- a/examples/raw.rs
+++ b/examples/raw.rs
@@ -91,12 +91,12 @@ async fn main() -> Result<()> {
         .await
         .expect("Could not scan");
 
-    let keys: Vec<_> = pairs.into_iter().map(|p| p.key().clone()).collect();
+    let keys: Vec<_> = pairs.into_iter().map(|p| p.into_key()).collect();
     assert_eq!(
         &keys,
         &[Key::from("k1".to_owned()), Key::from("k2".to_owned())]
     );
-    println!("Scaning from {:?} to {:?} gives: {:?}", start, end, keys);
+    println!("Scanning from {:?} to {:?} gives: {:?}", start, end, keys);
 
     // Cleanly exit.
     Ok(())

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,7 +14,7 @@ use std::{path::PathBuf, time::Duration};
 ///
 /// By default, this client will use an insecure connection over instead of one protected by
 /// Transport Layer Security (TLS). Your deployment may have chosen to rely on security measures
-/// such as a private network, or a VPN layer to provid secure transmission.
+/// such as a private network, or a VPN layer to provide secure transmission.
 ///
 /// To use a TLS secured connection, use the `with_security` function to set the required
 /// parameters.

--- a/src/raw/requests.rs
+++ b/src/raw/requests.rs
@@ -4,7 +4,7 @@ use super::RawRpcRequest;
 use crate::{
     kv_client::{KvClient, RpcFnType, Store},
     pd::PdClient,
-    request::{store_stream_for_key, store_stream_for_keys, store_stream_for_range, KvRequest},
+    request::{store_stream_for_key, store_stream_for_keys, KvRequest},
     transaction::HasLocks,
     BoundRange, ColumnFamily, Error, Key, KvPair, Result, Value,
 };
@@ -325,7 +325,7 @@ impl KvRequest for kvrpcpb::RawDeleteRangeRequest {
         let start_key = mem::take(&mut self.start_key);
         let end_key = mem::take(&mut self.end_key);
         let range = BoundRange::from((start_key, end_key));
-        store_stream_for_range(range, pd_client)
+        pd_client.stores_for_range(range)
     }
 
     fn map_result(_: Self::RpcResponse) -> Self::Result {}
@@ -382,7 +382,7 @@ impl KvRequest for kvrpcpb::RawScanRequest {
         let start_key = mem::take(&mut self.start_key);
         let end_key = mem::take(&mut self.end_key);
         let range = BoundRange::from((start_key, end_key));
-        store_stream_for_range(range, pd_client)
+        pd_client.stores_for_range(range)
     }
 
     fn map_result(mut resp: Self::RpcResponse) -> Self::Result {

--- a/src/request.rs
+++ b/src/request.rs
@@ -5,7 +5,7 @@ use crate::{
     kv_client::{HasError, HasRegionError, KvClient, RpcFnType, Store},
     pd::PdClient,
     transaction::{resolve_locks, HasLocks},
-    BoundRange, Error, Key, Result,
+    Error, Key, Result,
 };
 
 use futures::future::BoxFuture;
@@ -160,21 +160,6 @@ where
                 .store_for_id(region_id)
                 .map_ok(move |store| (key, store))
         })
-        .boxed()
-}
-
-pub fn store_stream_for_range<PdC: PdClient>(
-    range: BoundRange,
-    pd_client: Arc<PdC>,
-) -> BoxStream<'static, Result<((Key, Key), Store<PdC::KvClient>)>> {
-    pd_client
-        .stores_for_range(range)
-        .map_ok(move |store| {
-            // FIXME should be bounded by self.range
-            let range = store.region.range();
-            (range, store)
-        })
-        .into_stream()
         .boxed()
 }
 


### PR DESCRIPTION
Prior scan range is ignored before passing into requests.
Propagate out each region range and pass them into requests.

Signed-off-by: Tzu-Chiao Yeh <su3g4284zo6y7@gmail.com>