### PR TITLE
Add backoff and retry limit to lock resolving

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ name = "tikv_client"
 
 [dependencies]
 derive-new = "0.5"
+fail = { version = "0.3", features = [ "failpoints" ] }
 failure = "0.1"
 futures = { version = "0.3.1", features = ["compat", "async-await", "thread-pool"] }
 grpcio = { version = "0.5.0", features = [ "secure", "prost-codec" ], default-features = false }
@@ -42,7 +43,6 @@ tempdir = "0.3"
 tokio = { version = "0.2", features = ["rt-threaded", "macros"] }
 proptest = "0.9"
 proptest-derive = "0.1.0"
-fail = { version = "0.3", features = [ "failpoints" ] }
 
 [patch.crates-io]
 raft-proto = { git = "https://github.com/tikv/raft-rs", rev = "e624c1d48460940a40d8aa69b5329460d9af87dd" }

--- a/src/backoff.rs
+++ b/src/backoff.rs
@@ -63,12 +63,9 @@ pub struct FullJitterBackoff {
 }
 
 impl FullJitterBackoff {
+    // Both base_delay_ms and max_delay_ms must be positive.
     #[allow(dead_code)]
-    pub fn new(base_delay_ms: u64, max_delay_ms: u64, max_attempts: u32) -> Self {
-        if base_delay_ms == 0 || max_delay_ms == 0 {
-            panic!("Both base_delay_ms and max_delay_ms must be positive");
-        }
-
+    pub const fn new(base_delay_ms: u64, max_delay_ms: u64, max_attempts: u32) -> Self {
         Self {
             current_attempts: 0,
             max_attempts,
@@ -110,12 +107,8 @@ pub struct EqualJitterBackoff {
 }
 
 impl EqualJitterBackoff {
-    #[allow(dead_code)]
-    pub fn new(base_delay_ms: u64, max_delay_ms: u64, max_attempts: u32) -> Self {
-        if base_delay_ms < 2 || max_delay_ms < 2 {
-            panic!("Both base_delay_ms and max_delay_ms must be greater than 1");
-        }
-
+    // Both base_delay_ms and max_delay_ms must be greater than 1.
+    pub const fn new(base_delay_ms: u64, max_delay_ms: u64, max_attempts: u32) -> Self {
         Self {
             current_attempts: 0,
             max_attempts,
@@ -159,12 +152,9 @@ pub struct DecorrelatedJitterBackoff {
 }
 
 impl DecorrelatedJitterBackoff {
+    // base_delay_ms must be positive.
     #[allow(dead_code)]
-    pub fn new(base_delay_ms: u64, max_delay_ms: u64, max_attempts: u32) -> Self {
-        if base_delay_ms == 0 {
-            panic!("base_delay_ms must be positive");
-        }
-
+    pub const fn new(base_delay_ms: u64, max_delay_ms: u64, max_attempts: u32) -> Self {
         Self {
             current_attempts: 0,
             max_attempts,
@@ -243,18 +233,6 @@ mod test {
     }
 
     #[test]
-    #[should_panic(expected = "Both base_delay_ms and max_delay_ms must be positive")]
-    fn test_full_jitter_backoff_with_invalid_base_delay_ms() {
-        FullJitterBackoff::new(0, 7, 3);
-    }
-
-    #[test]
-    #[should_panic(expected = "Both base_delay_ms and max_delay_ms must be positive")]
-    fn test_full_jitter_backoff_with_invalid_max_delay_ms() {
-        FullJitterBackoff::new(2, 0, 3);
-    }
-
-    #[test]
     fn test_equal_jitter_backoff() {
         let mut backoff = EqualJitterBackoff::new(2, 7, 3);
 
@@ -271,18 +249,6 @@ mod test {
         assert!(third_delay_dur <= Duration::from_millis(6));
 
         assert_eq!(backoff.next_delay_duration(), None);
-    }
-
-    #[test]
-    #[should_panic(expected = "Both base_delay_ms and max_delay_ms must be greater than 1")]
-    fn test_equal_jitter_backoff_with_invalid_base_delay_ms() {
-        EqualJitterBackoff::new(1, 7, 3);
-    }
-
-    #[test]
-    #[should_panic(expected = "Both base_delay_ms and max_delay_ms must be greater than 1")]
-    fn test_equal_jitter_backoff_with_invalid_max_delay_ms() {
-        EqualJitterBackoff::new(2, 1, 3);
     }
 
     #[test]
@@ -304,11 +270,5 @@ mod test {
         assert!(second_delay_dur <= Duration::from_millis(cap_ms));
 
         assert_eq!(backoff.next_delay_duration(), None);
-    }
-
-    #[test]
-    #[should_panic(expected = "base_delay_ms must be positive")]
-    fn test_decorrelated_jitter_backoff_with_invalid_base_delay_ms() {
-        DecorrelatedJitterBackoff::new(0, 7, 3);
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -60,6 +60,8 @@ pub enum ErrorKind {
     /// Multiple errors
     #[fail(display = "Multiple errors: {:?}", _0)]
     MultipleErrors(Vec<Error>),
+    #[fail(display = "Lock error. {}", message)]
+    LockError { message: String },
 }
 
 impl Fail for Error {
@@ -127,6 +129,10 @@ impl Error {
 
     pub(crate) fn undetermined_error(error: Error) -> Self {
         Error::from(ErrorKind::UndeterminedError(error))
+    }
+
+    pub(crate) fn lock_error(message: String) -> Self {
+        Error::from(ErrorKind::LockError { message })
     }
 }
 

--- a/src/transaction/lock.rs
+++ b/src/transaction/lock.rs
@@ -3,6 +3,7 @@ use crate::pd::{PdClient, RegionVerId};
 use crate::request::KvRequest;
 use crate::{ErrorKind, Key, Result, Timestamp};
 
+use fail::fail_point;
 use kvproto::kvrpcpb;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
@@ -20,6 +21,8 @@ pub async fn resolve_locks(
     locks: Vec<kvrpcpb::LockInfo>,
     pd_client: Arc<impl PdClient>,
 ) -> Result<bool> {
+    fail_point!("transaction-unresolved-lock", |_| { Ok(false) });
+
     let ts = pd_client.clone().get_timestamp().await?;
     let mut has_live_locks = false;
     let expired_locks = locks.into_iter().filter(|lock| {

--- a/src/transaction/requests.rs
+++ b/src/transaction/requests.rs
@@ -205,7 +205,8 @@ impl KvRequest for kvrpcpb::ResolveLockRequest {
         self,
         region_error: Error,
         _pd_client: Arc<impl PdClient>,
-        _backoff: impl Backoff,
+        _lock_backoff: impl Backoff,
+        _region_backoff: impl Backoff,
     ) -> BoxStream<'static, Result<Self::RpcResponse>> {
         stream::once(future::err(region_error)).boxed()
     }


### PR DESCRIPTION
UCP #135

Adds backoff and retry limit to lock resolving. Fixes #135.

Signed-off-by: Steven Gu <asongala@163.com>