### PR TITLE
fix: fix #146

### DIFF
--- a/src/transaction/transaction.rs
+++ b/src/transaction/transaction.rs
@@ -249,6 +249,7 @@ struct TwoPhaseCommitter {
 impl TwoPhaseCommitter {
     async fn commit(mut self) -> Result<()> {
         if self.mutations.is_empty() {
+            self.committed = true;
             return Ok(());
         }
         self.prewrite().await?;


### PR DESCRIPTION
Signed-off-by: longfangsong <longfangsong@icloud.com>

fix #146.

I think there's no need to rollback if there's no mutations. 
So `self.committed` should be set to `true` in the `self.mutations.is_empty()` branch in `TwoPhaseCommitter::commit` to prevent `rollback` being called when it is dropped.