### PR TITLE
set Value type to an alias of Vec<u8>

### DIFF
--- a/examples/raw.rs
+++ b/examples/raw.rs
@@ -43,7 +43,7 @@ async fn main() -> Result<()> {
     // Above, you saw we can use a `&'static str`, this is primarily for making examples short.
     // This type is practical to use for real things, and usage forces an internal copy.
     //
-    // It is best to pass a `Vec<u8>` in terms of explictness and speed. `String`s and a few other
+    // It is best to pass a `Vec<u8>` in terms of explicitness and speed. `String`s and a few other
     // types are supported as well, but it all ends up as `Vec<u8>` in the end.
     let value: Option<Value> = client.get(KEY.to_owned()).await?;
     assert_eq!(value, Some(Value::from(VALUE.to_owned())));
@@ -114,17 +114,20 @@ async fn main() -> Result<()> {
         .batch_scan(batch_scan_keys.to_owned(), 10)
         .await
         .expect("Could not batch scan");
-    let vals: Vec<_> = kv_pairs.into_iter().map(|p| p.1).collect();
+    let vals: Vec<_> = kv_pairs
+        .into_iter()
+        .map(|p| String::from_utf8(p.1).unwrap().to_owned())
+        .collect();
     assert_eq!(
         &vals,
         &[
-            "v1".to_owned().into(),
-            "v2".to_owned().into(),
-            "v2".to_owned().into(),
-            "v3".to_owned().into(),
-            "v1".to_owned().into(),
-            "v2".to_owned().into(),
-            "v3".to_owned().into()
+            "v1".to_owned(),
+            "v2".to_owned(),
+            "v2".to_owned(),
+            "v3".to_owned(),
+            "v1".to_owned(),
+            "v2".to_owned(),
+            "v3".to_owned()
         ]
     );
     println!(

--- a/src/kv/kvpair.rs
+++ b/src/kv/kvpair.rs
@@ -95,7 +95,7 @@ impl Into<(Key, Value)> for KvPair {
 
 impl From<kvrpcpb::KvPair> for KvPair {
     fn from(mut pair: kvrpcpb::KvPair) -> Self {
-        KvPair(Key::from(pair.take_key()), Value::from(pair.take_value()))
+        KvPair(Key::from(pair.take_key()), pair.take_value())
     }
 }
 
@@ -104,7 +104,7 @@ impl Into<kvrpcpb::KvPair> for KvPair {
         let mut result = kvrpcpb::KvPair::default();
         let (key, value) = self.into();
         result.set_key(key.into());
-        result.set_value(value.into());
+        result.set_value(value);
         result
     }
 }
@@ -124,9 +124,9 @@ impl AsRef<Value> for KvPair {
 impl fmt::Debug for KvPair {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let KvPair(key, value) = self;
-        match str::from_utf8(&value.0) {
+        match str::from_utf8(&value) {
             Ok(s) => write!(f, "KvPair({}, {:?})", HexRepr(&key.0), s),
-            Err(_) => write!(f, "KvPair({}, {})", HexRepr(&key.0), HexRepr(&value.0)),
+            Err(_) => write!(f, "KvPair({}, {})", HexRepr(&key.0), HexRepr(&value)),
         }
     }
 }

--- a/src/kv/value.rs
+++ b/src/kv/value.rs
@@ -1,11 +1,6 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
-use super::HexRepr;
-#[cfg(test)]
-use proptest::{arbitrary::any_with, collection::size_range};
-#[cfg(test)]
-use proptest_derive::Arbitrary;
-use std::{fmt, str, u8};
+use std::u8;
 
 /// The value part of a key/value pair.
 ///
@@ -48,54 +43,5 @@ use std::{fmt, str, u8};
 ///
 /// Many functions which accept a `Value` accept an `Into<Value>`, which means all of the above types
 /// can be passed directly to those functions.
-#[derive(Default, Clone, Eq, PartialEq, Hash)]
-#[cfg_attr(test, derive(Arbitrary))]
-pub struct Value(
-    #[cfg_attr(
-        test,
-        proptest(
-            strategy = "any_with::<Vec<u8>>((size_range(crate::proptests::PROPTEST_VALUE_MAX), ()))"
-        )
-    )]
-    pub(super) Vec<u8>,
-);
 
-impl Value {
-    #[inline]
-    pub fn is_empty(&self) -> bool {
-        self.0.is_empty()
-    }
-}
-
-impl From<Vec<u8>> for Value {
-    fn from(v: Vec<u8>) -> Self {
-        Value(v)
-    }
-}
-
-impl From<String> for Value {
-    fn from(v: String) -> Value {
-        Value(v.into_bytes())
-    }
-}
-
-impl Into<Vec<u8>> for Value {
-    fn into(self) -> Vec<u8> {
-        self.0
-    }
-}
-
-impl<'a> Into<&'a [u8]> for &'a Value {
-    fn into(self) -> &'a [u8] {
-        &self.0
-    }
-}
-
-impl fmt::Debug for Value {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match str::from_utf8(&self.0) {
-            Ok(s) => write!(f, "Value({:?})", s),
-            Err(_) => write!(f, "Value({})", HexRepr(&self.0)),
-        }
-    }
-}
+pub type Value = Vec<u8>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
 #![type_length_limit = "16777216"]
 #![allow(clippy::redundant_closure)]
 #![allow(clippy::type_complexity)]
+#![allow(incomplete_features)]
 #![cfg_attr(test, feature(specialization))]
 
 //! This crate provides a clean, ready to use client for [TiKV](https://github.com/tikv/tikv), a

--- a/src/proptests/mod.rs
+++ b/src/proptests/mod.rs
@@ -11,7 +11,6 @@ mod raw;
 
 pub(crate) const ENV_PD_ADDRS: &str = "PD_ADDRS";
 pub(crate) const PROPTEST_KEY_MAX: usize = 1024 * 2; // 2 KB
-pub(crate) const PROPTEST_VALUE_MAX: usize = 1024 * 16; // 16 KB
 pub(crate) const PROPTEST_BATCH_SIZE_MAX: usize = 16;
 
 pub fn arb_batch<T: core::fmt::Debug>(

--- a/src/proptests/raw.rs
+++ b/src/proptests/raw.rs
@@ -23,7 +23,7 @@ proptest! {
         ).unwrap();
 
         match out_value {
-            None =>assert!(pair.value().is_empty()),
+            None => assert!(pair.value().is_empty()),
             Some(out) => assert_eq!(Value::from(pair.value().clone()), out)
         }
 

--- a/src/proptests/raw.rs
+++ b/src/proptests/raw.rs
@@ -21,7 +21,11 @@ proptest! {
         let out_value = block_on(
             client.get(pair.key().clone())
         ).unwrap();
-        assert_eq!(Some(Value::from(pair.value().clone())), out_value);
+
+        match out_value {
+            None =>assert!(pair.value().is_empty()),
+            Some(out) => assert_eq!(Value::from(pair.value().clone()), out)
+        }
 
         block_on(
             client.delete(pair.key().clone())

--- a/src/transaction/buffer.rs
+++ b/src/transaction/buffer.rs
@@ -139,7 +139,7 @@ impl Mutation {
             Mutation::Cached(_) => return None,
             Mutation::Put(v) => {
                 pb.set_op(kvrpcpb::Op::Put);
-                pb.set_value(v.clone().into());
+                pb.set_value(v.clone());
             }
             Mutation::Del => pb.set_op(kvrpcpb::Op::Del),
             Mutation::Lock => pb.set_op(kvrpcpb::Op::Lock),
@@ -192,7 +192,7 @@ mod tests {
             block_on(buffer.get_or_else(b"key1".to_vec().into(), move |_| ready(panic!())))
                 .unwrap()
                 .unwrap(),
-            b"value1".to_vec().into()
+            b"value1".to_vec()
         );
 
         buffer.delete(b"key2".to_vec().into());

--- a/src/transaction/requests.rs
+++ b/src/transaction/requests.rs
@@ -39,7 +39,7 @@ impl KvRequest for kvrpcpb::GetRequest {
     }
 
     fn map_result(mut resp: Self::RpcResponse) -> Self::Result {
-        let result: Value = resp.take_value().into();
+        let result: Value = resp.take_value();
         if resp.not_found {
             None
         } else {


### PR DESCRIPTION
set Value type to an alias of Vec<u8> since the Original Value implementation does not do more than Vec<u8>. (#151 )

Signed-off-by: ekexium <ekexium@gmail.com>