### PR TITLE
Avoid one unnecessary region in stores_for_range

### DIFF
--- a/src/pd/client.rs
+++ b/src/pd/client.rs
@@ -97,7 +97,7 @@ pub trait PdClient: Send + Sync + 'static {
             Either::Left(self.region_for_key(&start_key).and_then(move |region| {
                 let region_end = region.end_key();
                 this.map_region_to_store(region).map_ok(move |store| {
-                    if end_key.map(|x| x < region_end).unwrap_or(false) || region_end.is_empty() {
+                    if end_key.map(|x| x <= region_end).unwrap_or(false) || region_end.is_empty() {
                         return Some((None, store));
                     }
                     Some((Some(region_end), store))


### PR DESCRIPTION
In `stores_for_range`, both upper bound are exclusive. If `x=region_end` , we don’t need a next region