### PR TITLE
update kvproto dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -719,7 +719,7 @@ dependencies = [
 [[package]]
 name = "kvproto"
 version = "0.0.2"
-source = "git+https://github.com/pingcap/kvproto.git?rev=1e28226154c374788f38d3a542fc505cd74720f3#1e28226154c374788f38d3a542fc505cd74720f3"
+source = "git+https://github.com/pingcap/kvproto.git#c0e3a4d8bbece2b8d796ed5a08649ea5223b7abf"
 dependencies = [
  "futures 0.3.5",
  "grpcio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ derive-new = "0.5"
 failure = "0.1"
 futures = { version = "0.3.5", features = ["async-await", "thread-pool"] }
 grpcio = { version = "0.6", features = [ "secure", "prost-codec" ], default-features = false }
-kvproto = { git = "https://github.com/pingcap/kvproto.git", rev = "1e28226154c374788f38d3a542fc505cd74720f3", features = [ "prost-codec" ], default-features = false }
+kvproto = { git = "https://github.com/pingcap/kvproto.git", features = [ "prost-codec" ], default-features = false }
 lazy_static = "1"
 log = "0.4" 
 rand = "0.7"

--- a/tikv-client-common/Cargo.toml
+++ b/tikv-client-common/Cargo.toml
@@ -16,7 +16,7 @@ log = "0.4"
 proptest = "0.9"
 proptest-derive = "0.1.0"
 derive-new = "0.5"
-kvproto = { git = "https://github.com/pingcap/kvproto.git", rev = "1e28226154c374788f38d3a542fc505cd74720f3", features = [ "prost-codec" ], default-features = false }
+kvproto = { git = "https://github.com/pingcap/kvproto.git", features = [ "prost-codec" ], default-features = false }
 
 [dependencies.prometheus]
 version = "0.8"

--- a/tikv-client-pd/Cargo.toml
+++ b/tikv-client-pd/Cargo.toml
@@ -8,7 +8,7 @@ async-trait = "0.1"
 derive-new = "0.5"
 futures = { version = "0.3.5", features = ["compat", "async-await", "thread-pool"] }
 grpcio = { version = "0.6", features = [ "secure", "prost-codec" ], default-features = false }
-kvproto = { git = "https://github.com/pingcap/kvproto.git", rev = "1e28226154c374788f38d3a542fc505cd74720f3", features = [ "prost-codec" ], default-features = false }
+kvproto = { git = "https://github.com/pingcap/kvproto.git", features = [ "prost-codec" ], default-features = false }
 log = "0.4"
 tikv-client-common = { path = "../tikv-client-common" }
 tokio = { version = "0.2", features = ["sync"] }

--- a/tikv-client-store/Cargo.toml
+++ b/tikv-client-store/Cargo.toml
@@ -6,9 +6,9 @@ edition = "2018"
 
 [dependencies]
 futures = { version = "0.3.5", features = ["compat", "async-await", "thread-pool"] }
-kvproto = { git = "https://github.com/pingcap/kvproto.git", rev = "1e28226154c374788f38d3a542fc505cd74720f3", features = [ "prost-codec" ], default-features = false }
+kvproto = { git = "https://github.com/pingcap/kvproto.git", features = ["prost-codec"], default-features = false }
 derive-new = "0.5"
-grpcio = { version = "0.6", features = [ "secure", "prost-codec" ], default-features = false }
+grpcio = { version = "0.6", features = ["secure", "prost-codec"], default-features = false }
 log = "0.4"
 
 tikv-client-common = { path = "../tikv-client-common" }


### PR DESCRIPTION
After [kvproto#633](https://github.com/pingcap/kvproto/pull/633) merged into master, we no longer need to depend on another branch in kvproto.