### PR TITLE
Bound region range by query range

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -205,11 +205,10 @@ pub fn store_stream_for_range<PdC: PdClient>(
 fn bound_range(region_range: (Key, Key), range: BoundRange) -> (Key, Key) {
     let (lower, upper) = region_range;
     let (lower_bound, upper_bound) = range.into_keys();
-    let upper_bound = upper_bound.unwrap_or_default();
-    let up = match (upper.is_empty(), upper_bound.is_empty()) {
-        (_, true) => upper,
-        (true, _) => upper_bound,
-        _ => min(upper, upper_bound),
+    let up = match (upper.is_empty(), upper_bound) {
+        (_, None) => upper,
+        (true, Some(ub)) => ub,
+        (_, Some(ub)) => min(upper, ub),
     };
     (max(lower, lower_bound), up)
 }

--- a/src/request.rs
+++ b/src/request.rs
@@ -188,14 +188,28 @@ pub fn store_stream_for_range<PdC: PdClient>(
     pd_client: Arc<PdC>,
 ) -> BoxStream<'static, Result<((Key, Key), Store<PdC::KvClient>)>> {
     pd_client
-        .stores_for_range(range)
+        .stores_for_range(range.clone())
         .map_ok(move |store| {
-            // FIXME should be bounded by self.range
-            let range = store.region.range();
-            (range, store)
+            let region_range = store.region.range();
+            (bound_range(region_range, range.clone()), store)
         })
         .into_stream()
         .boxed()
+}
+
+/// The range used for request should be the common range of `region_range` and `range`.
+fn bound_range(region_range: (Key, Key), range: BoundRange) -> (Key, Key) {
+    let (mut lower, mut upper) = region_range;
+    let (lower_bound, upper_bound) = range.into_keys();
+    if lower_bound > lower {
+        lower = lower_bound;
+    }
+    if let Some(up) = upper_bound {
+        if up < upper || upper.is_empty() {
+            upper = up;
+        }
+    }
+    (lower, upper)
 }
 
 pub fn store_stream_for_ranges<PdC: PdClient>(


### PR DESCRIPTION
In `store_stream_for_range`, we passed the `region_range` to following steps and use it in request, which is incorrect if `region_range` is not a subset of origianl query range. We should take the common part of the two.