### PR TITLE
Handle None when converting BoundRange to KeyRange

### DIFF
--- a/tikv-client-common/src/kv/bound_range.rs
+++ b/tikv-client-common/src/kv/bound_range.rs
@@ -189,11 +189,7 @@ impl Into<kvrpcpb::KeyRange> for BoundRange {
         let (start, end) = self.into_keys();
         let mut range = kvrpcpb::KeyRange::default();
         range.set_start_key(start.into());
-        let end_key = match end {
-            Some(k) => k.into(),
-            None => vec![],
-        };
-        range.set_end_key(end_key);
+        range.set_end_key(end.unwrap_or_default().into());
         range
     }
 }

--- a/tikv-client-common/src/kv/bound_range.rs
+++ b/tikv-client-common/src/kv/bound_range.rs
@@ -189,8 +189,11 @@ impl Into<kvrpcpb::KeyRange> for BoundRange {
         let (start, end) = self.into_keys();
         let mut range = kvrpcpb::KeyRange::default();
         range.set_start_key(start.into());
-        // FIXME handle end = None rather than unwrapping
-        end.map(|k| range.set_end_key(k.into())).unwrap();
+        let end_key = match end {
+            Some(k) => k.into(),
+            None => vec![],
+        };
+        range.set_end_key(end_key);
         range
     }
 }


### PR DESCRIPTION
Convert `None` to empty Vec instead of `unwrap`