### PR TITLE
Fix txn.batch_get

### DIFF
--- a/src/raw/client.rs
+++ b/src/raw/client.rs
@@ -103,7 +103,7 @@ impl Client {
     /// Create a new 'batch get' request.
     ///
     /// Once resolved this request will result in the fetching of the values associated with the
-    /// given keys.
+    /// given keys, skipping non-existent entris.
     ///
     /// ```rust,no_run
     /// # use tikv_client::{KvPair, Config, RawClient};

--- a/src/raw/client.rs
+++ b/src/raw/client.rs
@@ -103,7 +103,7 @@ impl Client {
     /// Create a new 'batch get' request.
     ///
     /// Once resolved this request will result in the fetching of the values associated with the
-    /// given keys, skipping non-existent entris.
+    /// given keys, skipping non-existent entries.
     ///
     /// ```rust,no_run
     /// # use tikv_client::{KvPair, Config, RawClient};

--- a/src/transaction/buffer.rs
+++ b/src/transaction/buffer.rs
@@ -63,10 +63,7 @@ impl Buffer {
 
             let cached_results = cached_results
                 .into_iter()
-                .filter_map(|(k, v)| match v.unwrap() {
-                    Some(v) => Some(KvPair(k, v)),
-                    None => None,
-                });
+                .filter_map(|(k, v)| v.unwrap().map(|v| KvPair(k, v)));
 
             let undetermined_keys = undetermined_keys.into_iter().map(|(k, _)| k).collect();
             (cached_results, undetermined_keys)

--- a/src/transaction/snapshot.rs
+++ b/src/transaction/snapshot.rs
@@ -24,7 +24,7 @@ impl Snapshot {
     pub async fn batch_get(
         &self,
         keys: impl IntoIterator<Item = impl Into<Key>>,
-    ) -> Result<impl Iterator<Item = (Key, Option<Value>)>> {
+    ) -> Result<impl Iterator<Item = KvPair>> {
         self.transaction.batch_get(keys).await
     }
 

--- a/src/transaction/transaction.rs
+++ b/src/transaction/transaction.rs
@@ -75,7 +75,7 @@ impl Transaction {
             .await
     }
 
-    /// Gets the values associated with the given keys, skipping non-existent entris.
+    /// Gets the values associated with the given keys, skipping non-existent entries.
     ///
     /// ```rust,no_run
     /// # use tikv_client::{Key, Value, Config, transaction::Client};

--- a/src/transaction/transaction.rs
+++ b/src/transaction/transaction.rs
@@ -72,7 +72,7 @@ impl Transaction {
             .await
     }
 
-    /// Gets the values associated with the given keys.
+    /// Gets the values associated with the given keys, skipping non-existent entris.
     ///
     /// ```rust,no_run
     /// # use tikv_client::{Key, Value, Config, transaction::Client};
@@ -86,7 +86,8 @@ impl Transaction {
     ///     .batch_get(keys)
     ///     .await
     ///     .unwrap()
-    ///     .filter_map(|(k, v)| v.map(move |v| (k, v))).collect();
+    ///     .map(|pair| (pair.0, pair.1))
+    ///     .collect();
     /// // Finish the transaction...
     /// txn.commit().await.unwrap();
     /// # });
@@ -94,7 +95,7 @@ impl Transaction {
     pub async fn batch_get(
         &self,
         keys: impl IntoIterator<Item = impl Into<Key>>,
-    ) -> Result<impl Iterator<Item = (Key, Option<Value>)>> {
+    ) -> Result<impl Iterator<Item = KvPair>> {
         let timestamp = self.timestamp.clone();
         let rpc = self.rpc.clone();
         self.buffer

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -18,7 +18,7 @@ const SCAN_BATCH_SIZE: u32 = 1000;
 const NUM_PEOPLE: u32 = 100;
 const NUM_TRNASFER: u32 = 100;
 
-/// Delete all entris in TiKV to leave a clean space for following tests.
+/// Delete all entries in TiKV to leave a clean space for following tests.
 /// TiKV does not provide an elegant way to do this, so it is done by scanning and deletions.
 async fn clear_tikv() -> Fallible<()> {
     delete_all_raw().await?;

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -81,12 +81,14 @@ async fn crud() -> Fallible<()> {
 
     let client = TransactionClient::new(config).await?;
     let mut txn = client.begin().await?;
+
     // Get non-existent keys
     assert!(txn.get("foo".to_owned()).await?.is_none());
+
+    // batch_get do not return non-existent entries
     assert_eq!(
         txn.batch_get(vec!["foo".to_owned(), "bar".to_owned()])
             .await?
-            .filter(|(_, v)| v.is_some())
             .count(),
         0
     );
@@ -101,7 +103,7 @@ async fn crud() -> Fallible<()> {
     let batch_get_res: HashMap<Key, Value> = txn
         .batch_get(vec!["foo".to_owned(), "bar".to_owned()])
         .await?
-        .filter_map(|(k, v)| v.map(|v| (k, v)))
+        .map(|pair| (pair.0, pair.1))
         .collect();
     assert_eq!(
         batch_get_res.get(&Key::from("foo".to_owned())),
@@ -122,7 +124,7 @@ async fn crud() -> Fallible<()> {
     let batch_get_res: HashMap<Key, Value> = txn
         .batch_get(vec!["foo".to_owned(), "bar".to_owned()])
         .await?
-        .filter_map(|(k, v)| v.map(|v| (k, v)))
+        .map(|pair| (pair.0, pair.1))
         .collect();
     assert_eq!(
         batch_get_res.get(&Key::from("foo".to_owned())),
@@ -141,7 +143,7 @@ async fn crud() -> Fallible<()> {
     let batch_get_res: HashMap<Key, Value> = txn
         .batch_get(vec!["foo".to_owned(), "bar".to_owned()])
         .await?
-        .filter_map(|(k, v)| v.map(|v| (k, v)))
+        .map(|pair| (pair.0, pair.1))
         .collect();
     assert_eq!(
         batch_get_res.get(&Key::from("foo".to_owned())),


### PR DESCRIPTION
Previously `txn.batch_get` returns an iterator of `(Key, Option<Value>)`. However, it does not always return all non-existent entries, which is confusing. 

Changes:
Change the signature and behavior to be same as `raw.batch_get`: it returns an iterator of `Kvpair` and skips non-existent entries.