### PR TITLE
Fix some misuse of into_future()

### DIFF
--- a/src/raw/requests.rs
+++ b/src/raw/requests.rs
@@ -330,16 +330,7 @@ impl KvRequest for kvrpcpb::RawDeleteRangeRequest {
     fn reduce(
         results: BoxStream<'static, Result<Self::Result>>,
     ) -> BoxFuture<'static, Result<Self::Result>> {
-        results
-            .fold(Ok(()), |acc, res| {
-                let res = match (acc, res) {
-                    (Err(e), _) => Err(e),
-                    (_, Err(e)) => Err(e),
-                    _ => Ok(()),
-                };
-                future::ready(res)
-            })
-            .boxed()
+        results.try_for_each(|_| future::ready(Ok(()))).boxed()
     }
 }
 

--- a/src/transaction/requests.rs
+++ b/src/transaction/requests.rs
@@ -347,8 +347,14 @@ impl KvRequest for kvrpcpb::PrewriteRequest {
         results: BoxStream<'static, Result<Self::Result>>,
     ) -> BoxFuture<'static, Result<Self::Result>> {
         results
-            .into_future()
-            .map(|(f, _)| f.expect("no results should be impossible"))
+            .fold(Ok(()), |acc, res| {
+                let res = match (acc, res) {
+                    (Err(e), _) => Err(e),
+                    (_, Err(e)) => Err(e),
+                    _ => Ok(()),
+                };
+                future::ready(res)
+            })
             .boxed()
     }
 }
@@ -409,8 +415,14 @@ impl KvRequest for kvrpcpb::CommitRequest {
         results: BoxStream<'static, Result<Self::Result>>,
     ) -> BoxFuture<'static, Result<Self::Result>> {
         results
-            .into_future()
-            .map(|(f, _)| f.expect("no results should be impossible"))
+            .fold(Ok(()), |acc, res| {
+                let res = match (acc, res) {
+                    (Err(e), _) => Err(e),
+                    (_, Err(e)) => Err(e),
+                    _ => Ok(()),
+                };
+                future::ready(res)
+            })
             .boxed()
     }
 }
@@ -457,8 +469,14 @@ impl KvRequest for kvrpcpb::BatchRollbackRequest {
         results: BoxStream<'static, Result<Self::Result>>,
     ) -> BoxFuture<'static, Result<Self::Result>> {
         results
-            .into_future()
-            .map(|(f, _)| f.expect("no results should be impossible"))
+            .fold(Ok(()), |acc, res| {
+                let res = match (acc, res) {
+                    (Err(e), _) => Err(e),
+                    (_, Err(e)) => Err(e),
+                    _ => Ok(()),
+                };
+                future::ready(res)
+            })
             .boxed()
     }
 }

--- a/src/transaction/requests.rs
+++ b/src/transaction/requests.rs
@@ -346,16 +346,7 @@ impl KvRequest for kvrpcpb::PrewriteRequest {
     fn reduce(
         results: BoxStream<'static, Result<Self::Result>>,
     ) -> BoxFuture<'static, Result<Self::Result>> {
-        results
-            .fold(Ok(()), |acc, res| {
-                let res = match (acc, res) {
-                    (Err(e), _) => Err(e),
-                    (_, Err(e)) => Err(e),
-                    _ => Ok(()),
-                };
-                future::ready(res)
-            })
-            .boxed()
+        results.try_for_each(|_| future::ready(Ok(()))).boxed()
     }
 }
 
@@ -414,16 +405,7 @@ impl KvRequest for kvrpcpb::CommitRequest {
     fn reduce(
         results: BoxStream<'static, Result<Self::Result>>,
     ) -> BoxFuture<'static, Result<Self::Result>> {
-        results
-            .fold(Ok(()), |acc, res| {
-                let res = match (acc, res) {
-                    (Err(e), _) => Err(e),
-                    (_, Err(e)) => Err(e),
-                    _ => Ok(()),
-                };
-                future::ready(res)
-            })
-            .boxed()
+        results.try_for_each(|_| future::ready(Ok(()))).boxed()
     }
 }
 
@@ -468,16 +450,7 @@ impl KvRequest for kvrpcpb::BatchRollbackRequest {
     fn reduce(
         results: BoxStream<'static, Result<Self::Result>>,
     ) -> BoxFuture<'static, Result<Self::Result>> {
-        results
-            .fold(Ok(()), |acc, res| {
-                let res = match (acc, res) {
-                    (Err(e), _) => Err(e),
-                    (_, Err(e)) => Err(e),
-                    _ => Ok(()),
-                };
-                future::ready(res)
-            })
-            .boxed()
+        results.try_for_each(|_| future::ready(Ok(()))).boxed()
     }
 }
 


### PR DESCRIPTION
In previous implementation, prewrite/commit/batch_rollback does not poll the entire result stream.

Changes:
Fold the stream instead of `into_future`