### PR TITLE
Basic support of pessimistic transaction

### DIFF
--- a/examples/pessimistic.rs
+++ b/examples/pessimistic.rs
@@ -1,0 +1,68 @@
+// Copyright 2018 TiKV Project Authors. Licensed under Apache-2.0.
+
+mod common;
+
+use crate::common::parse_args;
+use tikv_client::{BoundRange, Config, Key, KvPair, TransactionClient as Client, Value};
+
+async fn puts(client: &Client, pairs: impl IntoIterator<Item=impl Into<KvPair>>) {
+    let mut txn = client.begin().await.expect("Could not begin a transaction");
+    for pair in pairs {
+        let (key, value) = pair.into().into();
+        txn.put(key, value).await.expect("Could not set key value");
+    }
+    txn.commit().await.expect("Could not commit transaction");
+}
+
+async fn get(client: &Client, key: Key) -> Option<Value> {
+    let txn = client.begin().await.expect("Could not begin a transaction");
+    txn.get(key).await.expect("Could not get value")
+}
+
+async fn lock(client: &Client, key: Key) {
+    let txn = client.begin().await.expect("Could not begin a transaction");
+    txn.pessimistic_lock().await.expect("Could not lock key")
+
+}
+
+#[tokio::main]
+async fn main() {
+    // You can try running this example by passing your pd endpoints
+    // (and SSL options if necessary) through command line arguments.
+    let args = parse_args("txn");
+
+    // Create a configuration to use for the example.
+    // Optionally encrypt the traffic.
+    let config = if let (Some(ca), Some(cert), Some(key)) = (args.ca, args.cert, args.key) {
+        Config::new(args.pd).with_security(ca, cert, key)
+    } else {
+        Config::new(args.pd)
+    };
+
+    let txn = Client::new(config)
+        .await
+        .expect("Could not connect to tikv");
+
+    // set
+    let key1: Key = b"key1".to_vec().into();
+    let value1: Value = b"value1".to_vec().into();
+    let key2: Key = b"key2".to_vec().into();
+    let value2: Value = b"value2".to_vec().into();
+    puts(&txn, vec![(key1, value1), (key2, value2)]).await;
+
+
+    // lock and get
+    let key1: Key = b"key1".to_vec().into();
+    lock(&txn, &[key1]);
+    let value1 = get(&txn, key1.clone()).await;
+    println!("{:?}", (key1, value1));
+    //
+    // // scan
+    // let key1: Key = b"key1".to_vec().into();
+    // scan(&txn, key1.., 10).await;
+    //
+    // // delete
+    // let key1: Key = b"key1".to_vec().into();
+    // let key2: Key = b"key2".to_vec().into();
+    // dels(&txn, vec![key1, key2]).await;
+}

--- a/examples/pessimistic.rs
+++ b/examples/pessimistic.rs
@@ -48,6 +48,7 @@ async fn main() {
         txn2.put(key1, value2).await.unwrap();
         let result = txn2.commit().await;
         assert!(result.is_err());
+        // println!("{:?}", result);
     }
     // while this txn can still write it
     let value3: Value = b"value3".to_vec().into();

--- a/examples/pessimistic.rs
+++ b/examples/pessimistic.rs
@@ -41,7 +41,7 @@ async fn main() {
     // lock the key
     let key1: Key = b"key1".to_vec().into();
     let value = txn1
-        .get_and_lock(key1.clone())
+        .get_for_update(key1.clone())
         .await
         .expect("Could not get_and_lock the key");
     println!("{:?}", (&key1, value));

--- a/examples/pessimistic.rs
+++ b/examples/pessimistic.rs
@@ -32,7 +32,7 @@ async fn main() {
     for (key, value) in vec![(key1, value1), (key2, value2)] {
         txn0.put(key, value).await.expect("Could not set key value");
     }
-    txn0.commit().await.expect("");
+    txn0.commit().await.expect("Could not commit");
     drop(txn0);
     let mut txn1 = client
         .begin_pessimistic()
@@ -53,7 +53,6 @@ async fn main() {
         txn2.put(key1, value2).await.unwrap();
         let result = txn2.commit().await;
         assert!(result.is_err());
-        // println!("{:?}", result);
     }
     // while this txn can still write it
     let value3: Value = b"value3".to_vec().into();

--- a/src/backoff.rs
+++ b/src/backoff.rs
@@ -10,6 +10,16 @@ pub trait Backoff: Clone + Send + 'static {
     fn next_delay_duration(&mut self) -> Option<Duration>;
 }
 
+// NoBackoff means that we don't want any retry here.
+#[derive(Clone)]
+pub struct NoBackoff;
+
+impl Backoff for NoBackoff {
+    fn next_delay_duration(&mut self) -> Option<Duration> {
+        None
+    }
+}
+
 // Exponential backoff means that the retry delay should multiply a constant
 // after each attempt, up to a maximum value. After each attempt, the new retry
 // delay should be:

--- a/src/raw/client.rs
+++ b/src/raw/client.rs
@@ -1,6 +1,7 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
 use super::requests;
+use crate::request::OPTIMISTIC_BACKOFF;
 use crate::{pd::PdRpcClient, request::KvRequest, ColumnFamily};
 use std::{sync::Arc, u32};
 use tikv_client_common::{BoundRange, Config, Error, Key, KvPair, Result, Value};
@@ -96,7 +97,7 @@ impl Client {
     /// ```
     pub async fn get(&self, key: impl Into<Key>) -> Result<Option<Value>> {
         requests::new_raw_get_request(key, self.cf.clone())
-            .execute(self.rpc.clone())
+            .execute(self.rpc.clone(), OPTIMISTIC_BACKOFF)
             .await
     }
 
@@ -121,7 +122,7 @@ impl Client {
         keys: impl IntoIterator<Item = impl Into<Key>>,
     ) -> Result<Vec<KvPair>> {
         requests::new_raw_batch_get_request(keys, self.cf.clone())
-            .execute(self.rpc.clone())
+            .execute(self.rpc.clone(), OPTIMISTIC_BACKOFF)
             .await
     }
 
@@ -142,7 +143,7 @@ impl Client {
     /// ```
     pub async fn put(&self, key: impl Into<Key>, value: impl Into<Value>) -> Result<()> {
         requests::new_raw_put_request(key, value, self.cf.clone())
-            .execute(self.rpc.clone())
+            .execute(self.rpc.clone(), OPTIMISTIC_BACKOFF)
             .await
     }
 
@@ -167,7 +168,7 @@ impl Client {
         pairs: impl IntoIterator<Item = impl Into<KvPair>>,
     ) -> Result<()> {
         requests::new_raw_batch_put_request(pairs, self.cf.clone())
-            .execute(self.rpc.clone())
+            .execute(self.rpc.clone(), OPTIMISTIC_BACKOFF)
             .await
     }
 
@@ -188,7 +189,7 @@ impl Client {
     /// ```
     pub async fn delete(&self, key: impl Into<Key>) -> Result<()> {
         requests::new_raw_delete_request(key, self.cf.clone())
-            .execute(self.rpc.clone())
+            .execute(self.rpc.clone(), OPTIMISTIC_BACKOFF)
             .await
     }
 
@@ -209,7 +210,7 @@ impl Client {
     /// ```
     pub async fn batch_delete(&self, keys: impl IntoIterator<Item = impl Into<Key>>) -> Result<()> {
         requests::new_raw_batch_delete_request(keys, self.cf.clone())
-            .execute(self.rpc.clone())
+            .execute(self.rpc.clone(), OPTIMISTIC_BACKOFF)
             .await
     }
 
@@ -229,7 +230,7 @@ impl Client {
     /// ```
     pub async fn delete_range(&self, range: impl Into<BoundRange>) -> Result<()> {
         requests::new_raw_delete_range_request(range, self.cf.clone())
-            .execute(self.rpc.clone())
+            .execute(self.rpc.clone(), OPTIMISTIC_BACKOFF)
             .await
     }
 
@@ -253,7 +254,7 @@ impl Client {
         }
 
         let res = requests::new_raw_scan_request(range, limit, self.key_only, self.cf.clone())
-            .execute(self.rpc.clone())
+            .execute(self.rpc.clone(), OPTIMISTIC_BACKOFF)
             .await;
         res.map(|mut s| {
             s.truncate(limit as usize);
@@ -290,7 +291,7 @@ impl Client {
         }
 
         requests::new_raw_batch_scan_request(ranges, each_limit, self.key_only, self.cf.clone())
-            .execute(self.rpc.clone())
+            .execute(self.rpc.clone(), OPTIMISTIC_BACKOFF)
             .await
     }
 }

--- a/src/raw/client.rs
+++ b/src/raw/client.rs
@@ -1,8 +1,11 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
 use super::requests;
-use crate::request::OPTIMISTIC_BACKOFF;
-use crate::{pd::PdRpcClient, request::KvRequest, ColumnFamily};
+use crate::{
+    pd::PdRpcClient,
+    request::{KvRequest, OPTIMISTIC_BACKOFF},
+    ColumnFamily,
+};
 use std::{sync::Arc, u32};
 use tikv_client_common::{BoundRange, Config, Error, Key, KvPair, Result, Value};
 

--- a/src/raw/requests.rs
+++ b/src/raw/requests.rs
@@ -502,6 +502,7 @@ mod test {
 
     use crate::{mock::MockPdClient, request::DispatchHook};
 
+    use crate::request::OPTIMISTIC_BACKOFF;
     use futures::{
         executor,
         future::{ready, BoxFuture},
@@ -542,7 +543,7 @@ mod test {
             key_only: true,
             ..Default::default()
         };
-        let scan = executor::block_on(scan.execute(client)).unwrap();
+        let scan = executor::block_on(scan.execute(client, OPTIMISTIC_BACKOFF)).unwrap();
 
         assert_eq!(scan.len(), 10);
         // TODO test the keys returned.

--- a/src/request.rs
+++ b/src/request.rs
@@ -13,10 +13,11 @@ use std::{
     sync::Arc,
     time::Duration,
 };
-use tikv_client_common::{BoundRange, Error, Key, Result};
+use tikv_client_common::{BoundRange, Error, ErrorKind, Key, Result};
 use tikv_client_store::{HasError, HasRegionError, KvClient, RpcFnType, Store};
 
 const LOCK_RETRY_DELAY_MS: u64 = 10;
+const LOCK_RETRY_MAX_TIMES: usize = 10;
 const DEFAULT_REGION_BACKOFF: NoJitterBackoff = NoJitterBackoff::new(2, 500, 10);
 
 pub trait KvRequest: Sync + Send + 'static + Sized {
@@ -32,7 +33,7 @@ pub trait KvRequest: Sync + Send + 'static + Sized {
 
     fn execute(self, pd_client: Arc<impl PdClient>) -> BoxFuture<'static, Result<Self::Result>> {
         Self::reduce(
-            self.response_stream(pd_client)
+            self.response_stream(pd_client, LOCK_RETRY_MAX_TIMES)
                 .and_then(|mut response| match response.error() {
                     Some(e) => future::err(e),
                     None => future::ok(response),
@@ -45,14 +46,16 @@ pub trait KvRequest: Sync + Send + 'static + Sized {
     fn response_stream(
         self,
         pd_client: Arc<impl PdClient>,
+        remaining_retry_count: usize
     ) -> BoxStream<'static, Result<Self::RpcResponse>> {
-        self.retry_response_stream(pd_client, DEFAULT_REGION_BACKOFF)
+        self.retry_response_stream(pd_client, DEFAULT_REGION_BACKOFF, remaining_retry_count)
     }
 
     fn retry_response_stream(
         mut self,
         pd_client: Arc<impl PdClient>,
         backoff: impl Backoff,
+        remaining_retry_count: usize
     ) -> BoxStream<'static, Result<Self::RpcResponse>> {
         let stores = self.store_stream(pd_client.clone());
         stores
@@ -82,6 +85,7 @@ pub trait KvRequest: Sync + Send + 'static + Sized {
                 // Resolve locks
                 let locks = response.take_locks();
                 if !locks.is_empty() {
+                    // todo: exit directly when found PessimisticLock
                     let pd_client = pd_client.clone();
                     return resolve_locks(locks, pd_client.clone())
                         .map_ok(|resolved| {
@@ -89,8 +93,18 @@ pub trait KvRequest: Sync + Send + 'static + Sized {
                             let delay_ms = if resolved { 0 } else { LOCK_RETRY_DELAY_MS };
                             futures_timer::Delay::new(Duration::from_millis(delay_ms))
                         })
-                        .map_ok(move |_| request.response_stream(pd_client))
-                        .try_flatten_stream()
+                        .map_ok(move |_| {
+                            if remaining_retry_count != 0 {
+                                request.response_stream(pd_client, remaining_retry_count - 1)
+                            } else {
+                                // todo: when met up with a long-time lock, this might be called
+                                // recusively for many times and cause a stack overflow here
+                                // currently I use a temporaray solution of limiting retry times,
+                                // a better way to handle this situation needs to be discussed
+                                stream::once(future::err(ErrorKind::Unimplemented.into())).boxed()
+                            }
+                        }
+                        ).try_flatten_stream()
                         .boxed();
                 }
                 stream::once(future::ok(response)).boxed()
@@ -113,7 +127,7 @@ pub trait KvRequest: Sync + Send + 'static + Sized {
                     Ok(())
                 };
 
-                fut.map_ok(move |_| self.retry_response_stream(pd_client, backoff))
+                fut.map_ok(move |_| self.retry_response_stream(pd_client, backoff, LOCK_RETRY_MAX_TIMES))
                     .try_flatten_stream()
                     .boxed()
             },

--- a/src/request.rs
+++ b/src/request.rs
@@ -284,6 +284,7 @@ impl_kv_rpc_request!(BatchGetRequest);
 impl_kv_rpc_request!(BatchRollbackRequest);
 impl_kv_rpc_request!(ResolveLockRequest);
 impl_kv_rpc_request!(ScanLockRequest);
+impl_kv_rpc_request!(PessimisticLockRequest);
 
 #[cfg(test)]
 mod test {

--- a/src/request.rs
+++ b/src/request.rs
@@ -298,6 +298,7 @@ impl_kv_rpc_request!(CommitRequest);
 impl_kv_rpc_request!(CleanupRequest);
 impl_kv_rpc_request!(BatchGetRequest);
 impl_kv_rpc_request!(BatchRollbackRequest);
+impl_kv_rpc_request!(PessimisticRollbackRequest);
 impl_kv_rpc_request!(ResolveLockRequest);
 impl_kv_rpc_request!(ScanLockRequest);
 impl_kv_rpc_request!(PessimisticLockRequest);

--- a/src/transaction/client.rs
+++ b/src/transaction/client.rs
@@ -139,6 +139,7 @@ impl Client {
             self.bg_worker.clone(),
             self.pd.clone(),
             self.key_only,
+            false,
         )
     }
 }

--- a/src/transaction/client.rs
+++ b/src/transaction/client.rs
@@ -1,10 +1,9 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
 use super::{requests::new_scan_lock_request, resolve_locks};
-use crate::request::OPTIMISTIC_BACKOFF;
 use crate::{
     pd::{PdClient, PdRpcClient},
-    request::KvRequest,
+    request::{KvRequest, OPTIMISTIC_BACKOFF},
     transaction::{Snapshot, Transaction},
 };
 use futures::executor::ThreadPool;

--- a/src/transaction/client.rs
+++ b/src/transaction/client.rs
@@ -69,12 +69,17 @@ impl Client {
     /// ```
     pub async fn begin(&self) -> Result<Transaction> {
         let timestamp = self.current_timestamp().await?;
-        Ok(self.new_transaction(timestamp))
+        Ok(self.new_transaction(timestamp, false))
+    }
+
+    pub async fn begin_pessimistic(&self) -> Result<Transaction> {
+        let timestamp = self.current_timestamp().await?;
+        Ok(self.new_transaction(timestamp, true))
     }
 
     /// Creates a new [`Snapshot`](Snapshot) at the given time.
     pub fn snapshot(&self, timestamp: Timestamp) -> Snapshot {
-        Snapshot::new(self.new_transaction(timestamp))
+        Snapshot::new(self.new_transaction(timestamp, false))
     }
 
     /// Retrieves the current [`Timestamp`](Timestamp).
@@ -133,13 +138,13 @@ impl Client {
         Ok(res)
     }
 
-    fn new_transaction(&self, timestamp: Timestamp) -> Transaction {
+    fn new_transaction(&self, timestamp: Timestamp, is_pessimistic: bool) -> Transaction {
         Transaction::new(
             timestamp,
             self.bg_worker.clone(),
             self.pd.clone(),
             self.key_only,
-            false,
+            is_pessimistic,
         )
     }
 }

--- a/src/transaction/client.rs
+++ b/src/transaction/client.rs
@@ -1,6 +1,7 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
 use super::{requests::new_scan_lock_request, resolve_locks};
+use crate::request::OPTIMISTIC_BACKOFF;
 use crate::{
     pd::{PdClient, PdRpcClient},
     request::KvRequest,
@@ -114,7 +115,8 @@ impl Client {
                 safepoint.clone(),
                 SCAN_LOCK_BATCH_SIZE,
             );
-            let res: Vec<kvrpcpb::LockInfo> = req.execute(self.pd.clone()).await?;
+            let res: Vec<kvrpcpb::LockInfo> =
+                req.execute(self.pd.clone(), OPTIMISTIC_BACKOFF).await?;
             if res.is_empty() {
                 break;
             }

--- a/src/transaction/lock.rs
+++ b/src/transaction/lock.rs
@@ -1,3 +1,4 @@
+use crate::request::OPTIMISTIC_BACKOFF;
 use crate::{pd::PdClient, request::KvRequest, transaction::requests, RegionVerId};
 use kvproto::{kvrpcpb, pdpb::Timestamp};
 use std::{
@@ -49,7 +50,7 @@ pub async fn resolve_locks(
             Some(&commit_version) => commit_version,
             None => {
                 let commit_version = requests::new_cleanup_request(primary_key, lock.lock_version)
-                    .execute(pd_client.clone())
+                    .execute(pd_client.clone(), OPTIMISTIC_BACKOFF)
                     .await?;
                 commit_versions.insert(lock.lock_version, commit_version);
                 commit_version
@@ -90,7 +91,7 @@ async fn resolve_lock_with_retry(
             }
         };
         match requests::new_resolve_lock_request(context, start_version, commit_version)
-            .execute(pd_client.clone())
+            .execute(pd_client.clone(), OPTIMISTIC_BACKOFF)
             .await
         {
             Ok(_) => {

--- a/src/transaction/lock.rs
+++ b/src/transaction/lock.rs
@@ -1,5 +1,9 @@
-use crate::request::OPTIMISTIC_BACKOFF;
-use crate::{pd::PdClient, request::KvRequest, transaction::requests, RegionVerId};
+use crate::{
+    pd::PdClient,
+    request::{KvRequest, OPTIMISTIC_BACKOFF},
+    transaction::requests,
+    RegionVerId,
+};
 use kvproto::{kvrpcpb, pdpb::Timestamp};
 use std::{
     collections::{HashMap, HashSet},

--- a/src/transaction/requests.rs
+++ b/src/transaction/requests.rs
@@ -513,13 +513,19 @@ impl KvRequest for kvrpcpb::PessimisticLockRequest {
 }
 
 pub fn new_pessimistic_lock_request(
-    mutations: Vec<kvrpcpb::Mutation>,
+    keys: Vec<Vec<u8>>,
     primary_lock: Vec<u8>,
     start_version: u64,
     lock_ttl: u64,
     for_update_ts: u64,
 ) -> kvrpcpb::PessimisticLockRequest {
     let mut req = kvrpcpb::PessimisticLockRequest::default();
+    let mutations = keys.into_iter().map(|key| {
+        let mut mutation = kvrpcpb::Mutation::default();
+        mutation.set_op(kvrpcpb::Op::PessimisticLock);
+        mutation.set_key(key);
+        mutation
+    }).collect();
     req.set_mutations(mutations);
     req.set_primary_lock(primary_lock);
     req.set_start_version(start_version);

--- a/src/transaction/requests.rs
+++ b/src/transaction/requests.rs
@@ -532,7 +532,9 @@ impl KvRequest for kvrpcpb::PessimisticLockRequest {
     fn reduce(
         results: BoxStream<'static, Result<Self::Result>>,
     ) -> BoxFuture<'static, Result<Self::Result>> {
-        results.try_for_each(|_| future::ready(Ok(()))).boxed()
+        results
+            .try_for_each_concurrent(None, |_| future::ready(Ok(())))
+            .boxed()
     }
 }
 
@@ -625,8 +627,13 @@ pub fn new_scan_lock_request(
 }
 
 impl HasLocks for kvrpcpb::CommitResponse {}
+
 impl HasLocks for kvrpcpb::CleanupResponse {}
+
 impl HasLocks for kvrpcpb::BatchRollbackResponse {}
+
 impl HasLocks for kvrpcpb::ResolveLockResponse {}
+
 impl HasLocks for kvrpcpb::ScanLockResponse {}
+
 impl HasLocks for kvrpcpb::PessimisticLockResponse {}

--- a/src/transaction/requests.rs
+++ b/src/transaction/requests.rs
@@ -220,7 +220,8 @@ impl KvRequest for kvrpcpb::ResolveLockRequest {
         self,
         region_error: Error,
         _pd_client: Arc<impl PdClient>,
-        _backoff: impl Backoff,
+        _region_backoff: impl Backoff,
+        _lock_backoff: impl Backoff,
     ) -> BoxStream<'static, Result<Self::RpcResponse>> {
         stream::once(future::err(region_error)).boxed()
     }

--- a/src/transaction/requests.rs
+++ b/src/transaction/requests.rs
@@ -527,6 +527,19 @@ impl KvRequest for kvrpcpb::PessimisticRollbackRequest {
     }
 }
 
+pub fn new_pessimistic_rollback_request(
+    keys: Vec<Key>,
+    start_version: u64,
+    for_update_ts: u64,
+) -> kvrpcpb::PessimisticRollbackRequest {
+    let mut req = kvrpcpb::PessimisticRollbackRequest::default();
+    req.set_keys(keys.into_iter().map(Into::into).collect());
+    req.set_start_version(start_version);
+    req.set_for_update_ts(for_update_ts);
+
+    req
+}
+
 impl KvRequest for kvrpcpb::PessimisticLockRequest {
     type Result = ();
     type RpcResponse = kvrpcpb::PessimisticLockResponse;

--- a/src/transaction/transaction.rs
+++ b/src/transaction/transaction.rs
@@ -89,13 +89,13 @@ impl Transaction {
     /// # let client = Client::new(Config::new(vec!["192.168.0.100", "192.168.0.101"])).await.unwrap();
     /// let mut txn = client.begin_pessimistic().await.unwrap();
     /// let key = "TiKV".to_owned();
-    /// let result: Option<Value> = txn.get_and_lock(key).await.unwrap();
+    /// let result: Option<Value> = txn.get_for_update(key).await.unwrap();
     /// // now the key "TiKV" is locked, other transactions cannot modify it
     /// // Finish the transaction...
     /// txn.commit().await.unwrap();
     /// # });
     /// ```
-    pub async fn get_and_lock(&mut self, key: impl Into<Key>) -> Result<Option<Value>> {
+    pub async fn get_for_update(&mut self, key: impl Into<Key>) -> Result<Option<Value>> {
         if !self.is_pessimistic {
             panic!("get_and_lock is not allowed in optimistic transaction!")
         }
@@ -156,7 +156,7 @@ impl Transaction {
     /// let mut txn = client.begin_pessimistic().await.unwrap();
     /// let keys = vec!["TiKV".to_owned(), "TiDB".to_owned()];
     /// let result: HashMap<Key, Value> = txn
-    ///     .batch_get_and_lock(keys)
+    ///     .batch_get_for_update(keys)
     ///     .await
     ///     .unwrap()
     ///     .map(|pair| (pair.0, pair.1))
@@ -166,7 +166,7 @@ impl Transaction {
     /// txn.commit().await.unwrap();
     /// # });
     /// ```
-    pub async fn batch_get_and_lock(
+    pub async fn batch_get_for_update(
         &mut self,
         keys: impl IntoIterator<Item = impl Into<Key>>,
     ) -> Result<impl Iterator<Item = KvPair>> {

--- a/src/transaction/transaction.rs
+++ b/src/transaction/transaction.rs
@@ -35,6 +35,7 @@ pub struct Transaction {
     rpc: Arc<PdRpcClient>,
     key_only: bool,
     for_update_ts: u64,
+    is_pessimistic: bool,
 }
 
 impl Transaction {
@@ -43,6 +44,7 @@ impl Transaction {
         bg_worker: ThreadPool,
         rpc: Arc<PdRpcClient>,
         key_only: bool,
+        is_pessimistic: bool,
     ) -> Transaction {
         Transaction {
             timestamp,
@@ -51,6 +53,7 @@ impl Transaction {
             rpc,
             key_only,
             for_update_ts: 0,
+            is_pessimistic,
         }
     }
 
@@ -101,8 +104,8 @@ impl Transaction {
     /// ```
     pub async fn batch_get(
         &self,
-        keys: impl IntoIterator<Item = impl Into<Key>>,
-    ) -> Result<impl Iterator<Item = KvPair>> {
+        keys: impl IntoIterator<Item=impl Into<Key>>,
+    ) -> Result<impl Iterator<Item=KvPair>> {
         let timestamp = self.timestamp.clone();
         let rpc = self.rpc.clone();
         self.buffer
@@ -136,7 +139,7 @@ impl Transaction {
         &self,
         range: impl Into<BoundRange>,
         limit: u32,
-    ) -> Result<impl Iterator<Item = KvPair>> {
+    ) -> Result<impl Iterator<Item=KvPair>> {
         let timestamp = self.timestamp.clone();
         let rpc = self.rpc.clone();
 
@@ -204,7 +207,7 @@ impl Transaction {
     /// txn.commit().await.unwrap();
     /// # });
     /// ```
-    pub async fn lock_keys(&self, keys: impl IntoIterator<Item = impl Into<Key>>) -> Result<()> {
+    pub async fn lock_keys(&self, keys: impl IntoIterator<Item=impl Into<Key>>) -> Result<()> {
         for key in keys {
             self.buffer.lock(key.into());
         }
@@ -230,9 +233,10 @@ impl Transaction {
             self.timestamp.version(),
             self.bg_worker.clone(),
             self.rpc.clone(),
+            self.for_update_ts,
         )
-        .commit()
-        .await
+            .commit()
+            .await
     }
 
     /// Pessimistically lock the keys
@@ -251,7 +255,7 @@ impl Transaction {
     /// ```
     pub async fn pessimistic_lock(
         &mut self,
-        keys: impl IntoIterator<Item = impl Into<Key>>,
+        keys: impl IntoIterator<Item=impl Into<Key>>,
     ) -> Result<()> {
         let mut keys: Vec<Vec<u8>> = keys
             .into_iter()
@@ -270,8 +274,8 @@ impl Transaction {
             lock_ttl,
             for_update_ts,
         )
-        .execute(self.rpc.clone())
-        .await
+            .execute(self.rpc.clone())
+            .await
     }
 
     /// Commits the actions of the pessimistic transaction.
@@ -293,9 +297,9 @@ impl Transaction {
             self.timestamp.version(),
             self.bg_worker.clone(),
             self.rpc.clone(),
-        )
-        .pessimistic_commit(self.for_update_ts)
-        .await
+            self.for_update_ts,
+        ).commit()
+            .await
     }
 }
 
@@ -308,6 +312,7 @@ struct TwoPhaseCommitter {
     start_version: u64,
     bg_worker: ThreadPool,
     rpc: Arc<PdRpcClient>,
+    for_update_ts: u64,
     #[new(default)]
     committed: bool,
     #[new(default)]
@@ -343,61 +348,30 @@ impl TwoPhaseCommitter {
         }
     }
 
-    async fn pessimistic_commit(mut self, for_update_ts: u64) -> Result<()> {
-        if self.mutations.is_empty() {
-            self.committed = true;
-            return Ok(());
-        }
-        self.pessimistic_prewrite(for_update_ts).await?;
-        match self.commit_primary().await {
-            Ok(commit_version) => {
-                self.committed = true;
-                self.bg_worker
-                    .clone()
-                    .spawn_ok(self.commit_secondary(commit_version).map(|res| {
-                        if let Err(e) = res {
-                            warn!("Failed to commit secondary keys: {}", e);
-                        }
-                    }));
-                Ok(())
-            }
-            Err(e) => {
-                if self.undetermined {
-                    Err(Error::undetermined_error(e))
-                } else {
-                    Err(e)
-                }
-            }
-        }
-    }
-
-    async fn pessimistic_prewrite(&mut self, for_update_ts: u64) -> Result<()> {
-        let primary_lock = self.mutations[0].key.clone().into();
-        // TODO: calculate TTL for big transactions
-        let lock_ttl = DEFAULT_LOCK_TTL;
-        new_pessimistic_prewrite_request(
-            self.mutations.clone(),
-            primary_lock,
-            self.start_version,
-            lock_ttl,
-            for_update_ts,
-        )
-        .execute(self.rpc.clone())
-        .await
-    }
-
     async fn prewrite(&mut self) -> Result<()> {
         let primary_lock = self.mutations[0].key.clone().into();
         // TODO: calculate TTL for big transactions
         let lock_ttl = DEFAULT_LOCK_TTL;
-        new_prewrite_request(
-            self.mutations.clone(),
-            primary_lock,
-            self.start_version,
-            lock_ttl,
-        )
-        .execute(self.rpc.clone())
-        .await
+        if self.for_update_ts > 0 {
+            new_pessimistic_prewrite_request(
+                self.mutations.clone(),
+                primary_lock,
+                self.start_version,
+                lock_ttl,
+                self.for_update_ts,
+            )
+                .execute(self.rpc.clone())
+                .await
+        } else {
+            new_prewrite_request(
+                self.mutations.clone(),
+                primary_lock,
+                self.start_version,
+                lock_ttl,
+            )
+                .execute(self.rpc.clone())
+                .await
+        }
     }
 
     /// Commits the primary key and returns the commit version
@@ -436,7 +410,7 @@ impl TwoPhaseCommitter {
             .await
     }
 
-    fn rollback(&mut self) -> impl Future<Output = Result<()>> + 'static {
+    fn rollback(&mut self) -> impl Future<Output=Result<()>> + 'static {
         let mutations = mem::take(&mut self.mutations);
         let keys = mutations
             .into_iter()

--- a/src/transaction/transaction.rs
+++ b/src/transaction/transaction.rs
@@ -235,7 +235,7 @@ impl Transaction {
         .await
     }
 
-    /// Pessimisticly lock the keys
+    /// Pessimistically lock the keys
     ///
     /// ```rust,no_run
     /// # use tikv_client::{Config, transaction::Client};

--- a/src/transaction/transaction.rs
+++ b/src/transaction/transaction.rs
@@ -450,7 +450,12 @@ impl TwoPhaseCommitter {
             .into_iter()
             .map(|mutation| mutation.key.into())
             .collect();
-        new_batch_rollback_request(keys, self.start_version).execute(self.rpc.clone())
+        if self.for_update_ts > 0 {
+            new_pessimistic_rollback_request(keys, self.start_version, self.for_update_ts)
+                .execute(self.rpc.clone())
+        } else {
+            new_batch_rollback_request(keys, self.start_version).execute(self.rpc.clone())
+        }
     }
 }
 

--- a/src/transaction/transaction.rs
+++ b/src/transaction/transaction.rs
@@ -235,7 +235,20 @@ impl Transaction {
         .await
     }
 
-    // todo: documentation
+    /// Pessimisticly lock the keys
+    ///
+    /// ```rust,no_run
+    /// # use tikv_client::{Config, transaction::Client};
+    /// # use futures::prelude::*;
+    /// # use tikv_client_common::Key;
+    /// # futures::executor::block_on(async {
+    /// # let client = Client::new(Config::default()).await.unwrap();
+    /// let mut txn = client.begin().await.unwrap();
+    /// // ... Do some actions.
+    /// let key1: Key = b"key1".to_vec().into();
+    /// let result: () = txn.pessimistic_lock(vec![key1.clone()]).await.unwrap();
+    /// # });
+    /// ```
     pub async fn pessimistic_lock(
         &mut self,
         keys: impl IntoIterator<Item = impl Into<Key>>,
@@ -261,6 +274,19 @@ impl Transaction {
         .await
     }
 
+    /// Commits the actions of the pessimistic transaction.
+    ///
+    /// ```rust,no_run
+    /// # use tikv_client::{Config, transaction::Client};
+    /// # use futures::prelude::*;
+    /// # futures::executor::block_on(async {
+    /// # let client = Client::new(Config::default()).await.unwrap();
+    /// let mut txn = client.begin().await.unwrap();
+    /// // ... Do some actions.
+    /// let req = txn.pessimistic_commit();
+    /// let result: () = req.await.unwrap();
+    /// # });
+    /// ```
     pub async fn pessimistic_commit(&mut self) -> Result<()> {
         TwoPhaseCommitter::new(
             self.buffer.to_proto_mutations(),

--- a/tikv-client-common/src/errors.rs
+++ b/tikv-client-common/src/errors.rs
@@ -66,6 +66,9 @@ pub enum ErrorKind {
     /// Invalid ColumnFamily
     #[fail(display = "Unsupported column family {}", _0)]
     ColumnFamilyError(String),
+    /// failed to resolve a lock
+    #[fail(display = "Failed to resolve lock")]
+    ResolveLockError,
 }
 
 impl Fail for Error {

--- a/tikv-client-common/src/errors.rs
+++ b/tikv-client-common/src/errors.rs
@@ -66,9 +66,12 @@ pub enum ErrorKind {
     /// Invalid ColumnFamily
     #[fail(display = "Unsupported column family {}", _0)]
     ColumnFamilyError(String),
-    /// failed to resolve a lock
+    /// Failed to resolve a lock
     #[fail(display = "Failed to resolve lock")]
     ResolveLockError,
+    /// Will raise this error when using a pessimistic txn only operation on an optimistic txn
+    #[fail(display = "Invalid operation for this type of transaction")]
+    InvalidTransactionType,
 }
 
 impl Fail for Error {

--- a/tikv-client-store/src/errors.rs
+++ b/tikv-client-store/src/errors.rs
@@ -29,6 +29,7 @@ has_region_error!(kvrpcpb::GetResponse);
 has_region_error!(kvrpcpb::ScanResponse);
 has_region_error!(kvrpcpb::PrewriteResponse);
 has_region_error!(kvrpcpb::CommitResponse);
+has_region_error!(kvrpcpb::PessimisticLockResponse);
 has_region_error!(kvrpcpb::ImportResponse);
 has_region_error!(kvrpcpb::BatchRollbackResponse);
 has_region_error!(kvrpcpb::CleanupResponse);
@@ -123,6 +124,12 @@ impl HasError for kvrpcpb::RawBatchScanResponse {
 }
 
 impl HasError for kvrpcpb::PrewriteResponse {
+    fn error(&mut self) -> Option<Error> {
+        extract_errors(self.take_errors().into_iter().map(Some))
+    }
+}
+
+impl HasError for kvrpcpb::PessimisticLockResponse {
     fn error(&mut self) -> Option<Error> {
         extract_errors(self.take_errors().into_iter().map(Some))
     }

--- a/tikv-client-store/src/errors.rs
+++ b/tikv-client-store/src/errors.rs
@@ -32,6 +32,7 @@ has_region_error!(kvrpcpb::CommitResponse);
 has_region_error!(kvrpcpb::PessimisticLockResponse);
 has_region_error!(kvrpcpb::ImportResponse);
 has_region_error!(kvrpcpb::BatchRollbackResponse);
+has_region_error!(kvrpcpb::PessimisticRollbackResponse);
 has_region_error!(kvrpcpb::CleanupResponse);
 has_region_error!(kvrpcpb::BatchGetResponse);
 has_region_error!(kvrpcpb::ScanLockResponse);
@@ -130,6 +131,12 @@ impl HasError for kvrpcpb::PrewriteResponse {
 }
 
 impl HasError for kvrpcpb::PessimisticLockResponse {
+    fn error(&mut self) -> Option<Error> {
+        extract_errors(self.take_errors().into_iter().map(Some))
+    }
+}
+
+impl HasError for kvrpcpb::PessimisticRollbackResponse {
     fn error(&mut self) -> Option<Error> {
         extract_errors(self.take_errors().into_iter().map(Some))
     }


### PR DESCRIPTION
Currently client-rust doesn't support pessimistic transaction, but pessimistic transaction is not only useful but also more and more important in TiKV. The client may support it, so it can at least work as a simpler demo of using the pessimistic transaction system in TiKV than the whole TiDB.
So this pr adds basic support of pessimistic transaction into the client.
Close #155.
