### PR TITLE
Fix: rollback and commit in transaction

### DIFF
--- a/src/transaction/client.rs
+++ b/src/transaction/client.rs
@@ -71,17 +71,17 @@ impl Client {
     /// ```
     pub async fn begin(&self) -> Result<Transaction> {
         let timestamp = self.current_timestamp().await?;
-        Ok(self.new_transaction(timestamp, false))
+        Ok(self.new_transaction(timestamp, false, false))
     }
 
     pub async fn begin_pessimistic(&self) -> Result<Transaction> {
         let timestamp = self.current_timestamp().await?;
-        Ok(self.new_transaction(timestamp, true))
+        Ok(self.new_transaction(timestamp, true, false))
     }
 
     /// Creates a new [`Snapshot`](Snapshot) at the given time.
     pub fn snapshot(&self, timestamp: Timestamp) -> Snapshot {
-        Snapshot::new(self.new_transaction(timestamp, false))
+        Snapshot::new(self.new_transaction(timestamp, false, true))
     }
 
     /// Retrieves the current [`Timestamp`](Timestamp).
@@ -141,13 +141,19 @@ impl Client {
         Ok(res)
     }
 
-    fn new_transaction(&self, timestamp: Timestamp, is_pessimistic: bool) -> Transaction {
+    fn new_transaction(
+        &self,
+        timestamp: Timestamp,
+        is_pessimistic: bool,
+        read_only: bool,
+    ) -> Transaction {
         Transaction::new(
             timestamp,
             self.bg_worker.clone(),
             self.pd.clone(),
             self.key_only,
             is_pessimistic,
+            read_only,
         )
     }
 }

--- a/src/transaction/transaction.rs
+++ b/src/transaction/transaction.rs
@@ -365,7 +365,6 @@ impl Transaction {
         &mut self,
         keys: impl IntoIterator<Item = impl Into<Key>>,
     ) -> Result<()> {
-        self.check_status()?;
         let mut keys: Vec<Vec<u8>> = keys
             .into_iter()
             .map(|it| it.into())

--- a/src/transaction/transaction.rs
+++ b/src/transaction/transaction.rs
@@ -507,6 +507,8 @@ impl TwoPhaseCommitter {
         if self.for_update_ts > 0 {
             new_pessimistic_rollback_request(keys, self.start_version, self.for_update_ts)
                 .execute(self.rpc.clone(), OPTIMISTIC_BACKOFF)
+        } else if self.mutations.is_empty() {
+            Box::pin(future::ready(Ok(())))
         } else {
             new_batch_rollback_request(keys, self.start_version)
                 .execute(self.rpc.clone(), OPTIMISTIC_BACKOFF)

--- a/tikv-client-common/src/errors.rs
+++ b/tikv-client-common/src/errors.rs
@@ -72,6 +72,9 @@ pub enum ErrorKind {
     /// Will raise this error when using a pessimistic txn only operation on an optimistic txn
     #[fail(display = "Invalid operation for this type of transaction")]
     InvalidTransactionType,
+    /// It's not allowed to perform operations in a transaction after it has been committed or rolled back.
+    #[fail(display = "Cannot operate after transaction successfully committed or rolled back")]
+    OperationAfterCommitError,
 }
 
 impl Fail for Error {

--- a/tikv-client-common/src/errors.rs
+++ b/tikv-client-common/src/errors.rs
@@ -73,7 +73,9 @@ pub enum ErrorKind {
     #[fail(display = "Invalid operation for this type of transaction")]
     InvalidTransactionType,
     /// It's not allowed to perform operations in a transaction after it has been committed or rolled back.
-    #[fail(display = "Cannot operate after transaction successfully committed or rolled back")]
+    #[fail(
+        display = "Cannot read or write data after any attempt to commit or roll back the transaction"
+    )]
     OperationAfterCommitError,
 }
 


### PR DESCRIPTION
We should not allow further operations in a transaction after it successfully commits or rolls back.
Close #35 .

I extended Fangsong's implementation at the drop of a `Transaction`: spawn a rollback work at the thread pool. 

Changes:

- Add a rollback function to Transaction
- Record the status of transaction, and check before every operation. 
- Use clone instead of `mem::take()` because commit or rollback can fail and the mutations are expected to still exist in the transaction.
- Automatically rollback transaction when `Transaction` gets dropped instead of when `TwoPhaseCommitter` gets dropped.