### PR TITLE
Improve ergonomics

### DIFF
--- a/examples/pessimistic.rs
+++ b/examples/pessimistic.rs
@@ -14,13 +14,13 @@ async fn main() {
     // Create a configuration to use for the example.
     // Optionally encrypt the traffic.
     let config = if let (Some(ca), Some(cert), Some(key)) = (args.ca, args.cert, args.key) {
-        Config::new(args.pd).with_security(ca, cert, key)
+        Config::default().with_security(ca, cert, key)
     } else {
-        Config::new(args.pd)
+        Config::default()
     };
 
     // init
-    let client = Client::new(config)
+    let client = Client::new_with_config(args.pd, config)
         .await
         .expect("Could not connect to tikv");
 

--- a/examples/raw.rs
+++ b/examples/raw.rs
@@ -19,14 +19,14 @@ async fn main() -> Result<()> {
     // Create a configuration to use for the example.
     // Optionally encrypt the traffic.
     let config = if let (Some(ca), Some(cert), Some(key)) = (args.ca, args.cert, args.key) {
-        Config::new(args.pd).with_security(ca, cert, key)
+        Config::default().with_security(ca, cert, key)
     } else {
-        Config::new(args.pd)
+        Config::default()
     };
 
     // When we first create a client we receive a `Connect` structure which must be resolved before
     // the client is actually connected and usable.
-    let client = Client::new(config).await?;
+    let client = Client::new_with_config(args.pd, config).await?;
 
     // Requests are created from the connected client. These calls return structures which
     // implement `Future`. This means the `Future` must be resolved before the action ever takes

--- a/examples/raw.rs
+++ b/examples/raw.rs
@@ -86,8 +86,7 @@ async fn main() -> Result<()> {
     let start = "k1";
     let end = "k2";
     let pairs = client
-        .with_key_only(true)
-        .scan((start..=end).to_owned(), 10)
+        .scan((start..=end).to_owned(), 10, true)
         .await
         .expect("Could not scan");
 
@@ -107,7 +106,7 @@ async fn main() -> Result<()> {
         (k1.to_owned()..=k3.to_owned()),
     ];
     let kv_pairs = client
-        .batch_scan(batch_scan_keys.to_owned(), 10)
+        .batch_scan(batch_scan_keys.to_owned(), 10, true)
         .await
         .expect("Could not batch scan");
     let vals: Vec<_> = kv_pairs

--- a/examples/raw.rs
+++ b/examples/raw.rs
@@ -86,7 +86,7 @@ async fn main() -> Result<()> {
     let start = "k1";
     let end = "k2";
     let pairs = client
-        .scan((start..=end).to_owned(), 10, true)
+        .scan((start..=end).to_owned(), 10)
         .await
         .expect("Could not scan");
 
@@ -106,7 +106,7 @@ async fn main() -> Result<()> {
         (k1.to_owned()..=k3.to_owned()),
     ];
     let kv_pairs = client
-        .batch_scan(batch_scan_keys.to_owned(), 10, true)
+        .batch_scan(batch_scan_keys.to_owned(), 10)
         .await
         .expect("Could not batch scan");
     let vals: Vec<_> = kv_pairs

--- a/examples/transaction.rs
+++ b/examples/transaction.rs
@@ -21,7 +21,7 @@ async fn get(client: &Client, key: Key) -> Option<Value> {
 
 async fn scan(client: &Client, range: impl Into<BoundRange>, limit: u32) {
     let mut txn = client.begin().await.expect("Could not begin a transaction");
-    txn.scan(range, limit)
+    txn.scan(range, limit, false)
         .await
         .expect("Could not scan key-value pairs in range")
         .for_each(|pair| println!("{:?}", pair));

--- a/examples/transaction.rs
+++ b/examples/transaction.rs
@@ -21,7 +21,7 @@ async fn get(client: &Client, key: Key) -> Option<Value> {
 
 async fn scan(client: &Client, range: impl Into<BoundRange>, limit: u32) {
     let mut txn = client.begin().await.expect("Could not begin a transaction");
-    txn.scan(range, limit, false)
+    txn.scan(range, limit)
         .await
         .expect("Could not scan key-value pairs in range")
         .for_each(|pair| println!("{:?}", pair));

--- a/examples/transaction.rs
+++ b/examples/transaction.rs
@@ -45,12 +45,12 @@ async fn main() {
     // Create a configuration to use for the example.
     // Optionally encrypt the traffic.
     let config = if let (Some(ca), Some(cert), Some(key)) = (args.ca, args.cert, args.key) {
-        Config::new(args.pd).with_security(ca, cert, key)
+        Config::default().with_security(ca, cert, key)
     } else {
-        Config::new(args.pd)
+        Config::default()
     };
 
-    let txn = Client::new(config)
+    let txn = Client::new_with_config(args.pd, config)
         .await
         .expect("Could not connect to tikv");
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -19,11 +19,10 @@ use std::{path::PathBuf, time::Duration};
 /// parameters.
 ///
 /// TiKV does not currently offer encrypted storage (or encryption-at-rest).
-#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 #[serde(default)]
 #[serde(rename_all = "kebab-case")]
 pub struct Config {
-    pub pd_endpoints: Vec<String>,
     pub ca_path: Option<PathBuf>,
     pub cert_path: Option<PathBuf>,
     pub key_path: Option<PathBuf>,
@@ -32,27 +31,18 @@ pub struct Config {
 
 const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(2);
 
-impl Config {
-    /// Create a new [`Config`](Config) which coordinates with the given PD endpoints.
-    ///
-    /// It's important to **include more than one PD endpoint** (include all, if possible!)
-    /// This helps avoid having a *single point of failure*.
-    ///
-    /// # Examples
-    /// ```rust
-    /// # use tikv_client::Config;
-    /// let config = Config::new(vec!["192.168.0.100:2379", "192.168.0.101:2379"]);
-    /// ```
-    pub fn new(pd_endpoints: impl IntoIterator<Item = impl Into<String>>) -> Self {
+impl Default for Config {
+    fn default() -> Self {
         Config {
-            pd_endpoints: pd_endpoints.into_iter().map(Into::into).collect(),
             ca_path: None,
             cert_path: None,
             key_path: None,
             timeout: DEFAULT_REQUEST_TIMEOUT,
         }
     }
+}
 
+impl Config {
     /// Set the certificate authority, certificate, and key locations for the
     /// [`Config`](Config).
     ///
@@ -62,11 +52,7 @@ impl Config {
     /// # Examples
     /// ```rust
     /// # use tikv_client::Config;
-    /// let config = Config::new(vec!["192.168.0.100:2379", "192.168.0.101:2379"]).with_security(
-    ///     "root.ca",
-    ///     "internal.cert",
-    ///     "internal.key",
-    /// );
+    /// let config = Config::default().with_security("root.ca", "internal.cert", "internal.key");
     /// ```
     pub fn with_security(
         mut self,
@@ -87,8 +73,7 @@ impl Config {
     /// ```rust
     /// # use tikv_client::Config;
     /// # use std::time::Duration;
-    /// let config = Config::new(vec!["192.168.0.100:2379", "192.168.0.101:2379"])
-    ///     .timeout(Duration::from_secs(10));
+    /// let config = Config::default().timeout(Duration::from_secs(10));
     /// ```
     pub fn timeout(mut self, timeout: Duration) -> Self {
         self.timeout = timeout;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,13 +61,15 @@
 //!
 //! # futures::executor::block_on(async {
 //! // Configure endpoints and optional TLS.
-//! let config = Config::new(vec![ // A list of PD endpoints.
-//!     "192.168.0.100:2379",
-//!     "192.168.0.101:2379",
-//! ]).with_security("root.ca", "internal.cert", "internal.key");
+//! let config = Config::default().with_security("root.ca", "internal.cert", "internal.key");
 //!
 //! // Get a transactional client.
-//! let client = TransactionClient::new(config).await.unwrap();
+//! let client = TransactionClient::new_with_config(
+//!     vec![
+//!         // A list of PD endpoints.
+//!         "192.168.0.100:2379",
+//!         "192.168.0.101:2379",
+//!     ], config).await.unwrap();
 //! # });
 //! ```
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,7 +101,7 @@ pub use crate::kv::{BoundRange, Key, KvPair, ToOwnedRange, Value};
 #[doc(inline)]
 pub use crate::raw::{Client as RawClient, ColumnFamily};
 #[doc(inline)]
-pub use crate::timestamp::Timestamp;
+pub use crate::timestamp::{Timestamp, TimestampExt};
 #[doc(inline)]
 pub use crate::transaction::{Client as TransactionClient, Snapshot, Transaction};
 pub use config::Config;

--- a/src/pd/client.rs
+++ b/src/pd/client.rs
@@ -233,12 +233,16 @@ impl<KvC: KvConnect + Send + Sync + 'static> PdClient for PdRpcClient<KvC> {
 }
 
 impl PdRpcClient<TikvConnect, Cluster> {
-    pub async fn connect(config: &Config, enable_codec: bool) -> Result<PdRpcClient> {
+    pub async fn connect(
+        pd_endpoints: &[String],
+        config: &Config,
+        enable_codec: bool,
+    ) -> Result<PdRpcClient> {
         PdRpcClient::new(
             config,
             |env, security_mgr| TikvConnect::new(env, security_mgr, config.timeout),
             |env, security_mgr| {
-                RetryClient::connect(env, &config.pd_endpoints, security_mgr, config.timeout)
+                RetryClient::connect(env, pd_endpoints, security_mgr, config.timeout)
             },
             enable_codec,
         )

--- a/src/raw/client.rs
+++ b/src/raw/client.rs
@@ -21,7 +21,6 @@ const MAX_RAW_KV_SCAN_LIMIT: u32 = 10240;
 pub struct Client {
     rpc: Arc<PdRpcClient>,
     cf: Option<ColumnFamily>,
-    key_only: bool,
 }
 
 impl Client {
@@ -37,11 +36,7 @@ impl Client {
     /// ```
     pub async fn new(config: Config) -> Result<Client> {
         let rpc = Arc::new(PdRpcClient::connect(&config, false).await?);
-        Ok(Client {
-            rpc,
-            cf: None,
-            key_only: false,
-        })
+        Ok(Client { rpc, cf: None })
     }
 
     /// Set the column family of requests.
@@ -67,34 +62,6 @@ impl Client {
         Client {
             rpc: self.rpc.clone(),
             cf: Some(cf),
-            key_only: self.key_only,
-        }
-    }
-
-    /// Set the `key_only` option of requests.
-    ///
-    /// This function returns a new `Client`, requests created with it will have the
-    /// supplied `key_only` option. The original `Client` can still be used. `key_only`
-    /// is only relevant for `scan`-like requests, for other kinds of request, it
-    /// will be ignored.
-    /// With `key_only` being true, `scan`-like requests will ignore values.
-    ///
-    /// By default, `key_only` is set to false.
-    ///
-    /// # Examples
-    /// ```rust,no_run
-    /// # use tikv_client::{Config, RawClient, ToOwnedRange};
-    /// # use futures::prelude::*;
-    /// # futures::executor::block_on(async {
-    /// let client = RawClient::new(Config::default()).await.unwrap().with_key_only(true);
-    /// let scan_request = client.scan(("TiKV"..="TiDB").to_owned(), 2);
-    /// # });
-    /// ```
-    pub fn with_key_only(&self, key_only: bool) -> Client {
-        Client {
-            rpc: self.rpc.clone(),
-            cf: self.cf.clone(),
-            key_only,
         }
     }
 
@@ -279,16 +246,21 @@ impl Client {
     /// # futures::executor::block_on(async {
     /// # let client = RawClient::new(Config::default()).await.unwrap();
     /// let inclusive_range = "TiKV"..="TiDB";
-    /// let req = client.scan(inclusive_range.to_owned(), 2);
+    /// let req = client.scan(inclusive_range.to_owned(), 2, true);
     /// let result: Vec<KvPair> = req.await.unwrap();
     /// # });
     /// ```
-    pub async fn scan(&self, range: impl Into<BoundRange>, limit: u32) -> Result<Vec<KvPair>> {
+    pub async fn scan(
+        &self,
+        range: impl Into<BoundRange>,
+        limit: u32,
+        key_only: bool,
+    ) -> Result<Vec<KvPair>> {
         if limit > MAX_RAW_KV_SCAN_LIMIT {
             return Err(Error::max_scan_limit_exceeded(limit, MAX_RAW_KV_SCAN_LIMIT));
         }
 
-        let res = requests::new_raw_scan_request(range, limit, self.key_only, self.cf.clone())
+        let res = requests::new_raw_scan_request(range, limit, key_only, self.cf.clone())
             .execute(self.rpc.clone(), OPTIMISTIC_BACKOFF)
             .await;
         res.map(|mut s| {
@@ -316,7 +288,7 @@ impl Client {
     /// let inclusive_range1 = "TiDB"..="TiKV";
     /// let inclusive_range2 = "TiKV"..="TiSpark";
     /// let iterable = vec![inclusive_range1.to_owned(), inclusive_range2.to_owned()];
-    /// let req = client.batch_scan(iterable, 2);
+    /// let req = client.batch_scan(iterable, 2, false);
     /// let result = req.await;
     /// # });
     /// ```
@@ -324,6 +296,7 @@ impl Client {
         &self,
         ranges: impl IntoIterator<Item = impl Into<BoundRange>>,
         each_limit: u32,
+        key_only: bool,
     ) -> Result<Vec<KvPair>> {
         if each_limit > MAX_RAW_KV_SCAN_LIMIT {
             return Err(Error::max_scan_limit_exceeded(
@@ -332,7 +305,7 @@ impl Client {
             ));
         }
 
-        requests::new_raw_batch_scan_request(ranges, each_limit, self.key_only, self.cf.clone())
+        requests::new_raw_batch_scan_request(ranges, each_limit, key_only, self.cf.clone())
             .execute(self.rpc.clone(), OPTIMISTIC_BACKOFF)
             .await
     }

--- a/src/transaction/client.rs
+++ b/src/transaction/client.rs
@@ -37,7 +37,6 @@ pub struct Client {
     /// The thread pool for background tasks including committing secondary keys and failed
     /// transaction cleanups.
     bg_worker: ThreadPool,
-    key_only: bool,
 }
 
 impl Client {
@@ -54,19 +53,7 @@ impl Client {
     pub async fn new(config: Config) -> Result<Client> {
         let bg_worker = ThreadPool::new()?;
         let pd = Arc::new(PdRpcClient::connect(&config, true).await?);
-        Ok(Client {
-            pd,
-            bg_worker,
-            key_only: false,
-        })
-    }
-
-    pub fn with_key_only(&self, key_only: bool) -> Client {
-        Client {
-            pd: self.pd.clone(),
-            bg_worker: self.bg_worker.clone(),
-            key_only,
-        }
+        Ok(Client { pd, bg_worker })
     }
 
     /// Creates a new [`Transaction`](Transaction) in optimistic mode.
@@ -186,7 +173,6 @@ impl Client {
             timestamp,
             self.bg_worker.clone(),
             self.pd.clone(),
-            self.key_only,
             is_pessimistic,
         )
     }

--- a/src/transaction/snapshot.rs
+++ b/src/transaction/snapshot.rs
@@ -36,8 +36,9 @@ impl Snapshot {
         &self,
         range: impl Into<BoundRange>,
         limit: u32,
+        key_only: bool,
     ) -> Result<impl Iterator<Item = KvPair>> {
-        self.transaction.scan(range, limit).await
+        self.transaction.scan(range, limit, key_only).await
     }
 
     /// Unimplemented. Similar to scan, but in the reverse direction.

--- a/src/transaction/snapshot.rs
+++ b/src/transaction/snapshot.rs
@@ -36,9 +36,17 @@ impl Snapshot {
         &self,
         range: impl Into<BoundRange>,
         limit: u32,
-        key_only: bool,
     ) -> Result<impl Iterator<Item = KvPair>> {
-        self.transaction.scan(range, limit, key_only).await
+        self.transaction.scan(range, limit).await
+    }
+
+    /// Scan a range, return at most `limit` keys that lying in the range.
+    pub async fn scan_keys(
+        &self,
+        range: impl Into<BoundRange>,
+        limit: u32,
+    ) -> Result<impl Iterator<Item = Key>> {
+        self.transaction.scan_keys(range, limit).await
     }
 
     /// Unimplemented. Similar to scan, but in the reverse direction.

--- a/src/transaction/transaction.rs
+++ b/src/transaction/transaction.rs
@@ -46,7 +46,6 @@ pub struct Transaction {
     buffer: Buffer,
     bg_worker: ThreadPool,
     rpc: Arc<PdRpcClient>,
-    key_only: bool,
     for_update_ts: u64,
     is_pessimistic: bool,
 }
@@ -56,7 +55,6 @@ impl Transaction {
         timestamp: Timestamp,
         bg_worker: ThreadPool,
         rpc: Arc<PdRpcClient>,
-        key_only: bool,
         is_pessimistic: bool,
     ) -> Transaction {
         Transaction {
@@ -64,7 +62,6 @@ impl Transaction {
             buffer: Default::default(),
             bg_worker,
             rpc,
-            key_only,
             for_update_ts: 0,
             is_pessimistic,
         }
@@ -243,11 +240,11 @@ impl Transaction {
         &self,
         range: impl Into<BoundRange>,
         limit: u32,
+        key_only: bool,
     ) -> Result<impl Iterator<Item = KvPair>> {
         let timestamp = self.timestamp.clone();
         let rpc = self.rpc.clone();
 
-        let key_only = self.key_only;
         self.buffer
             .scan_and_fetch(range.into(), limit, move |new_range, new_limit| {
                 new_mvcc_scan_request(new_range, timestamp, new_limit, key_only)

--- a/src/transaction/transaction.rs
+++ b/src/transaction/transaction.rs
@@ -53,7 +53,7 @@ enum TransactionStatus {
 /// use tikv_client::{Config, TransactionClient};
 /// use futures::prelude::*;
 /// # futures::executor::block_on(async {
-/// let client = TransactionClient::new(Config::default()).await.unwrap();
+/// let client = TransactionClient::new(vec!["192.168.0.100"]).await.unwrap();
 /// let txn = client.begin().await.unwrap();
 /// # });
 /// ```
@@ -103,7 +103,7 @@ impl Transaction {
     /// # use tikv_client::{Value, Config, TransactionClient};
     /// # use futures::prelude::*;
     /// # futures::executor::block_on(async {
-    /// # let client = TransactionClient::new(Config::new(vec!["192.168.0.100", "192.168.0.101"])).await.unwrap();
+    /// # let client = TransactionClient::new(vec!["192.168.0.100", "192.168.0.101"]).await.unwrap();
     /// let mut txn = client.begin().await.unwrap();
     /// let key = "TiKV".to_owned();
     /// let result: Option<Value> = txn.get(key).await.unwrap();
@@ -132,7 +132,7 @@ impl Transaction {
     /// # use tikv_client::{Value, Config, TransactionClient};
     /// # use futures::prelude::*;
     /// # futures::executor::block_on(async {
-    /// # let client = TransactionClient::new(Config::new(vec!["192.168.0.100", "192.168.0.101"])).await.unwrap();
+    /// # let client = TransactionClient::new(vec!["192.168.0.100", "192.168.0.101"]).await.unwrap();
     /// let mut txn = client.begin_pessimistic().await.unwrap();
     /// let key = "TiKV".to_owned();
     /// let result: Option<Value> = txn.get_for_update(key).await.unwrap();
@@ -170,7 +170,7 @@ impl Transaction {
     /// # use futures::prelude::*;
     /// # use std::collections::HashMap;
     /// # futures::executor::block_on(async {
-    /// # let client = TransactionClient::new(Config::new(vec!["192.168.0.100", "192.168.0.101"])).await.unwrap();
+    /// # let client = TransactionClient::new(vec!["192.168.0.100", "192.168.0.101"]).await.unwrap();
     /// let mut txn = client.begin().await.unwrap();
     /// let keys = vec!["TiKV".to_owned(), "TiDB".to_owned()];
     /// let result: HashMap<Key, Value> = txn
@@ -210,7 +210,7 @@ impl Transaction {
     /// # use futures::prelude::*;
     /// # use std::collections::HashMap;
     /// # futures::executor::block_on(async {
-    /// # let client = TransactionClient::new(Config::new(vec!["192.168.0.100", "192.168.0.101"])).await.unwrap();
+    /// # let client = TransactionClient::new(vec!["192.168.0.100", "192.168.0.101"]).await.unwrap();
     /// let mut txn = client.begin_pessimistic().await.unwrap();
     /// let keys = vec!["TiKV".to_owned(), "TiDB".to_owned()];
     /// let result: HashMap<Key, Value> = txn
@@ -251,7 +251,7 @@ impl Transaction {
     /// # use futures::prelude::*;
     /// # use std::collections::HashMap;
     /// # futures::executor::block_on(async {
-    /// # let client = TransactionClient::new(Config::new(vec!["192.168.0.100", "192.168.0.101"])).await.unwrap();
+    /// # let client = TransactionClient::new(vec!["192.168.0.100", "192.168.0.101"]).await.unwrap();
     /// let mut txn = client.begin().await.unwrap();
     /// let key1: Key = b"TiKV".to_vec().into();
     /// let key2: Key = b"TiDB".to_vec().into();
@@ -296,7 +296,7 @@ impl Transaction {
     /// # use tikv_client::{Key, Value, Config, TransactionClient};
     /// # use futures::prelude::*;
     /// # futures::executor::block_on(async {
-    /// # let client = TransactionClient::new(Config::new(vec!["192.168.0.100", "192.168.0.101"])).await.unwrap();
+    /// # let client = TransactionClient::new(vec!["192.168.0.100", "192.168.0.101"]).await.unwrap();
     /// let mut txn = client.begin().await.unwrap();
     /// let key = "TiKV".to_owned();
     /// let val = "TiKV".to_owned();
@@ -324,7 +324,7 @@ impl Transaction {
     /// # use tikv_client::{Key, Config, TransactionClient};
     /// # use futures::prelude::*;
     /// # futures::executor::block_on(async {
-    /// # let client = TransactionClient::new(Config::new(vec!["192.168.0.100", "192.168.0.101"])).await.unwrap();
+    /// # let client = TransactionClient::new(vec!["192.168.0.100", "192.168.0.101"]).await.unwrap();
     /// let mut txn = client.begin().await.unwrap();
     /// let key = "TiKV".to_owned();
     /// txn.delete(key);
@@ -356,7 +356,7 @@ impl Transaction {
     /// # use tikv_client::{Config, TransactionClient};
     /// # use futures::prelude::*;
     /// # futures::executor::block_on(async {
-    /// # let client = TransactionClient::new(Config::default()).await.unwrap();
+    /// # let client = TransactionClient::new(vec!["192.168.0.100"]).await.unwrap();
     /// let mut txn = client.begin().await.unwrap();
     /// txn.lock_keys(vec!["TiKV".to_owned(), "Rust".to_owned()]);
     /// // ... Do some actions.
@@ -378,7 +378,7 @@ impl Transaction {
     /// # use tikv_client::{Config, TransactionClient};
     /// # use futures::prelude::*;
     /// # futures::executor::block_on(async {
-    /// # let client = TransactionClient::new(Config::default()).await.unwrap();
+    /// # let client = TransactionClient::new(vec!["192.168.0.100"]).await.unwrap();
     /// let mut txn = client.begin().await.unwrap();
     /// // ... Do some actions.
     /// let req = txn.commit();

--- a/src/transaction/transaction.rs
+++ b/src/transaction/transaction.rs
@@ -228,7 +228,7 @@ impl Transaction {
     /// let key1: Key = b"TiKV".to_vec().into();
     /// let key2: Key = b"TiDB".to_vec().into();
     /// let result: Vec<KvPair> = txn
-    ///     .scan(key1..key2, 10)
+    ///     .scan(key1..key2, 10, true)
     ///     .await
     ///     .unwrap()
     ///     .collect();

--- a/tests/mock_tikv_tests.rs
+++ b/tests/mock_tikv_tests.rs
@@ -4,7 +4,7 @@ mod test {
     use log::debug;
     use mock_tikv::{start_mock_pd_server, start_mock_tikv_server, MOCK_PD_PORT};
     use simple_logger::SimpleLogger;
-    use tikv_client::{Config, KvPair, RawClient};
+    use tikv_client::{KvPair, RawClient};
 
     #[tokio::test]
     async fn test_raw_put_get() {
@@ -14,8 +14,9 @@ mod test {
         let mut tikv_server = start_mock_tikv_server();
         let _pd_server = start_mock_pd_server();
 
-        let config = Config::new(vec![format!("localhost:{}", MOCK_PD_PORT)]);
-        let client = RawClient::new(config).await.unwrap();
+        let client = RawClient::new(vec![format!("localhost:{}", MOCK_PD_PORT)])
+            .await
+            .unwrap();
 
         // empty; get non-existent key
         let res = client.get("k1".to_owned()).await;


### PR DESCRIPTION
This PR contains two changes:

1. move `key_only` from client to scan.
2. move `pd_endpoints` from config to client.

IMO, these two are a bit confusing and not so idiomatic to rust. 