### PR TITLE
make `new_pessimistic_lock_request` more consistent with `transaction::request`'s API

### DIFF
--- a/src/transaction/requests.rs
+++ b/src/transaction/requests.rs
@@ -536,8 +536,8 @@ impl KvRequest for kvrpcpb::PessimisticLockRequest {
 }
 
 pub fn new_pessimistic_lock_request(
-    keys: Vec<Vec<u8>>,
-    primary_lock: Vec<u8>,
+    keys: Vec<impl Into<Key>>,
+    primary_lock: Key,
     start_version: u64,
     lock_ttl: u64,
     for_update_ts: u64,
@@ -548,12 +548,12 @@ pub fn new_pessimistic_lock_request(
         .map(|key| {
             let mut mutation = kvrpcpb::Mutation::default();
             mutation.set_op(kvrpcpb::Op::PessimisticLock);
-            mutation.set_key(key);
+            mutation.set_key(key.into().into());
             mutation
         })
         .collect();
     req.set_mutations(mutations);
-    req.set_primary_lock(primary_lock);
+    req.set_primary_lock(primary_lock.into());
     req.set_start_version(start_version);
     req.set_lock_ttl(lock_ttl);
     req.set_for_update_ts(for_update_ts);

--- a/src/transaction/transaction.rs
+++ b/src/transaction/transaction.rs
@@ -503,7 +503,7 @@ impl Transaction {
         self.for_update_ts = std::cmp::max(self.for_update_ts, for_update_ts);
         new_pessimistic_lock_request(
             keys,
-            primary_lock,
+            primary_lock.into(),
             self.timestamp.version(),
             lock_ttl,
             for_update_ts,


### PR DESCRIPTION
related to #205 