### PR TITLE
Refactor the transaction API re how we set options, and add some options to skip resolve and retry

### DIFF
--- a/examples/pessimistic.rs
+++ b/examples/pessimistic.rs
@@ -28,7 +28,10 @@ async fn main() {
     let value1: Value = b"value1".to_vec();
     let key2: Key = b"key2".to_vec().into();
     let value2: Value = b"value2".to_vec();
-    let mut txn0 = client.begin().await.expect("Could not begin a transaction");
+    let mut txn0 = client
+        .begin_optimistic()
+        .await
+        .expect("Could not begin a transaction");
     for (key, value) in vec![(key1, value1), (key2, value2)] {
         txn0.put(key, value).await.expect("Could not set key value");
     }
@@ -47,7 +50,10 @@ async fn main() {
     println!("{:?}", (&key1, value));
     {
         // another txn cannot write to the locked key
-        let mut txn2 = client.begin().await.expect("Could not begin a transaction");
+        let mut txn2 = client
+            .begin_optimistic()
+            .await
+            .expect("Could not begin a transaction");
         let key1: Key = b"key1".to_vec().into();
         let value2: Value = b"value2".to_vec();
         txn2.put(key1, value2).await.unwrap();
@@ -58,7 +64,10 @@ async fn main() {
     let value3: Value = b"value3".to_vec();
     txn1.put(key1.clone(), value3).await.unwrap();
     txn1.commit().await.unwrap();
-    let mut txn3 = client.begin().await.expect("Could not begin a transaction");
+    let mut txn3 = client
+        .begin_optimistic()
+        .await
+        .expect("Could not begin a transaction");
     let result = txn3.get(key1.clone()).await.unwrap().unwrap();
     txn3.commit()
         .await

--- a/examples/pessimistic.rs
+++ b/examples/pessimistic.rs
@@ -24,15 +24,15 @@ async fn main() {
         .await
         .expect("Could not connect to tikv");
 
-    let key1: Key = b"key1".to_vec().into();
+    let key1: Key = b"key01".to_vec().into();
     let value1: Value = b"value1".to_vec();
-    let key2: Key = b"key2".to_vec().into();
+    let key2: Key = b"key02".to_vec().into();
     let value2: Value = b"value2".to_vec();
     let mut txn0 = client
         .begin_optimistic()
         .await
         .expect("Could not begin a transaction");
-    for (key, value) in vec![(key1, value1), (key2, value2)] {
+    for (key, value) in vec![(key1.clone(), value1), (key2, value2)] {
         txn0.put(key, value).await.expect("Could not set key value");
     }
     txn0.commit().await.expect("Could not commit");
@@ -42,7 +42,6 @@ async fn main() {
         .await
         .expect("Could not begin a transaction");
     // lock the key
-    let key1: Key = b"key1".to_vec().into();
     let value = txn1
         .get_for_update(key1.clone())
         .await
@@ -54,9 +53,8 @@ async fn main() {
             .begin_optimistic()
             .await
             .expect("Could not begin a transaction");
-        let key1: Key = b"key1".to_vec().into();
         let value2: Value = b"value2".to_vec();
-        txn2.put(key1, value2).await.unwrap();
+        txn2.put(key1.clone(), value2).await.unwrap();
         let result = txn2.commit().await;
         assert!(result.is_err());
     }

--- a/examples/transaction.rs
+++ b/examples/transaction.rs
@@ -6,7 +6,10 @@ use crate::common::parse_args;
 use tikv_client::{BoundRange, Config, Key, KvPair, TransactionClient as Client, Value};
 
 async fn puts(client: &Client, pairs: impl IntoIterator<Item = impl Into<KvPair>>) {
-    let mut txn = client.begin().await.expect("Could not begin a transaction");
+    let mut txn = client
+        .begin_optimistic()
+        .await
+        .expect("Could not begin a transaction");
     for pair in pairs {
         let (key, value) = pair.into().into();
         txn.put(key, value).await.expect("Could not set key value");
@@ -15,7 +18,10 @@ async fn puts(client: &Client, pairs: impl IntoIterator<Item = impl Into<KvPair>
 }
 
 async fn get(client: &Client, key: Key) -> Option<Value> {
-    let mut txn = client.begin().await.expect("Could not begin a transaction");
+    let mut txn = client
+        .begin_optimistic()
+        .await
+        .expect("Could not begin a transaction");
     let res = txn.get(key).await.expect("Could not get value");
     txn.commit()
         .await
@@ -24,7 +30,10 @@ async fn get(client: &Client, key: Key) -> Option<Value> {
 }
 
 async fn scan(client: &Client, range: impl Into<BoundRange>, limit: u32) {
-    let mut txn = client.begin().await.expect("Could not begin a transaction");
+    let mut txn = client
+        .begin_optimistic()
+        .await
+        .expect("Could not begin a transaction");
     txn.scan(range, limit)
         .await
         .expect("Could not scan key-value pairs in range")
@@ -33,7 +42,10 @@ async fn scan(client: &Client, range: impl Into<BoundRange>, limit: u32) {
 }
 
 async fn dels(client: &Client, keys: impl IntoIterator<Item = Key>) {
-    let mut txn = client.begin().await.expect("Could not begin a transaction");
+    let mut txn = client
+        .begin_optimistic()
+        .await
+        .expect("Could not begin a transaction");
     for key in keys {
         txn.delete(key).await.expect("Could not delete the key");
     }

--- a/src/backoff.rs
+++ b/src/backoff.rs
@@ -64,6 +64,10 @@ impl Backoff {
         }
     }
 
+    pub fn is_none(&self) -> bool {
+        self.kind == BackoffKind::None
+    }
+
     pub const fn no_backoff() -> Backoff {
         Backoff {
             kind: BackoffKind::None,

--- a/src/backoff.rs
+++ b/src/backoff.rs
@@ -5,7 +5,7 @@
 use rand::{thread_rng, Rng};
 use std::time::Duration;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Backoff {
     kind: BackoffKind,
     current_attempts: u32,
@@ -148,7 +148,7 @@ impl Backoff {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 enum BackoffKind {
     // NoBackoff means that we don't want any retry here.
     None,

--- a/src/backoff.rs
+++ b/src/backoff.rs
@@ -5,162 +5,9 @@
 use rand::{thread_rng, Rng};
 use std::time::Duration;
 
-pub trait Backoff: Clone + Send + 'static {
-    // Returns the delay period for next retry. If the maximum retry count is hit returns None.
-    fn next_delay_duration(&mut self) -> Option<Duration>;
-}
-
-// NoBackoff means that we don't want any retry here.
-#[derive(Clone)]
-pub struct NoBackoff;
-
-impl Backoff for NoBackoff {
-    fn next_delay_duration(&mut self) -> Option<Duration> {
-        None
-    }
-}
-
-// Exponential backoff means that the retry delay should multiply a constant
-// after each attempt, up to a maximum value. After each attempt, the new retry
-// delay should be:
-//
-// new_delay = min(max_delay, base_delay * 2 ** attempts)
-#[derive(Clone)]
-pub struct NoJitterBackoff {
-    current_attempts: u32,
-    max_attempts: u32,
-    current_delay_ms: u64,
-    max_delay_ms: u64,
-}
-
-impl NoJitterBackoff {
-    pub const fn new(base_delay_ms: u64, max_delay_ms: u64, max_attempts: u32) -> Self {
-        Self {
-            current_attempts: 0,
-            max_attempts,
-            current_delay_ms: base_delay_ms,
-            max_delay_ms,
-        }
-    }
-}
-
-impl Backoff for NoJitterBackoff {
-    fn next_delay_duration(&mut self) -> Option<Duration> {
-        if self.current_attempts >= self.max_attempts {
-            return None;
-        }
-
-        let delay_ms = self.max_delay_ms.min(self.current_delay_ms);
-
-        self.current_attempts += 1;
-        self.current_delay_ms <<= 1;
-
-        Some(Duration::from_millis(delay_ms))
-    }
-}
-
-// Adds Jitter to the basic exponential backoff. Returns a random value between
-// zero and the calculated exponential backoff:
-//
-// temp = min(max_delay, base_delay * 2 ** attempts)
-// new_delay = random_between(0, temp)
-#[derive(Clone)]
-pub struct FullJitterBackoff {
-    current_attempts: u32,
-    max_attempts: u32,
-    current_delay_ms: u64,
-    max_delay_ms: u64,
-}
-
-impl FullJitterBackoff {
-    #[allow(dead_code)]
-    pub fn new(base_delay_ms: u64, max_delay_ms: u64, max_attempts: u32) -> Self {
-        if base_delay_ms == 0 || max_delay_ms == 0 {
-            panic!("Both base_delay_ms and max_delay_ms must be positive");
-        }
-
-        Self {
-            current_attempts: 0,
-            max_attempts,
-            current_delay_ms: base_delay_ms,
-            max_delay_ms,
-        }
-    }
-}
-
-impl Backoff for FullJitterBackoff {
-    fn next_delay_duration(&mut self) -> Option<Duration> {
-        if self.current_attempts >= self.max_attempts {
-            return None;
-        }
-
-        let delay_ms = self.max_delay_ms.min(self.current_delay_ms);
-
-        let mut rng = thread_rng();
-        let delay_ms: u64 = rng.gen_range(0, delay_ms);
-
-        self.current_attempts += 1;
-        self.current_delay_ms <<= 1;
-
-        Some(Duration::from_millis(delay_ms))
-    }
-}
-
-// Equal Jitter limits the random value should be equal or greater than half of
-// the calculated exponential backoff:
-//
-// temp = min(max_delay, base_delay * 2 ** attempts)
-// new_delay = random_between(temp / 2, temp)
-#[derive(Clone)]
-pub struct EqualJitterBackoff {
-    current_attempts: u32,
-    max_attempts: u32,
-    current_delay_ms: u64,
-    max_delay_ms: u64,
-}
-
-impl EqualJitterBackoff {
-    #[allow(dead_code)]
-    pub fn new(base_delay_ms: u64, max_delay_ms: u64, max_attempts: u32) -> Self {
-        if base_delay_ms < 2 || max_delay_ms < 2 {
-            panic!("Both base_delay_ms and max_delay_ms must be greater than 1");
-        }
-
-        Self {
-            current_attempts: 0,
-            max_attempts,
-            current_delay_ms: base_delay_ms,
-            max_delay_ms,
-        }
-    }
-}
-
-impl Backoff for EqualJitterBackoff {
-    fn next_delay_duration(&mut self) -> Option<Duration> {
-        if self.current_attempts >= self.max_attempts {
-            return None;
-        }
-
-        let delay_ms = self.max_delay_ms.min(self.current_delay_ms);
-        let half_delay_ms = delay_ms >> 1;
-
-        let mut rng = thread_rng();
-        let delay_ms: u64 = rng.gen_range(0, half_delay_ms) + half_delay_ms;
-
-        self.current_attempts += 1;
-        self.current_delay_ms <<= 1;
-
-        Some(Duration::from_millis(delay_ms))
-    }
-}
-
-// Decorrelated Jitter is always calculated with the previous backoff
-// (the initial value is base_delay):
-//
-// temp = random_between(base_delay, previous_delay * 3)
-// new_delay = min(max_delay, temp)
-#[derive(Clone)]
-pub struct DecorrelatedJitterBackoff {
+#[derive(Debug, Clone)]
+pub struct Backoff {
+    kind: BackoffKind,
     current_attempts: u32,
     max_attempts: u32,
     base_delay_ms: u64,
@@ -168,14 +15,130 @@ pub struct DecorrelatedJitterBackoff {
     max_delay_ms: u64,
 }
 
-impl DecorrelatedJitterBackoff {
-    #[allow(dead_code)]
-    pub fn new(base_delay_ms: u64, max_delay_ms: u64, max_attempts: u32) -> Self {
-        if base_delay_ms == 0 {
-            panic!("base_delay_ms must be positive");
+impl Backoff {
+    // Returns the delay period for next retry. If the maximum retry count is hit returns None.
+    pub fn next_delay_duration(&mut self) -> Option<Duration> {
+        if self.current_attempts >= self.max_attempts {
+            return None;
         }
+        self.current_attempts += 1;
 
-        Self {
+        match self.kind {
+            BackoffKind::None => None,
+            BackoffKind::NoJitter => {
+                let delay_ms = self.max_delay_ms.min(self.current_delay_ms);
+                self.current_delay_ms <<= 1;
+
+                Some(Duration::from_millis(delay_ms))
+            }
+            BackoffKind::FullJitter => {
+                let delay_ms = self.max_delay_ms.min(self.current_delay_ms);
+
+                let mut rng = thread_rng();
+                let delay_ms: u64 = rng.gen_range(0, delay_ms);
+                self.current_delay_ms <<= 1;
+
+                Some(Duration::from_millis(delay_ms))
+            }
+            BackoffKind::EqualJitter => {
+                let delay_ms = self.max_delay_ms.min(self.current_delay_ms);
+                let half_delay_ms = delay_ms >> 1;
+
+                let mut rng = thread_rng();
+                let delay_ms: u64 = rng.gen_range(0, half_delay_ms) + half_delay_ms;
+                self.current_delay_ms <<= 1;
+
+                Some(Duration::from_millis(delay_ms))
+            }
+            BackoffKind::DecorrelatedJitter => {
+                let mut rng = thread_rng();
+                let delay_ms: u64 = rng
+                    .gen_range(0, self.current_delay_ms * 3 - self.base_delay_ms)
+                    + self.base_delay_ms;
+
+                let delay_ms = delay_ms.min(self.max_delay_ms);
+                self.current_delay_ms = delay_ms;
+
+                Some(Duration::from_millis(delay_ms))
+            }
+        }
+    }
+
+    pub const fn no_backoff() -> Backoff {
+        Backoff {
+            kind: BackoffKind::None,
+            current_attempts: 0,
+            max_attempts: 0,
+            base_delay_ms: 0,
+            current_delay_ms: 0,
+            max_delay_ms: 0,
+        }
+    }
+
+    pub const fn no_jitter_backoff(
+        base_delay_ms: u64,
+        max_delay_ms: u64,
+        max_attempts: u32,
+    ) -> Backoff {
+        Backoff {
+            kind: BackoffKind::NoJitter,
+            current_attempts: 0,
+            max_attempts,
+            base_delay_ms,
+            current_delay_ms: base_delay_ms,
+            max_delay_ms,
+        }
+    }
+
+    pub fn full_jitter_backoff(
+        base_delay_ms: u64,
+        max_delay_ms: u64,
+        max_attempts: u32,
+    ) -> Backoff {
+        assert!(
+            base_delay_ms > 0 && max_delay_ms > 0,
+            "Both base_delay_ms and max_delay_ms must be positive"
+        );
+
+        Backoff {
+            kind: BackoffKind::FullJitter,
+            current_attempts: 0,
+            max_attempts,
+            base_delay_ms,
+            current_delay_ms: base_delay_ms,
+            max_delay_ms,
+        }
+    }
+
+    pub fn equal_jitter_backoff(
+        base_delay_ms: u64,
+        max_delay_ms: u64,
+        max_attempts: u32,
+    ) -> Backoff {
+        assert!(
+            base_delay_ms > 1 && max_delay_ms > 1,
+            "Both base_delay_ms and max_delay_ms must be greater than 1"
+        );
+
+        Backoff {
+            kind: BackoffKind::EqualJitter,
+            current_attempts: 0,
+            max_attempts,
+            base_delay_ms,
+            current_delay_ms: base_delay_ms,
+            max_delay_ms,
+        }
+    }
+
+    pub fn decorrelated_jitter_backoff(
+        base_delay_ms: u64,
+        max_delay_ms: u64,
+        max_attempts: u32,
+    ) -> Backoff {
+        assert!(base_delay_ms > 0, "base_delay_ms must be positive");
+
+        Backoff {
+            kind: BackoffKind::DecorrelatedJitter,
             current_attempts: 0,
             max_attempts,
             base_delay_ms,
@@ -185,23 +148,34 @@ impl DecorrelatedJitterBackoff {
     }
 }
 
-impl Backoff for DecorrelatedJitterBackoff {
-    fn next_delay_duration(&mut self) -> Option<Duration> {
-        if self.current_attempts >= self.max_attempts {
-            return None;
-        }
-
-        let mut rng = thread_rng();
-        let delay_ms: u64 =
-            rng.gen_range(0, self.current_delay_ms * 3 - self.base_delay_ms) + self.base_delay_ms;
-
-        let delay_ms = delay_ms.min(self.max_delay_ms);
-
-        self.current_attempts += 1;
-        self.current_delay_ms = delay_ms;
-
-        Some(Duration::from_millis(delay_ms))
-    }
+#[derive(Debug, Clone)]
+enum BackoffKind {
+    // NoBackoff means that we don't want any retry here.
+    None,
+    // Exponential backoff means that the retry delay should multiply a constant
+    // after each attempt, up to a maximum value. After each attempt, the new retry
+    // delay should be:
+    //
+    // new_delay = min(max_delay, base_delay * 2 ** attempts)
+    NoJitter,
+    // Adds Jitter to the basic exponential backoff. Returns a random value between
+    // zero and the calculated exponential backoff:
+    //
+    // temp = min(max_delay, base_delay * 2 ** attempts)
+    // new_delay = random_between(0, temp)
+    FullJitter,
+    // Equal Jitter limits the random value should be equal or greater than half of
+    // the calculated exponential backoff:
+    //
+    // temp = min(max_delay, base_delay * 2 ** attempts)
+    // new_delay = random_between(temp / 2, temp)
+    EqualJitter,
+    // Decorrelated Jitter is always calculated with the previous backoff
+    // (the initial value is base_delay):
+    //
+    // temp = random_between(base_delay, previous_delay * 3)
+    // new_delay = min(max_delay, temp)
+    DecorrelatedJitter,
 }
 
 #[cfg(test)]
@@ -212,22 +186,10 @@ mod test {
     #[test]
     fn test_no_jitter_backoff() {
         // Tests for zero attempts.
-        let mut backoff = NoJitterBackoff {
-            current_attempts: 0,
-            max_attempts: 0,
-            current_delay_ms: 0,
-            max_delay_ms: 0,
-        };
-
+        let mut backoff = Backoff::no_jitter_backoff(0, 0, 0);
         assert_eq!(backoff.next_delay_duration(), None);
 
-        let mut backoff = NoJitterBackoff {
-            current_attempts: 0,
-            max_attempts: 3,
-            current_delay_ms: 2,
-            max_delay_ms: 7,
-        };
-
+        let mut backoff = Backoff::no_jitter_backoff(2, 7, 3);
         assert_eq!(
             backoff.next_delay_duration(),
             Some(Duration::from_millis(2))
@@ -245,7 +207,7 @@ mod test {
 
     #[test]
     fn test_full_jitter_backoff() {
-        let mut backoff = FullJitterBackoff::new(2, 7, 3);
+        let mut backoff = Backoff::full_jitter_backoff(2, 7, 3);
         assert!(backoff.next_delay_duration().unwrap() <= Duration::from_millis(2));
         assert!(backoff.next_delay_duration().unwrap() <= Duration::from_millis(4));
         assert!(backoff.next_delay_duration().unwrap() <= Duration::from_millis(7));
@@ -255,18 +217,18 @@ mod test {
     #[test]
     #[should_panic(expected = "Both base_delay_ms and max_delay_ms must be positive")]
     fn test_full_jitter_backoff_with_invalid_base_delay_ms() {
-        FullJitterBackoff::new(0, 7, 3);
+        Backoff::full_jitter_backoff(0, 7, 3);
     }
 
     #[test]
     #[should_panic(expected = "Both base_delay_ms and max_delay_ms must be positive")]
     fn test_full_jitter_backoff_with_invalid_max_delay_ms() {
-        FullJitterBackoff::new(2, 0, 3);
+        Backoff::full_jitter_backoff(2, 0, 3);
     }
 
     #[test]
     fn test_equal_jitter_backoff() {
-        let mut backoff = EqualJitterBackoff::new(2, 7, 3);
+        let mut backoff = Backoff::equal_jitter_backoff(2, 7, 3);
 
         let first_delay_dur = backoff.next_delay_duration().unwrap();
         assert!(first_delay_dur >= Duration::from_millis(1));
@@ -286,18 +248,18 @@ mod test {
     #[test]
     #[should_panic(expected = "Both base_delay_ms and max_delay_ms must be greater than 1")]
     fn test_equal_jitter_backoff_with_invalid_base_delay_ms() {
-        EqualJitterBackoff::new(1, 7, 3);
+        Backoff::equal_jitter_backoff(1, 7, 3);
     }
 
     #[test]
     #[should_panic(expected = "Both base_delay_ms and max_delay_ms must be greater than 1")]
     fn test_equal_jitter_backoff_with_invalid_max_delay_ms() {
-        EqualJitterBackoff::new(2, 1, 3);
+        Backoff::equal_jitter_backoff(2, 1, 3);
     }
 
     #[test]
     fn test_decorrelated_jitter_backoff() {
-        let mut backoff = DecorrelatedJitterBackoff::new(2, 7, 3);
+        let mut backoff = Backoff::decorrelated_jitter_backoff(2, 7, 3);
 
         let first_delay_dur = backoff.next_delay_duration().unwrap();
         assert!(first_delay_dur >= Duration::from_millis(2));
@@ -319,6 +281,6 @@ mod test {
     #[test]
     #[should_panic(expected = "base_delay_ms must be positive")]
     fn test_decorrelated_jitter_backoff_with_invalid_base_delay_ms() {
-        DecorrelatedJitterBackoff::new(0, 7, 3);
+        Backoff::decorrelated_jitter_backoff(0, 7, 3);
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -27,7 +27,6 @@ pub struct Config {
     pub cert_path: Option<PathBuf>,
     pub key_path: Option<PathBuf>,
     pub timeout: Duration,
-    pub try_one_pc: bool,
 }
 
 const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(2);
@@ -39,7 +38,6 @@ impl Default for Config {
             cert_path: None,
             key_path: None,
             timeout: DEFAULT_REQUEST_TIMEOUT,
-            try_one_pc: false,
         }
     }
 }
@@ -79,11 +77,6 @@ impl Config {
     /// ```
     pub fn timeout(mut self, timeout: Duration) -> Self {
         self.timeout = timeout;
-        self
-    }
-
-    pub fn try_one_pc(mut self) -> Self {
-        self.try_one_pc = true;
         self
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,6 +99,8 @@ mod proptests;
 extern crate log;
 
 #[doc(inline)]
+pub use crate::backoff::Backoff;
+#[doc(inline)]
 pub use crate::kv::{BoundRange, Key, KvPair, ToOwnedRange, Value};
 #[doc(inline)]
 pub use crate::raw::{Client as RawClient, ColumnFamily};
@@ -106,6 +108,7 @@ pub use crate::raw::{Client as RawClient, ColumnFamily};
 pub use crate::timestamp::{Timestamp, TimestampExt};
 #[doc(inline)]
 pub use crate::transaction::{Client as TransactionClient, Snapshot, Transaction};
+#[doc(inline)]
 pub use config::Config;
 #[doc(inline)]
 pub use region::{Region, RegionId, RegionVerId, StoreId};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,7 +107,9 @@ pub use crate::raw::{Client as RawClient, ColumnFamily};
 #[doc(inline)]
 pub use crate::timestamp::{Timestamp, TimestampExt};
 #[doc(inline)]
-pub use crate::transaction::{Client as TransactionClient, Snapshot, Transaction};
+pub use crate::transaction::{
+    Client as TransactionClient, Snapshot, Transaction, TransactionOptions,
+};
 #[doc(inline)]
 pub use config::Config;
 #[doc(inline)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,6 +105,8 @@ pub use crate::kv::{BoundRange, Key, KvPair, ToOwnedRange, Value};
 #[doc(inline)]
 pub use crate::raw::{Client as RawClient, ColumnFamily};
 #[doc(inline)]
+pub use crate::request::RetryOptions;
+#[doc(inline)]
 pub use crate::timestamp::{Timestamp, TimestampExt};
 #[doc(inline)]
 pub use crate::transaction::{

--- a/src/raw/client.rs
+++ b/src/raw/client.rs
@@ -6,7 +6,7 @@ use super::requests;
 use crate::{
     config::Config,
     pd::PdRpcClient,
-    request::{KvRequest, OPTIMISTIC_BACKOFF},
+    request::{KvRequest, RetryOptions},
     BoundRange, ColumnFamily, Key, KvPair, Result, Value,
 };
 use std::{sync::Arc, u32};
@@ -111,7 +111,7 @@ impl Client {
     /// ```
     pub async fn get(&self, key: impl Into<Key>) -> Result<Option<Value>> {
         requests::new_raw_get_request(key, self.cf.clone())
-            .execute(self.rpc.clone(), OPTIMISTIC_BACKOFF)
+            .execute(self.rpc.clone(), RetryOptions::default_optimistic())
             .await
     }
 
@@ -138,7 +138,7 @@ impl Client {
         keys: impl IntoIterator<Item = impl Into<Key>>,
     ) -> Result<Vec<KvPair>> {
         requests::new_raw_batch_get_request(keys, self.cf.clone())
-            .execute(self.rpc.clone(), OPTIMISTIC_BACKOFF)
+            .execute(self.rpc.clone(), RetryOptions::default_optimistic())
             .await
     }
 
@@ -160,7 +160,7 @@ impl Client {
     /// ```
     pub async fn put(&self, key: impl Into<Key>, value: impl Into<Value>) -> Result<()> {
         requests::new_raw_put_request(key, value, self.cf.clone())
-            .execute(self.rpc.clone(), OPTIMISTIC_BACKOFF)
+            .execute(self.rpc.clone(), RetryOptions::default_optimistic())
             .await
     }
 
@@ -186,7 +186,7 @@ impl Client {
         pairs: impl IntoIterator<Item = impl Into<KvPair>>,
     ) -> Result<()> {
         requests::new_raw_batch_put_request(pairs, self.cf.clone())
-            .execute(self.rpc.clone(), OPTIMISTIC_BACKOFF)
+            .execute(self.rpc.clone(), RetryOptions::default_optimistic())
             .await
     }
 
@@ -209,7 +209,7 @@ impl Client {
     /// ```
     pub async fn delete(&self, key: impl Into<Key>) -> Result<()> {
         requests::new_raw_delete_request(key, self.cf.clone())
-            .execute(self.rpc.clone(), OPTIMISTIC_BACKOFF)
+            .execute(self.rpc.clone(), RetryOptions::default_optimistic())
             .await
     }
 
@@ -232,7 +232,7 @@ impl Client {
     /// ```
     pub async fn batch_delete(&self, keys: impl IntoIterator<Item = impl Into<Key>>) -> Result<()> {
         requests::new_raw_batch_delete_request(keys, self.cf.clone())
-            .execute(self.rpc.clone(), OPTIMISTIC_BACKOFF)
+            .execute(self.rpc.clone(), RetryOptions::default_optimistic())
             .await
     }
 
@@ -253,7 +253,7 @@ impl Client {
     /// ```
     pub async fn delete_range(&self, range: impl Into<BoundRange>) -> Result<()> {
         requests::new_raw_delete_range_request(range, self.cf.clone())
-            .execute(self.rpc.clone(), OPTIMISTIC_BACKOFF)
+            .execute(self.rpc.clone(), RetryOptions::default_optimistic())
             .await
     }
 
@@ -389,7 +389,7 @@ impl Client {
         }
 
         let res = requests::new_raw_scan_request(range, limit, key_only, self.cf.clone())
-            .execute(self.rpc.clone(), OPTIMISTIC_BACKOFF)
+            .execute(self.rpc.clone(), RetryOptions::default_optimistic())
             .await;
         res.map(|mut s| {
             s.truncate(limit as usize);
@@ -411,7 +411,7 @@ impl Client {
         }
 
         requests::new_raw_batch_scan_request(ranges, each_limit, key_only, self.cf.clone())
-            .execute(self.rpc.clone(), OPTIMISTIC_BACKOFF)
+            .execute(self.rpc.clone(), RetryOptions::default_optimistic())
             .await
     }
 }

--- a/src/raw/requests.rs
+++ b/src/raw/requests.rs
@@ -467,7 +467,7 @@ mod test {
     use super::*;
     use crate::{
         mock::{MockKvClient, MockPdClient},
-        request::OPTIMISTIC_BACKOFF,
+        request::RetryOptions,
     };
     use futures::executor;
     use std::any::Any;
@@ -502,7 +502,8 @@ mod test {
             key_only: true,
             ..Default::default()
         };
-        let scan = executor::block_on(scan.execute(client, OPTIMISTIC_BACKOFF)).unwrap();
+        let scan =
+            executor::block_on(scan.execute(client, RetryOptions::default_optimistic())).unwrap();
 
         assert_eq!(scan.len(), 10);
         // TODO test the keys returned.

--- a/src/request.rs
+++ b/src/request.rs
@@ -9,6 +9,7 @@ use crate::{
     BoundRange, Error, Key, Result,
 };
 use async_trait::async_trait;
+use derive_new::new;
 use futures::{prelude::*, stream::BoxStream};
 use std::{
     cmp::{max, min},
@@ -160,7 +161,7 @@ pub trait KvRequest: Request + Clone + Sync + Send + 'static + Sized {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, new, Eq, PartialEq)]
 pub struct RetryOptions {
     region_backoff: Backoff,
     lock_backoff: Backoff,

--- a/src/request.rs
+++ b/src/request.rs
@@ -165,7 +165,9 @@ pub trait KvRequest: Request + Clone + Sync + Send + 'static + Sized {
 
 #[derive(Clone, Debug, new, Eq, PartialEq)]
 pub struct RetryOptions {
+    /// How to retry when there is a region error and we need to resolve regions with PD.
     pub region_backoff: Backoff,
+    /// How to retry when a key is locked.
     pub lock_backoff: Backoff,
 }
 

--- a/src/transaction/client.rs
+++ b/src/transaction/client.rs
@@ -4,7 +4,7 @@ use super::{requests::new_scan_lock_request, resolve_locks};
 use crate::{
     config::Config,
     pd::{PdClient, PdRpcClient},
-    request::{KvRequest, OPTIMISTIC_BACKOFF},
+    request::{KvRequest, RetryOptions},
     timestamp::TimestampExt,
     transaction::{Snapshot, Transaction, TransactionOptions},
     Result,
@@ -183,8 +183,9 @@ impl Client {
                 safepoint.clone(),
                 SCAN_LOCK_BATCH_SIZE,
             );
-            let res: Vec<kvrpcpb::LockInfo> =
-                req.execute(self.pd.clone(), OPTIMISTIC_BACKOFF).await?;
+            let res: Vec<kvrpcpb::LockInfo> = req
+                .execute(self.pd.clone(), RetryOptions::default_optimistic())
+                .await?;
             if res.is_empty() {
                 break;
             }

--- a/src/transaction/mod.rs
+++ b/src/transaction/mod.rs
@@ -11,8 +11,7 @@
 pub use client::Client;
 pub(crate) use lock::{resolve_locks, HasLocks};
 pub use snapshot::Snapshot;
-pub use transaction::Transaction;
-use transaction::TransactionOptions;
+pub use transaction::{Transaction, TransactionOptions};
 
 mod buffer;
 mod client;

--- a/src/transaction/mod.rs
+++ b/src/transaction/mod.rs
@@ -12,7 +12,7 @@ pub use client::Client;
 pub(crate) use lock::{resolve_locks, HasLocks};
 pub use snapshot::Snapshot;
 pub use transaction::Transaction;
-use transaction::TransactionStyle;
+use transaction::TransactionOptions;
 
 mod buffer;
 mod client;

--- a/src/transaction/requests.rs
+++ b/src/transaction/requests.rs
@@ -1,9 +1,11 @@
 // Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
 
 use crate::{
-    backoff::Backoff,
     pd::PdClient,
-    request::{store_stream_for_key, store_stream_for_keys, store_stream_for_range, KvRequest},
+    request::{
+        store_stream_for_key, store_stream_for_keys, store_stream_for_range, KvRequest,
+        RetryOptions,
+    },
     store::Store,
     timestamp::TimestampExt,
     transaction::HasLocks,
@@ -201,8 +203,7 @@ impl KvRequest for kvrpcpb::ResolveLockRequest {
         self,
         region_error: Error,
         _pd_client: Arc<impl PdClient>,
-        _region_backoff: impl Backoff,
-        _lock_backoff: impl Backoff,
+        _: RetryOptions,
     ) -> BoxStream<'static, Result<Self::RpcResponse>> {
         stream::once(future::err(region_error)).boxed()
     }

--- a/src/transaction/transaction.rs
+++ b/src/transaction/transaction.rs
@@ -579,11 +579,15 @@ impl TransactionOptions {
         self
     }
 
-    pub fn no_retry(self) -> TransactionOptions {
-        self.retry_options(RetryOptions::new(
-            Backoff::no_backoff(),
-            Backoff::no_backoff(),
-        ))
+    pub fn no_resolve_locks(mut self) -> TransactionOptions {
+        self.retry_options.auto_resolve_locks = false;
+        self
+    }
+
+    pub fn no_retry(mut self) -> TransactionOptions {
+        self.retry_options.region_backoff = Backoff::no_backoff();
+        self.retry_options.lock_backoff = Backoff::no_backoff();
+        self
     }
 
     pub fn retry_options(mut self, options: RetryOptions) -> TransactionOptions {

--- a/src/transaction/transaction.rs
+++ b/src/transaction/transaction.rs
@@ -579,7 +579,7 @@ impl TransactionOptions {
     }
 
     /// Try to use async commit.
-    pub fn async_commit(mut self) -> TransactionOptions {
+    pub fn use_async_commit(mut self) -> TransactionOptions {
         self.async_commit = true;
         self
     }

--- a/src/transaction/transaction.rs
+++ b/src/transaction/transaction.rs
@@ -402,7 +402,7 @@ impl Transaction {
         }
         self.status = TransactionStatus::StartedCommit;
 
-        let res = TwoPhaseCommitter::new(
+        let res = Committer::new(
             self.buffer.to_proto_mutations().await,
             self.timestamp.version(),
             self.bg_worker.clone(),
@@ -430,7 +430,7 @@ impl Transaction {
         }
         self.status = TransactionStatus::StartedRollback;
 
-        let res = TwoPhaseCommitter::new(
+        let res = Committer::new(
             self.buffer.to_proto_mutations().await,
             self.timestamp.version(),
             self.bg_worker.clone(),
@@ -596,7 +596,7 @@ const DEFAULT_LOCK_TTL: u64 = 3000;
 ///
 /// The committer implements `prewrite`, `commit` and `rollback` functions.
 #[derive(new)]
-struct TwoPhaseCommitter {
+struct Committer {
     mutations: Vec<kvrpcpb::Mutation>,
     start_version: u64,
     bg_worker: ThreadPool,
@@ -606,7 +606,7 @@ struct TwoPhaseCommitter {
     undetermined: bool,
 }
 
-impl TwoPhaseCommitter {
+impl Committer {
     async fn commit(mut self) -> Result<u64> {
         if self.mutations.is_empty() {
             return Ok(0);

--- a/src/transaction/transaction.rs
+++ b/src/transaction/transaction.rs
@@ -584,6 +584,11 @@ impl TransactionOptions {
         self
     }
 
+    pub fn no_resolve_regions(mut self) -> TransactionOptions {
+        self.retry_options.auto_resolve_regions = false;
+        self
+    }
+
     pub fn no_retry(mut self) -> TransactionOptions {
         self.retry_options.region_backoff = Backoff::no_backoff();
         self.retry_options.lock_backoff = Backoff::no_backoff();

--- a/src/transaction/transaction.rs
+++ b/src/transaction/transaction.rs
@@ -580,18 +580,12 @@ impl TransactionOptions {
     }
 
     pub fn no_resolve_locks(mut self) -> TransactionOptions {
-        self.retry_options.auto_resolve_locks = false;
+        self.retry_options.lock_backoff = Backoff::no_backoff();
         self
     }
 
     pub fn no_resolve_regions(mut self) -> TransactionOptions {
-        self.retry_options.auto_resolve_regions = false;
-        self
-    }
-
-    pub fn no_retry(mut self) -> TransactionOptions {
         self.retry_options.region_backoff = Backoff::no_backoff();
-        self.retry_options.lock_backoff = Backoff::no_backoff();
         self
     }
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -55,7 +55,7 @@ async fn crud() -> Result<()> {
     clear_tikv().await?;
 
     let client = TransactionClient::new(pd_addrs()).await?;
-    let mut txn = client.begin().await?;
+    let mut txn = client.begin_optimistic().await?;
 
     // Get non-existent keys
     assert!(txn.get("foo".to_owned()).await?.is_none());
@@ -91,7 +91,7 @@ async fn crud() -> Result<()> {
     txn.commit().await?;
 
     // Read from TiKV then update and delete
-    let mut txn = client.begin().await?;
+    let mut txn = client.begin_optimistic().await?;
     assert_eq!(
         txn.get("foo".to_owned()).await?,
         Some("bar".to_owned().into())
@@ -199,13 +199,13 @@ async fn txn_write_million() -> Result<()> {
         .map(|u| u.to_be_bytes().to_vec())
         .take(2usize.pow(NUM_BITS_KEY_PER_TXN))
         .collect::<Vec<_>>(); // each txn puts 2 ^ 12 keys. 12 = 25 - 13
-        let mut txn = client.begin().await?;
+        let mut txn = client.begin_optimistic().await?;
         for (k, v) in keys.iter().zip(iter::repeat(1u32.to_be_bytes().to_vec())) {
             txn.put(k.clone(), v).await?;
         }
         txn.commit().await?;
 
-        let mut txn = client.begin().await?;
+        let mut txn = client.begin_optimistic().await?;
         let res = txn.batch_get(keys).await?;
         assert_eq!(res.count(), 2usize.pow(NUM_BITS_KEY_PER_TXN));
         txn.commit().await?;
@@ -258,7 +258,7 @@ async fn txn_bank_transfer() -> Result<()> {
     let mut rng = thread_rng();
 
     let people = gen_u32_keys(NUM_PEOPLE, &mut rng);
-    let mut txn = client.begin().await?;
+    let mut txn = client.begin_optimistic().await?;
     let mut sum: u32 = 0;
     for person in &people {
         let init = rng.gen::<u8>() as u32;
@@ -269,7 +269,7 @@ async fn txn_bank_transfer() -> Result<()> {
 
     // transfer
     for _ in 0..NUM_TRNASFER {
-        let mut txn = client.begin().await?;
+        let mut txn = client.begin_optimistic().await?;
         txn.use_async_commit();
         let chosen_people = people.iter().choose_multiple(&mut rng, 2);
         let alice = chosen_people[0];
@@ -291,7 +291,7 @@ async fn txn_bank_transfer() -> Result<()> {
 
     // check
     let mut new_sum = 0;
-    let mut txn = client.begin().await?;
+    let mut txn = client.begin_optimistic().await?;
     for person in people.iter() {
         new_sum += get_txn_u32(&txn, person.clone()).await?;
     }


### PR DESCRIPTION
The goal here is to make it easier for users to have more control over transactions if they want it, without adding boilerplate to the common path. It also polishes our API a little in a general way, e.g., not prioriitising optimistic transactions over pessimistic ones (since the latter are usually the better default).

It's mostly useful to read the commits individually, but the three commits which add retry options are significantly refactored in the penultimate commit.

PTAL @andylokandy @ekexium 