### PR TITLE
 CI: use nightly TiKV and PD images and run examples

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,3 +52,6 @@ script:
   - if [[ $TRAVIS_OS_NAME == "linux" && $TRAVIS_RUST_VERSION == "nightly" ]]; then docker logs pd; fi
   - if [[ $TRAVIS_OS_NAME == "linux" && $TRAVIS_RUST_VERSION == "nightly" ]]; then docker logs kv; fi
   - if [[ $TRAVIS_OS_NAME == "linux" && $TRAVIS_RUST_VERSION == "nightly" ]]; then PD_ADDRS="127.0.0.1:2379" cargo test --all --features integration-tests -- --nocapture; fi
+  - if [[ $TRAVIS_OS_NAME == "linux" && $TRAVIS_RUST_VERSION == "nightly" ]]; then cargo run --example raw -- --pd="127.0.0.1:2379"; fi
+  - if [[ $TRAVIS_OS_NAME == "linux" && $TRAVIS_RUST_VERSION == "nightly" ]]; then cargo run --example transaction -- --pd="127.0.0.1:2379"; fi
+  - if [[ $TRAVIS_OS_NAME == "linux" && $TRAVIS_RUST_VERSION == "nightly" ]]; then cargo run --example pessimistic -- --pd="127.0.0.1:2379"; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,8 +46,8 @@ script:
   # For now we only run full integration tests on Linux. Here's why:
   # * Docker on OS X is not supported by Travis.
   # * Docker on Windows seems to not have the correct binary at `"/c/Program Files/Docker/Docker/DockerCli.exe" to switch it to Linux containers.
-  - if [[ $TRAVIS_OS_NAME == "linux" && $TRAVIS_RUST_VERSION == "nightly" ]]; then docker run -d --net=host --name pd --rm pingcap/pd:latest --name "pd" --data-dir "pd" --client-urls "http://127.0.0.1:2379" --advertise-client-urls "http://127.0.0.1:2379"; fi
-  - if [[ $TRAVIS_OS_NAME == "linux" && $TRAVIS_RUST_VERSION == "nightly" ]]; then docker run -d --net=host --name kv --rm --ulimit nofile=90000:90000 pingcap/tikv:latest --pd-endpoints "127.0.0.1:2379" --addr "127.0.0.1:2378" --data-dir "kv"; fi
+  - if [[ $TRAVIS_OS_NAME == "linux" && $TRAVIS_RUST_VERSION == "nightly" ]]; then docker run -d --net=host --name pd --rm pingcap/pd:nightly --name "pd" --data-dir "pd" --client-urls "http://127.0.0.1:2379" --advertise-client-urls "http://127.0.0.1:2379"; fi
+  - if [[ $TRAVIS_OS_NAME == "linux" && $TRAVIS_RUST_VERSION == "nightly" ]]; then docker run -d --net=host --name kv --rm --ulimit nofile=90000:90000 pingcap/tikv:nightly --pd-endpoints "127.0.0.1:2379" --addr "127.0.0.1:2378" --data-dir "kv"; fi
   - if [[ $TRAVIS_OS_NAME == "linux" && $TRAVIS_RUST_VERSION == "nightly" ]]; then docker ps; fi
   - if [[ $TRAVIS_OS_NAME == "linux" && $TRAVIS_RUST_VERSION == "nightly" ]]; then docker logs pd; fi
   - if [[ $TRAVIS_OS_NAME == "linux" && $TRAVIS_RUST_VERSION == "nightly" ]]; then docker logs kv; fi

--- a/examples/pessimistic.rs
+++ b/examples/pessimistic.rs
@@ -58,7 +58,10 @@ async fn main() {
     let value3: Value = b"value3".to_vec();
     txn1.put(key1.clone(), value3).await.unwrap();
     txn1.commit().await.unwrap();
-    let txn3 = client.begin().await.expect("Could not begin a transaction");
+    let mut txn3 = client.begin().await.expect("Could not begin a transaction");
     let result = txn3.get(key1.clone()).await.unwrap().unwrap();
+    txn3.commit()
+        .await
+        .expect("Committing read-only transaction should not fail");
     println!("{:?}", (key1, result));
 }

--- a/examples/transaction.rs
+++ b/examples/transaction.rs
@@ -15,8 +15,12 @@ async fn puts(client: &Client, pairs: impl IntoIterator<Item = impl Into<KvPair>
 }
 
 async fn get(client: &Client, key: Key) -> Option<Value> {
-    let txn = client.begin().await.expect("Could not begin a transaction");
-    txn.get(key).await.expect("Could not get value")
+    let mut txn = client.begin().await.expect("Could not begin a transaction");
+    let res = txn.get(key).await.expect("Could not get value");
+    txn.commit()
+        .await
+        .expect("Committing read-only transaction should not fail");
+    res
 }
 
 async fn scan(client: &Client, range: impl Into<BoundRange>, limit: u32) {

--- a/tikv-client-store/src/request.rs
+++ b/tikv-client-store/src/request.rs
@@ -27,7 +27,7 @@ macro_rules! impl_request {
                     .$fun(self, options)?
                     .await
                     .map(|r| Box::new(r) as Box<dyn Any>)
-                    .map_err(|e| Error::Grpc(e))
+                    .map_err(Error::Grpc)
             }
 
             fn label(&self) -> &'static str {


### PR DESCRIPTION
We started to use the `latest` channel in #181, now it's time to use `nightly` since we are implementing async commit.

We should also run examples in CI to make sure they are up-to-date when making breaking changes.