### PR TITLE
Refactor: fix nightly cargo clippy

### DIFF
--- a/examples/raw.rs
+++ b/examples/raw.rs
@@ -5,7 +5,7 @@
 mod common;
 
 use crate::common::parse_args;
-use tikv_client::{Config, Key, KvPair, RawClient as Client, Result, ToOwnedRange, Value};
+use tikv_client::{Config, IntoOwnedRange, Key, KvPair, RawClient as Client, Result, Value};
 
 const KEY: &str = "TiKV";
 const VALUE: &str = "Rust";
@@ -86,7 +86,7 @@ async fn main() -> Result<()> {
     let start = "k1";
     let end = "k2";
     let pairs = client
-        .scan((start..=end).to_owned(), 10)
+        .scan((start..=end).into_owned(), 10)
         .await
         .expect("Could not scan");
 

--- a/src/kv/key.rs
+++ b/src/kv/key.rs
@@ -140,15 +140,15 @@ impl From<String> for Key {
     }
 }
 
-impl Into<Vec<u8>> for Key {
-    fn into(self) -> Vec<u8> {
-        self.0
+impl From<Key> for Vec<u8> {
+    fn from(key: Key) -> Self {
+        key.0
     }
 }
 
-impl<'a> Into<&'a [u8]> for &'a Key {
-    fn into(self) -> &'a [u8] {
-        &self.0
+impl<'a> From<&'a Key> for &'a [u8] {
+    fn from(key: &'a Key) -> Self {
+        &key.0
     }
 }
 

--- a/src/kv/kvpair.rs
+++ b/src/kv/kvpair.rs
@@ -90,9 +90,9 @@ where
     }
 }
 
-impl Into<(Key, Value)> for KvPair {
-    fn into(self) -> (Key, Value) {
-        (self.0, self.1)
+impl From<KvPair> for (Key, Value) {
+    fn from(pair: KvPair) -> Self {
+        (pair.0, pair.1)
     }
 }
 
@@ -102,10 +102,10 @@ impl From<kvrpcpb::KvPair> for KvPair {
     }
 }
 
-impl Into<kvrpcpb::KvPair> for KvPair {
-    fn into(self) -> kvrpcpb::KvPair {
+impl From<KvPair> for kvrpcpb::KvPair {
+    fn from(pair: KvPair) -> Self {
         let mut result = kvrpcpb::KvPair::default();
-        let (key, value) = self.into();
+        let (key, value) = pair.into();
         result.set_key(key.into());
         result.set_value(value);
         result

--- a/src/kv/mod.rs
+++ b/src/kv/mod.rs
@@ -7,7 +7,7 @@ mod key;
 mod kvpair;
 mod value;
 
-pub use bound_range::{BoundRange, ToOwnedRange};
+pub use bound_range::{BoundRange, IntoOwnedRange};
 pub use key::Key;
 pub use kvpair::KvPair;
 pub use value::Value;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,7 +101,7 @@ extern crate log;
 #[doc(inline)]
 pub use crate::backoff::Backoff;
 #[doc(inline)]
-pub use crate::kv::{BoundRange, Key, KvPair, ToOwnedRange, Value};
+pub use crate::kv::{BoundRange, IntoOwnedRange, Key, KvPair, Value};
 #[doc(inline)]
 pub use crate::raw::{Client as RawClient, ColumnFamily};
 #[doc(inline)]

--- a/src/raw/client.rs
+++ b/src/raw/client.rs
@@ -170,7 +170,7 @@ impl Client {
     ///
     /// # Examples
     /// ```rust,no_run
-    /// # use tikv_client::{Result, KvPair, Key, Value, Config, RawClient, ToOwnedRange};
+    /// # use tikv_client::{Result, KvPair, Key, Value, Config, RawClient, IntoOwnedRange};
     /// # use futures::prelude::*;
     /// # futures::executor::block_on(async {
     /// # let client = RawClient::new(vec!["192.168.0.100"]).await.unwrap();
@@ -242,12 +242,12 @@ impl Client {
     ///
     /// # Examples
     /// ```rust,no_run
-    /// # use tikv_client::{Key, Config, RawClient, ToOwnedRange};
+    /// # use tikv_client::{Key, Config, RawClient, IntoOwnedRange};
     /// # use futures::prelude::*;
     /// # futures::executor::block_on(async {
     /// # let client = RawClient::new(vec!["192.168.0.100"]).await.unwrap();
     /// let inclusive_range = "TiKV"..="TiDB";
-    /// let req = client.delete_range(inclusive_range.to_owned());
+    /// let req = client.delete_range(inclusive_range.into_owned());
     /// let result: () = req.await.unwrap();
     /// # });
     /// ```
@@ -267,12 +267,12 @@ impl Client {
     ///
     /// # Examples
     /// ```rust,no_run
-    /// # use tikv_client::{KvPair, Config, RawClient, ToOwnedRange};
+    /// # use tikv_client::{KvPair, Config, RawClient, IntoOwnedRange};
     /// # use futures::prelude::*;
     /// # futures::executor::block_on(async {
     /// # let client = RawClient::new(vec!["192.168.0.100"]).await.unwrap();
     /// let inclusive_range = "TiKV"..="TiDB";
-    /// let req = client.scan(inclusive_range.to_owned(), 2);
+    /// let req = client.scan(inclusive_range.into_owned(), 2);
     /// let result: Vec<KvPair> = req.await.unwrap();
     /// # });
     /// ```
@@ -290,12 +290,12 @@ impl Client {
     ///
     /// # Examples
     /// ```rust,no_run
-    /// # use tikv_client::{Key, Config, RawClient, ToOwnedRange};
+    /// # use tikv_client::{Key, Config, RawClient, IntoOwnedRange};
     /// # use futures::prelude::*;
     /// # futures::executor::block_on(async {
     /// # let client = RawClient::new(vec!["192.168.0.100"]).await.unwrap();
     /// let inclusive_range = "TiKV"..="TiDB";
-    /// let req = client.scan_keys(inclusive_range.to_owned(), 2);
+    /// let req = client.scan_keys(inclusive_range.into_owned(), 2);
     /// let result: Vec<Key> = req.await.unwrap();
     /// # });
     /// ```
@@ -320,13 +320,13 @@ impl Client {
     ///
     /// # Examples
     /// ```rust,no_run
-    /// # use tikv_client::{Key, Config, RawClient, ToOwnedRange};
+    /// # use tikv_client::{Key, Config, RawClient, IntoOwnedRange};
     /// # use futures::prelude::*;
     /// # futures::executor::block_on(async {
     /// # let client = RawClient::new(vec!["192.168.0.100"]).await.unwrap();
     /// let inclusive_range1 = "TiDB"..="TiKV";
     /// let inclusive_range2 = "TiKV"..="TiSpark";
-    /// let iterable = vec![inclusive_range1.to_owned(), inclusive_range2.to_owned()];
+    /// let iterable = vec![inclusive_range1.into_owned(), inclusive_range2.into_owned()];
     /// let req = client.batch_scan(iterable, 2);
     /// let result = req.await;
     /// # });
@@ -351,13 +351,13 @@ impl Client {
     ///
     /// # Examples
     /// ```rust,no_run
-    /// # use tikv_client::{Key, Config, RawClient, ToOwnedRange};
+    /// # use tikv_client::{Key, Config, RawClient, IntoOwnedRange};
     /// # use futures::prelude::*;
     /// # futures::executor::block_on(async {
     /// # let client = RawClient::new(vec!["192.168.0.100"]).await.unwrap();
     /// let inclusive_range1 = "TiDB"..="TiKV";
     /// let inclusive_range2 = "TiKV"..="TiSpark";
-    /// let iterable = vec![inclusive_range1.to_owned(), inclusive_range2.to_owned()];
+    /// let iterable = vec![inclusive_range1.into_owned(), inclusive_range2.into_owned()];
     /// let req = client.batch_scan(iterable, 2);
     /// let result = req.await;
     /// # });


### PR DESCRIPTION
Fix nightly clippy

Changes:
- Convert some `Into` to `From`
- Rename `ToOwnedRange::to_owned(self)` to `IntoOwnedRange::into_owned(self)`