### PR TITLE
Fix HasError and HasLocks

### DIFF
--- a/src/raw/client.rs
+++ b/src/raw/client.rs
@@ -179,6 +179,7 @@ impl Client {
             .await?
             .resolve_lock(OPTIMISTIC_BACKOFF)
             .retry_region(DEFAULT_REGION_BACKOFF)
+            .propagate_error()
             .plan();
         plan.execute().await?;
         Ok(())
@@ -210,6 +211,7 @@ impl Client {
             .resolve_lock(OPTIMISTIC_BACKOFF)
             .multi_region()
             .retry_region(DEFAULT_REGION_BACKOFF)
+            .propagate_error()
             .plan();
         plan.execute().await?;
         Ok(())
@@ -239,6 +241,7 @@ impl Client {
             .await?
             .resolve_lock(OPTIMISTIC_BACKOFF)
             .retry_region(DEFAULT_REGION_BACKOFF)
+            .propagate_error()
             .plan();
         plan.execute().await?;
         Ok(())
@@ -268,6 +271,7 @@ impl Client {
             .resolve_lock(OPTIMISTIC_BACKOFF)
             .multi_region()
             .retry_region(DEFAULT_REGION_BACKOFF)
+            .propagate_error()
             .plan();
         plan.execute().await?;
         Ok(())
@@ -294,6 +298,7 @@ impl Client {
             .resolve_lock(OPTIMISTIC_BACKOFF)
             .multi_region()
             .retry_region(DEFAULT_REGION_BACKOFF)
+            .propagate_error()
             .plan();
         plan.execute().await?;
         Ok(())

--- a/src/raw/client.rs
+++ b/src/raw/client.rs
@@ -179,7 +179,7 @@ impl Client {
             .await?
             .resolve_lock(OPTIMISTIC_BACKOFF)
             .retry_region(DEFAULT_REGION_BACKOFF)
-            .propagate_error()
+            .extract_error()
             .plan();
         plan.execute().await?;
         Ok(())
@@ -211,7 +211,7 @@ impl Client {
             .resolve_lock(OPTIMISTIC_BACKOFF)
             .multi_region()
             .retry_region(DEFAULT_REGION_BACKOFF)
-            .propagate_error()
+            .extract_error()
             .plan();
         plan.execute().await?;
         Ok(())
@@ -241,7 +241,7 @@ impl Client {
             .await?
             .resolve_lock(OPTIMISTIC_BACKOFF)
             .retry_region(DEFAULT_REGION_BACKOFF)
-            .propagate_error()
+            .extract_error()
             .plan();
         plan.execute().await?;
         Ok(())
@@ -271,7 +271,7 @@ impl Client {
             .resolve_lock(OPTIMISTIC_BACKOFF)
             .multi_region()
             .retry_region(DEFAULT_REGION_BACKOFF)
-            .propagate_error()
+            .extract_error()
             .plan();
         plan.execute().await?;
         Ok(())
@@ -298,7 +298,7 @@ impl Client {
             .resolve_lock(OPTIMISTIC_BACKOFF)
             .multi_region()
             .retry_region(DEFAULT_REGION_BACKOFF)
-            .propagate_error()
+            .extract_error()
             .plan();
         plan.execute().await?;
         Ok(())

--- a/src/request/mod.rs
+++ b/src/request/mod.rs
@@ -10,8 +10,8 @@ use tikv_client_store::{HasError, Request};
 
 pub use self::{
     plan::{
-        Collect, CollectError, DefaultProcessor, Dispatch, Merge, MergeResponse, MultiRegion, Plan,
-        Process, ProcessResponse, PropagateError, ResolveLock, RetryRegion,
+        Collect, CollectError, DefaultProcessor, Dispatch, ExtractError, Merge, MergeResponse,
+        MultiRegion, Plan, Process, ProcessResponse, ResolveLock, RetryRegion,
     },
     plan_builder::{PlanBuilder, SingleKey},
     shard::Shardable,
@@ -167,7 +167,7 @@ mod test {
             .resolve_lock(Backoff::no_jitter_backoff(1, 1, 3))
             .multi_region()
             .retry_region(Backoff::no_jitter_backoff(1, 1, 3))
-            .propagate_error()
+            .extract_error()
             .plan();
         let _ = executor::block_on(async { plan.execute().await });
 

--- a/src/request/mod.rs
+++ b/src/request/mod.rs
@@ -167,6 +167,7 @@ mod test {
             .resolve_lock(Backoff::no_jitter_backoff(1, 1, 3))
             .multi_region()
             .retry_region(Backoff::no_jitter_backoff(1, 1, 3))
+            .propagate_error()
             .plan();
         let _ = executor::block_on(async { plan.execute().await });
 

--- a/src/request/mod.rs
+++ b/src/request/mod.rs
@@ -11,7 +11,7 @@ use tikv_client_store::{HasError, Request};
 pub use self::{
     plan::{
         Collect, CollectError, DefaultProcessor, Dispatch, Merge, MergeResponse, MultiRegion, Plan,
-        Process, ProcessResponse, ResolveLock, RetryRegion,
+        Process, ProcessResponse, PropagateError, ResolveLock, RetryRegion,
     },
     plan_builder::{PlanBuilder, SingleKey},
     shard::Shardable,

--- a/src/request/plan.rs
+++ b/src/request/plan.rs
@@ -261,6 +261,11 @@ impl<P: Plan> Clone for ExtractError<P> {
     }
 }
 
+/// When executed, the plan extracts errors from its inner plan, and
+/// returns an `Err` wrapping the error.
+///
+/// The errors come from two places: `Err` from inner plans, and `Ok(response)`
+/// where `response` contains unresolved errors.
 #[async_trait]
 impl<P: Plan> Plan for ExtractError<P>
 where

--- a/src/request/plan.rs
+++ b/src/request/plan.rs
@@ -265,7 +265,7 @@ impl<P: Plan> Clone for ExtractError<P> {
 /// returns an `Err` wrapping the error.
 ///
 /// The errors come from two places: `Err` from inner plans, and `Ok(response)`
-/// where `response` contains unresolved errors.
+/// where `response` contains unresolved errors (`error` and `region_error`).
 #[async_trait]
 impl<P: Plan> Plan for ExtractError<P>
 where
@@ -276,6 +276,8 @@ where
     async fn execute(&self) -> Result<Self::Result> {
         let mut result = self.inner.execute().await?;
         if let Some(error) = result.error() {
+            Err(error)
+        } else if let Some(error) = result.region_error() {
             Err(error)
         } else {
             Ok(result)

--- a/src/request/plan.rs
+++ b/src/request/plan.rs
@@ -249,20 +249,20 @@ where
     }
 }
 
-pub struct PropagateError<P: Plan> {
+pub struct ExtractError<P: Plan> {
     pub inner: P,
 }
 
-impl<P: Plan> Clone for PropagateError<P> {
+impl<P: Plan> Clone for ExtractError<P> {
     fn clone(&self) -> Self {
-        PropagateError {
+        ExtractError {
             inner: self.inner.clone(),
         }
     }
 }
 
 #[async_trait]
-impl<P: Plan> Plan for PropagateError<P>
+impl<P: Plan> Plan for ExtractError<P>
 where
     P::Result: HasError,
 {

--- a/src/request/plan_builder.rs
+++ b/src/request/plan_builder.rs
@@ -4,8 +4,8 @@ use crate::{
     backoff::Backoff,
     pd::PdClient,
     request::{
-        DefaultProcessor, Dispatch, KvRequest, Merge, MergeResponse, MultiRegion, Plan, Process,
-        ProcessResponse, PropagateError, ResolveLock, RetryRegion, Shardable,
+        DefaultProcessor, Dispatch, ExtractError, KvRequest, Merge, MergeResponse, MultiRegion,
+        Plan, Process, ProcessResponse, ResolveLock, RetryRegion, Shardable,
     },
     store::Store,
     transaction::HasLocks,
@@ -165,10 +165,10 @@ impl<PdC: PdClient, P: Plan> PlanBuilder<PdC, P, Targetted>
 where
     P::Result: HasError,
 {
-    pub fn propagate_error(self) -> PlanBuilder<PdC, PropagateError<P>, Targetted> {
+    pub fn extract_error(self) -> PlanBuilder<PdC, ExtractError<P>, Targetted> {
         PlanBuilder {
             pd_client: self.pd_client,
-            plan: PropagateError { inner: self.plan },
+            plan: ExtractError { inner: self.plan },
             phantom: self.phantom,
         }
     }

--- a/src/transaction/lock.rs
+++ b/src/transaction/lock.rs
@@ -104,6 +104,7 @@ async fn resolve_lock_with_retry(
             .await?
             .resolve_lock(Backoff::no_backoff())
             .retry_region(Backoff::no_backoff())
+            .propagate_error()
             .plan();
         match plan.execute().await {
             Ok(_) => {

--- a/src/transaction/lock.rs
+++ b/src/transaction/lock.rs
@@ -104,7 +104,7 @@ async fn resolve_lock_with_retry(
             .await?
             .resolve_lock(Backoff::no_backoff())
             .retry_region(Backoff::no_backoff())
-            .propagate_error()
+            .extract_error()
             .plan();
         match plan.execute().await {
             Ok(_) => {

--- a/src/transaction/requests.rs
+++ b/src/transaction/requests.rs
@@ -79,10 +79,18 @@ impl Merge<kvrpcpb::BatchGetResponse> for Collect {
 
 impl HasLocks for kvrpcpb::BatchGetResponse {
     fn take_locks(&mut self) -> Vec<kvrpcpb::LockInfo> {
-        self.pairs
-            .iter_mut()
-            .filter_map(|pair| pair.error.as_mut().and_then(|error| error.locked.take()))
-            .collect()
+        if self.pairs.is_empty() {
+            self.error
+                .as_mut()
+                .and_then(|error| error.locked.take())
+                .into_iter()
+                .collect()
+        } else {
+            self.pairs
+                .iter_mut()
+                .filter_map(|pair| pair.error.as_mut().and_then(|error| error.locked.take()))
+                .collect()
+        }
     }
 }
 
@@ -121,10 +129,18 @@ impl Merge<kvrpcpb::ScanResponse> for Collect {
 
 impl HasLocks for kvrpcpb::ScanResponse {
     fn take_locks(&mut self) -> Vec<kvrpcpb::LockInfo> {
-        self.pairs
-            .iter_mut()
-            .filter_map(|pair| pair.error.as_mut().and_then(|error| error.locked.take()))
-            .collect()
+        if self.pairs.is_empty() {
+            self.error
+                .as_mut()
+                .and_then(|error| error.locked.take())
+                .into_iter()
+                .collect()
+        } else {
+            self.pairs
+                .iter_mut()
+                .filter_map(|pair| pair.error.as_mut().and_then(|error| error.locked.take()))
+                .collect()
+        }
     }
 }
 
@@ -547,13 +563,82 @@ pub struct SecondaryLocksStatus {
     pub commit_ts: Option<Timestamp>,
 }
 
-impl HasLocks for kvrpcpb::CommitResponse {}
+impl HasLocks for kvrpcpb::CommitResponse {
+    fn take_locks(&mut self) -> Vec<kvrpcpb::LockInfo> {
+        self.error
+            .as_mut()
+            .and_then(|error| error.locked.take())
+            .into_iter()
+            .collect()
+    }
+}
+
+impl HasLocks for kvrpcpb::BatchRollbackResponse {
+    fn take_locks(&mut self) -> Vec<kvrpcpb::LockInfo> {
+        self.error
+            .as_mut()
+            .and_then(|error| error.locked.take())
+            .into_iter()
+            .collect()
+    }
+}
+impl HasLocks for kvrpcpb::PessimisticRollbackResponse {
+    fn take_locks(&mut self) -> Vec<kvrpcpb::LockInfo> {
+        self.errors
+            .iter_mut()
+            .filter_map(|error| error.locked.take())
+            .collect()
+    }
+}
+
+impl HasLocks for kvrpcpb::ResolveLockResponse {
+    fn take_locks(&mut self) -> Vec<kvrpcpb::LockInfo> {
+        self.error
+            .as_mut()
+            .and_then(|error| error.locked.take())
+            .into_iter()
+            .collect()
+    }
+}
+
+impl HasLocks for kvrpcpb::PessimisticLockResponse {
+    fn take_locks(&mut self) -> Vec<kvrpcpb::LockInfo> {
+        self.errors
+            .iter_mut()
+            .filter_map(|error| error.locked.take())
+            .collect()
+    }
+}
+
+impl HasLocks for kvrpcpb::TxnHeartBeatResponse {
+    fn take_locks(&mut self) -> Vec<kvrpcpb::LockInfo> {
+        self.error
+            .as_mut()
+            .and_then(|error| error.locked.take())
+            .into_iter()
+            .collect()
+    }
+}
+
+impl HasLocks for kvrpcpb::CheckTxnStatusResponse {
+    fn take_locks(&mut self) -> Vec<kvrpcpb::LockInfo> {
+        self.error
+            .as_mut()
+            .and_then(|error| error.locked.take())
+            .into_iter()
+            .collect()
+    }
+}
+
+impl HasLocks for kvrpcpb::CheckSecondaryLocksResponse {
+    fn take_locks(&mut self) -> Vec<kvrpcpb::LockInfo> {
+        self.error
+            .as_mut()
+            .and_then(|error| error.locked.take())
+            .into_iter()
+            .collect()
+    }
+}
+
 impl HasLocks for kvrpcpb::CleanupResponse {}
-impl HasLocks for kvrpcpb::BatchRollbackResponse {}
-impl HasLocks for kvrpcpb::PessimisticRollbackResponse {}
-impl HasLocks for kvrpcpb::ResolveLockResponse {}
 impl HasLocks for kvrpcpb::ScanLockResponse {}
-impl HasLocks for kvrpcpb::PessimisticLockResponse {}
-impl HasLocks for kvrpcpb::TxnHeartBeatResponse {}
-impl HasLocks for kvrpcpb::CheckTxnStatusResponse {}
-impl HasLocks for kvrpcpb::CheckSecondaryLocksResponse {}

--- a/src/transaction/transaction.rs
+++ b/src/transaction/transaction.rs
@@ -901,7 +901,7 @@ impl Committer {
             .multi_region()
             .retry_region(self.options.retry_options.region_backoff.clone())
             .merge(CollectError)
-            .propagate_error()
+            .extract_error()
             .plan();
         let response = plan.execute().await?;
 
@@ -940,7 +940,7 @@ impl Committer {
             .resolve_lock(self.options.retry_options.lock_backoff.clone())
             .multi_region()
             .retry_region(self.options.retry_options.region_backoff.clone())
-            .propagate_error()
+            .extract_error()
             .plan();
         plan.execute()
             .inspect_err(|e| {
@@ -977,7 +977,7 @@ impl Committer {
             .resolve_lock(self.options.retry_options.lock_backoff)
             .multi_region()
             .retry_region(self.options.retry_options.region_backoff)
-            .propagate_error()
+            .extract_error()
             .plan();
         plan.execute().await?;
         Ok(())
@@ -998,7 +998,7 @@ impl Committer {
                     .resolve_lock(self.options.retry_options.lock_backoff)
                     .multi_region()
                     .retry_region(self.options.retry_options.region_backoff)
-                    .propagate_error()
+                    .extract_error()
                     .plan();
                 plan.execute().await?;
             }
@@ -1008,7 +1008,7 @@ impl Committer {
                     .resolve_lock(self.options.retry_options.lock_backoff)
                     .multi_region()
                     .retry_region(self.options.retry_options.region_backoff)
-                    .propagate_error()
+                    .extract_error()
                     .plan();
                 plan.execute().await?;
             }

--- a/src/transaction/transaction.rs
+++ b/src/transaction/transaction.rs
@@ -901,6 +901,7 @@ impl Committer {
             .multi_region()
             .retry_region(self.options.retry_options.region_backoff.clone())
             .merge(CollectError)
+            .propagate_error()
             .plan();
         let response = plan.execute().await?;
 
@@ -939,6 +940,7 @@ impl Committer {
             .resolve_lock(self.options.retry_options.lock_backoff.clone())
             .multi_region()
             .retry_region(self.options.retry_options.region_backoff.clone())
+            .propagate_error()
             .plan();
         plan.execute()
             .inspect_err(|e| {
@@ -975,6 +977,7 @@ impl Committer {
             .resolve_lock(self.options.retry_options.lock_backoff)
             .multi_region()
             .retry_region(self.options.retry_options.region_backoff)
+            .propagate_error()
             .plan();
         plan.execute().await?;
         Ok(())
@@ -995,6 +998,7 @@ impl Committer {
                     .resolve_lock(self.options.retry_options.lock_backoff)
                     .multi_region()
                     .retry_region(self.options.retry_options.region_backoff)
+                    .propagate_error()
                     .plan();
                 plan.execute().await?;
             }
@@ -1004,6 +1008,7 @@ impl Committer {
                     .resolve_lock(self.options.retry_options.lock_backoff)
                     .multi_region()
                     .retry_region(self.options.retry_options.region_backoff)
+                    .propagate_error()
                     .plan();
                 plan.execute().await?;
             }

--- a/tikv-client-common/src/errors.rs
+++ b/tikv-client-common/src/errors.rs
@@ -69,6 +69,8 @@ pub enum Error {
     KvError { message: String },
     #[error("{}", message)]
     InternalError { message: String },
+    #[error("{0}")]
+    StringError(String),
 }
 
 impl From<tikv_client_proto::errorpb::Error> for Error {

--- a/tikv-client-store/src/errors.rs
+++ b/tikv-client-store/src/errors.rs
@@ -1,6 +1,7 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
 use crate::Error;
+use std::fmt::Display;
 use tikv_client_proto::kvrpcpb;
 
 pub trait HasRegionError {
@@ -150,9 +151,12 @@ impl HasError for kvrpcpb::PessimisticRollbackResponse {
     }
 }
 
-impl<T: HasError, E> HasError for Result<T, E> {
+impl<T: HasError, E: Display> HasError for Result<T, E> {
     fn error(&mut self) -> Option<Error> {
-        self.as_mut().ok().and_then(|t| t.error())
+        match self {
+            Ok(x) => x.error(),
+            Err(e) => Some(Error::StringError(e.to_string())),
+        }
     }
 }
 


### PR DESCRIPTION
Related issues: #242 #238 

The PR tries to fix the following issues:
1. `HasError for Result` ignores `Err`
2. `HasLocks` ignores the `error` field
3. If a request returns `Ok(response)` while the response contains a non-empty `error` field, it's often ignored.