### PR TITLE
README: quote version in dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The TiKV client is a Rust library (crate). To use this crate in your project, ad
 
 ```toml
 [dependencies]
-tikv-client = 0.0.99
+tikv-client = "0.0.99"
 ```
 
 The minimum supported version of Rust is 1.40. The minimum supported version of TiKV is 5.0.


### PR DESCRIPTION
Without this it doesn't seem to get parsed as valid TOML