### PR TITLE
The minimal region cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: check
+          args: --all-targets --all-features
 
   fmt:
     name: rustfmt
@@ -49,7 +50,7 @@ jobs:
       - uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-features
+          args: --all-targets --all-features -- -D clippy::all
           name: Clippy Output
   unit-test:
     name: unit test
@@ -98,7 +99,6 @@ jobs:
           path: |
             ~/.cargo/.crates.toml
             ~/.cargo/.crates2.json
-            ~/.cargo/bin
             ~/.cargo/registry/index
             ~/.cargo/registry/cache
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('Cargo.lock') }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ regex = "1"
 serde = "1.0"
 serde_derive = "1.0"
 thiserror = "1"
-tokio = { version = "1", features = [ "sync", "time" ] }
+tokio = { version = "1", features = [ "sync", "rt-multi-thread", "macros" ] }
 async-recursion = "0.3"
 
 tikv-client-common = { version = "0.1.0", path = "tikv-client-common" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,8 @@ regex = "1"
 serde = "1.0"
 serde_derive = "1.0"
 thiserror = "1"
-tokio = { version = "1.0", features = [ "sync", "time" ] }
+tokio = { version = "1", features = [ "sync", "time" ] }
+async-recursion = "0.3"
 
 tikv-client-common = { version = "0.0.99", path = "tikv-client-common" }
 tikv-client-pd = { version = "0.0.99", path = "tikv-client-pd" }
@@ -48,7 +49,7 @@ proptest = "1"
 proptest-derive = "0.3"
 serial_test = "0.5.0"
 simple_logger = "1"
-tokio = { version = "1.0", features = [ "sync", "rt-multi-thread", "macros" ] }
+tokio = { version = "1", features = [ "sync", "rt-multi-thread", "macros" ] }
 reqwest = {version = "0.11", default-features = false, features = ["native-tls-vendored"]}
 serde_json = "1"
 

--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,9 @@
 default: check
 
 check:
-	cargo check --all
+	cargo check --all --all-targets --all-features
 	cargo fmt -- --check
-	cargo clippy -- -D clippy::all
+	cargo clippy --all-targets --all-features -- -D clippy::all
 
 unit-test:
 	cargo test --all

--- a/src/backoff.rs
+++ b/src/backoff.rs
@@ -5,7 +5,7 @@
 use rand::{thread_rng, Rng};
 use std::time::Duration;
 
-pub const DEFAULT_REGION_BACKOFF: Backoff = Backoff::no_jitter_backoff(2, 500, 10);
+pub const DEFAULT_REGION_BACKOFF: Backoff = Backoff::no_jitter_backoff(2, 100, 30);
 pub const OPTIMISTIC_BACKOFF: Backoff = Backoff::no_jitter_backoff(2, 500, 10);
 pub const PESSIMISTIC_BACKOFF: Backoff = Backoff::no_backoff();
 

--- a/src/backoff.rs
+++ b/src/backoff.rs
@@ -76,6 +76,11 @@ impl Backoff {
         self.kind == BackoffKind::None
     }
 
+    /// Returns the number of attempts
+    pub fn current_attempts(&self) -> u32 {
+        self.current_attempts
+    }
+
     /// Don't wait. Usually indicates that we should not retry a request.
     pub const fn no_backoff() -> Backoff {
         Backoff {

--- a/src/backoff.rs
+++ b/src/backoff.rs
@@ -5,7 +5,7 @@
 use rand::{thread_rng, Rng};
 use std::time::Duration;
 
-pub const DEFAULT_REGION_BACKOFF: Backoff = Backoff::no_jitter_backoff(2, 100, 30);
+pub const DEFAULT_REGION_BACKOFF: Backoff = Backoff::no_jitter_backoff(2, 500, 10);
 pub const OPTIMISTIC_BACKOFF: Backoff = Backoff::no_jitter_backoff(2, 500, 10);
 pub const PESSIMISTIC_BACKOFF: Backoff = Backoff::no_backoff();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,6 +104,7 @@ mod pd;
 #[doc(hidden)]
 pub mod raw;
 mod region;
+mod region_cache;
 mod stats;
 mod store;
 mod timestamp;

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -128,7 +128,7 @@ impl PdClient for MockPdClient {
         Ok(Store::new(region, Arc::new(self.client.clone())))
     }
 
-    async fn region_for_key(&self, key: &Key) -> Result<Region> {
+    async fn region_for_key(&self, key: &Key, _read_through_cache: bool) -> Result<Region> {
         let bytes: &[_] = key.into();
         let region = if bytes.is_empty() || bytes[0] < 10 {
             Self::region1()
@@ -139,7 +139,7 @@ impl PdClient for MockPdClient {
         Ok(region)
     }
 
-    async fn region_for_id(&self, id: RegionId) -> Result<Region> {
+    async fn region_for_id(&self, id: RegionId, _read_through_cache: bool) -> Result<Region> {
         match id {
             1 => Ok(Self::region1()),
             2 => Ok(Self::region2()),

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -147,7 +147,7 @@ impl PdClient for MockPdClient {
         match id {
             1 => Ok(Self::region1()),
             2 => Ok(Self::region2()),
-            _ => Err(Error::RegionNotFound { region_id: id }),
+            _ => Err(Error::RegionNotFoundInResponse { region_id: id }),
         }
     }
 
@@ -157,6 +157,18 @@ impl PdClient for MockPdClient {
 
     async fn update_safepoint(self: Arc<Self>, _safepoint: u64) -> Result<bool> {
         unimplemented!()
+    }
+
+    async fn update_leader(
+        &self,
+        _ver_id: crate::region::RegionVerId,
+        _leader: metapb::Peer,
+    ) -> Result<()> {
+        todo!()
+    }
+
+    async fn invalidate_region_cache(&self, _ver_id: crate::region::RegionVerId) {
+        todo!()
     }
 }
 

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -38,6 +38,7 @@ pub async fn pd_rpc_client() -> PdRpcClient<MockKvConnect, MockCluster> {
     .unwrap()
 }
 
+#[allow(clippy::type_complexity)]
 #[derive(new, Default, Clone)]
 pub struct MockKvClient {
     pub addr: String,
@@ -99,8 +100,10 @@ impl MockPdClient {
         region.region.set_start_key(vec![0]);
         region.region.set_end_key(vec![10]);
 
-        let mut leader = metapb::Peer::default();
-        leader.store_id = 41;
+        let leader = metapb::Peer {
+            store_id: 41,
+            ..Default::default()
+        };
         region.leader = Some(leader);
 
         region
@@ -112,8 +115,10 @@ impl MockPdClient {
         region.region.set_start_key(vec![10]);
         region.region.set_end_key(vec![250, 250]);
 
-        let mut leader = metapb::Peer::default();
-        leader.store_id = 42;
+        let leader = metapb::Peer {
+            store_id: 42,
+            ..Default::default()
+        };
         region.leader = Some(leader);
 
         region

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -124,7 +124,11 @@ impl MockPdClient {
 impl PdClient for MockPdClient {
     type KvClient = MockKvClient;
 
-    async fn map_region_to_store(self: Arc<Self>, region: Region) -> Result<Store> {
+    async fn map_region_to_store(
+        self: Arc<Self>,
+        region: Region,
+        _read_through_cache: bool,
+    ) -> Result<Store> {
         Ok(Store::new(region, Arc::new(self.client.clone())))
     }
 

--- a/src/pd/client.rs
+++ b/src/pd/client.rs
@@ -358,9 +358,9 @@ pub mod test {
         let addr1 = "foo";
         let addr2 = "bar";
 
-        let kv1 = client.kv_client(&addr1).await.unwrap();
-        let kv2 = client.kv_client(&addr2).await.unwrap();
-        let kv3 = client.kv_client(&addr2).await.unwrap();
+        let kv1 = client.kv_client(addr1).await.unwrap();
+        let kv2 = client.kv_client(addr2).await.unwrap();
+        let kv3 = client.kv_client(addr2).await.unwrap();
         assert!(kv1.addr != kv2.addr);
         assert_eq!(kv2.addr, kv3.addr);
     }

--- a/src/pd/client.rs
+++ b/src/pd/client.rs
@@ -3,7 +3,7 @@
 use crate::{
     compat::stream_fn,
     kv::codec,
-    pd::RetryClient,
+    pd::{retry::RetryClientTrait, RetryClient},
     region::{Region, RegionId, RegionVerId},
     region_cache::RegionCache,
     store::RegionStore,
@@ -212,7 +212,7 @@ pub struct PdRpcClient<KvC: KvConnect + Send + Sync + 'static = TikvConnect, Cl 
     kv_connect: KvC,
     kv_client_cache: Arc<RwLock<HashMap<String, KvC::KvClient>>>,
     enable_codec: bool,
-    region_cache: RegionCache<Cl>,
+    region_cache: RegionCache<RetryClient<Cl>>,
 }
 
 #[async_trait]

--- a/src/pd/mod.rs
+++ b/src/pd/mod.rs
@@ -2,4 +2,4 @@ mod client;
 mod retry;
 
 pub use client::{PdClient, PdRpcClient};
-pub use retry::RetryClient;
+pub use retry::{RetryClient, RetryClientTrait};

--- a/src/pd/retry.rs
+++ b/src/pd/retry.rs
@@ -126,7 +126,9 @@ impl RetryClient<Cluster> {
             cluster
                 .get_region_by_id(region_id, self.timeout)
                 .await
-                .and_then(|resp| region_from_response(resp, || Error::RegionNotFound { region_id }))
+                .and_then(|resp| {
+                    region_from_response(resp, || Error::RegionNotFoundInResponse { region_id })
+                })
         })
     }
 

--- a/src/raw/client.rs
+++ b/src/raw/client.rs
@@ -2,14 +2,7 @@
 
 use tikv_client_common::Error;
 
-use crate::{
-    backoff::DEFAULT_REGION_BACKOFF,
-    config::Config,
-    pd::PdRpcClient,
-    raw::lowering::*,
-    request::{Collect, Plan},
-    BoundRange, ColumnFamily, Key, KvPair, Result, Value,
-};
+use crate::{BoundRange, ColumnFamily, Key, KvPair, Result, Value, backoff::DEFAULT_REGION_BACKOFF, config::Config, pd::PdRpcClient, raw::lowering::*, request::{Collect, Plan, PlanContext}};
 use std::{sync::Arc, u32};
 
 const MAX_RAW_KV_SCAN_LIMIT: u32 = 10240;
@@ -154,7 +147,7 @@ impl Client {
             .retry_region(DEFAULT_REGION_BACKOFF)
             .post_process_default()
             .plan();
-        plan.execute().await
+        plan.execute(PlanContext::default()).await
     }
 
     /// Create a new 'batch get' request.
@@ -185,7 +178,7 @@ impl Client {
             .retry_region(DEFAULT_REGION_BACKOFF)
             .merge(Collect)
             .plan();
-        plan.execute()
+        plan.execute(PlanContext::default())
             .await
             .map(|r| r.into_iter().map(Into::into).collect())
     }
@@ -214,7 +207,7 @@ impl Client {
             .retry_region(DEFAULT_REGION_BACKOFF)
             .extract_error()
             .plan();
-        plan.execute().await?;
+        plan.execute(PlanContext::default()).await?;
         Ok(())
     }
 
@@ -249,7 +242,7 @@ impl Client {
             .retry_region(DEFAULT_REGION_BACKOFF)
             .extract_error()
             .plan();
-        plan.execute().await?;
+        plan.execute(PlanContext::default()).await?;
         Ok(())
     }
 
@@ -278,7 +271,7 @@ impl Client {
             .retry_region(DEFAULT_REGION_BACKOFF)
             .extract_error()
             .plan();
-        plan.execute().await?;
+        plan.execute(PlanContext::default()).await?;
         Ok(())
     }
 
@@ -308,7 +301,7 @@ impl Client {
             .retry_region(DEFAULT_REGION_BACKOFF)
             .extract_error()
             .plan();
-        plan.execute().await?;
+        plan.execute(PlanContext::default()).await?;
         Ok(())
     }
 
@@ -335,7 +328,7 @@ impl Client {
             .retry_region(DEFAULT_REGION_BACKOFF)
             .extract_error()
             .plan();
-        plan.execute().await?;
+        plan.execute(PlanContext::default()).await?;
         Ok(())
     }
 
@@ -488,7 +481,7 @@ impl Client {
             .retry_region(DEFAULT_REGION_BACKOFF)
             .post_process_default()
             .plan();
-        plan.execute().await
+        plan.execute(PlanContext::default()).await
     }
 
     async fn scan_inner(
@@ -510,7 +503,7 @@ impl Client {
             .retry_region(DEFAULT_REGION_BACKOFF)
             .merge(Collect)
             .plan();
-        let res = plan.execute().await;
+        let res = plan.execute(PlanContext::default()).await;
         res.map(|mut s| {
             s.truncate(limit as usize);
             s
@@ -541,7 +534,7 @@ impl Client {
             .retry_region(DEFAULT_REGION_BACKOFF)
             .merge(Collect)
             .plan();
-        plan.execute().await
+        plan.execute(PlanContext::default()).await
     }
 
     fn assert_non_atomic(&self) -> Result<()> {

--- a/src/raw/client.rs
+++ b/src/raw/client.rs
@@ -7,7 +7,7 @@ use crate::{
     config::Config,
     pd::PdRpcClient,
     raw::lowering::*,
-    request::{Collect, CollectFirst, Plan},
+    request::{Collect, CollectSingle, Plan},
     BoundRange, ColumnFamily, Key, KvPair, Result, Value,
 };
 use log::debug;
@@ -152,7 +152,7 @@ impl Client {
         let request = new_raw_get_request(key.into(), self.cf.clone());
         let plan = crate::request::PlanBuilder::new(self.rpc.clone(), request)
             .retry_multi_region(DEFAULT_REGION_BACKOFF)
-            .merge(CollectFirst)
+            .merge(CollectSingle)
             .post_process_default()
             .plan();
         plan.execute().await
@@ -212,7 +212,7 @@ impl Client {
         let request = new_raw_put_request(key.into(), value.into(), self.cf.clone(), self.atomic);
         let plan = crate::request::PlanBuilder::new(self.rpc.clone(), request)
             .retry_multi_region(DEFAULT_REGION_BACKOFF)
-            .merge(CollectFirst)
+            .merge(CollectSingle)
             .extract_error()
             .plan();
         plan.execute().await?;
@@ -276,7 +276,7 @@ impl Client {
         let request = new_raw_delete_request(key.into(), self.cf.clone(), self.atomic);
         let plan = crate::request::PlanBuilder::new(self.rpc.clone(), request)
             .retry_multi_region(DEFAULT_REGION_BACKOFF)
-            .merge(CollectFirst)
+            .merge(CollectSingle)
             .extract_error()
             .plan();
         plan.execute().await?;
@@ -488,7 +488,7 @@ impl Client {
         );
         let plan = crate::request::PlanBuilder::new(self.rpc.clone(), req)
             .retry_multi_region(DEFAULT_REGION_BACKOFF)
-            .merge(CollectFirst)
+            .merge(CollectSingle)
             .post_process_default()
             .plan();
         plan.execute().await

--- a/src/raw/client.rs
+++ b/src/raw/client.rs
@@ -2,7 +2,14 @@
 
 use tikv_client_common::Error;
 
-use crate::{BoundRange, ColumnFamily, Key, KvPair, Result, Value, backoff::DEFAULT_REGION_BACKOFF, config::Config, pd::PdRpcClient, raw::lowering::*, request::{Collect, Plan, PlanContext}};
+use crate::{
+    backoff::DEFAULT_REGION_BACKOFF,
+    config::Config,
+    pd::PdRpcClient,
+    raw::lowering::*,
+    request::{Collect, Plan, PlanContext},
+    BoundRange, ColumnFamily, Key, KvPair, Result, Value,
+};
 use std::{sync::Arc, u32};
 
 const MAX_RAW_KV_SCAN_LIMIT: u32 = 10240;

--- a/src/raw/client.rs
+++ b/src/raw/client.rs
@@ -7,7 +7,7 @@ use crate::{
     config::Config,
     pd::PdRpcClient,
     raw::lowering::*,
-    request::{Collect, CollectSingleKey, Plan},
+    request::{Collect, CollectFirst, Plan},
     BoundRange, ColumnFamily, Key, KvPair, Result, Value,
 };
 use log::debug;
@@ -152,7 +152,7 @@ impl Client {
         let request = new_raw_get_request(key.into(), self.cf.clone());
         let plan = crate::request::PlanBuilder::new(self.rpc.clone(), request)
             .retry_multi_region(DEFAULT_REGION_BACKOFF)
-            .merge(CollectSingleKey)
+            .merge(CollectFirst)
             .post_process_default()
             .plan();
         plan.execute().await
@@ -212,7 +212,7 @@ impl Client {
         let request = new_raw_put_request(key.into(), value.into(), self.cf.clone(), self.atomic);
         let plan = crate::request::PlanBuilder::new(self.rpc.clone(), request)
             .retry_multi_region(DEFAULT_REGION_BACKOFF)
-            .merge(CollectSingleKey)
+            .merge(CollectFirst)
             .extract_error()
             .plan();
         plan.execute().await?;
@@ -276,7 +276,7 @@ impl Client {
         let request = new_raw_delete_request(key.into(), self.cf.clone(), self.atomic);
         let plan = crate::request::PlanBuilder::new(self.rpc.clone(), request)
             .retry_multi_region(DEFAULT_REGION_BACKOFF)
-            .merge(CollectSingleKey)
+            .merge(CollectFirst)
             .extract_error()
             .plan();
         plan.execute().await?;
@@ -488,7 +488,7 @@ impl Client {
         );
         let plan = crate::request::PlanBuilder::new(self.rpc.clone(), req)
             .retry_multi_region(DEFAULT_REGION_BACKOFF)
-            .merge(CollectSingleKey)
+            .merge(CollectFirst)
             .post_process_default()
             .plan();
         plan.execute().await

--- a/src/raw/requests.rs
+++ b/src/raw/requests.rs
@@ -2,8 +2,12 @@
 
 use super::RawRpcRequest;
 use crate::{
+    collect_first,
     pd::PdClient,
-    request::{Collect, DefaultProcessor, KvRequest, Merge, Process, Shardable, SingleKey},
+    request::{
+        Collect, CollectSingleKey, DefaultProcessor, KvRequest, Merge, Process, Shardable,
+        SingleKey,
+    },
     store::{store_stream_for_keys, store_stream_for_ranges, RegionStore},
     transaction::HasLocks,
     util::iter::FlatMapOkIterExt,
@@ -24,6 +28,9 @@ pub fn new_raw_get_request(key: Vec<u8>, cf: Option<ColumnFamily>) -> kvrpcpb::R
 impl KvRequest for kvrpcpb::RawGetRequest {
     type Response = kvrpcpb::RawGetResponse;
 }
+
+shardable_key!(kvrpcpb::RawGetRequest);
+collect_first!(kvrpcpb::RawGetResponse);
 
 impl SingleKey for kvrpcpb::RawGetRequest {
     fn key(&self) -> &Vec<u8> {
@@ -91,6 +98,8 @@ impl KvRequest for kvrpcpb::RawPutRequest {
     type Response = kvrpcpb::RawPutResponse;
 }
 
+shardable_key!(kvrpcpb::RawPutRequest);
+collect_first!(kvrpcpb::RawPutResponse);
 impl SingleKey for kvrpcpb::RawPutRequest {
     fn key(&self) -> &Vec<u8> {
         &self.key
@@ -153,6 +162,8 @@ impl KvRequest for kvrpcpb::RawDeleteRequest {
     type Response = kvrpcpb::RawDeleteResponse;
 }
 
+shardable_key!(kvrpcpb::RawDeleteRequest);
+collect_first!(kvrpcpb::RawDeleteResponse);
 impl SingleKey for kvrpcpb::RawDeleteRequest {
     fn key(&self) -> &Vec<u8> {
         &self.key
@@ -297,6 +308,8 @@ impl KvRequest for kvrpcpb::RawCasRequest {
     type Response = kvrpcpb::RawCasResponse;
 }
 
+shardable_key!(kvrpcpb::RawCasRequest);
+collect_first!(kvrpcpb::RawCasResponse);
 impl SingleKey for kvrpcpb::RawCasRequest {
     fn key(&self) -> &Vec<u8> {
         &self.key

--- a/src/raw/requests.rs
+++ b/src/raw/requests.rs
@@ -138,7 +138,7 @@ impl Shardable for kvrpcpb::RawBatchPutRequest {
     }
 
     fn apply_shard(&mut self, shard: Self::Shard, store: &RegionStore) -> Result<()> {
-        self.set_context(store.region.context()?);
+        self.set_context(store.region_with_leader.context()?);
         self.set_pairs(shard);
         Ok(())
     }
@@ -269,7 +269,7 @@ impl Shardable for kvrpcpb::RawBatchScanRequest {
     }
 
     fn apply_shard(&mut self, shard: Self::Shard, store: &RegionStore) -> Result<()> {
-        self.set_context(store.region.context()?);
+        self.set_context(store.region_with_leader.context()?);
         self.set_ranges(shard);
         Ok(())
     }

--- a/src/raw/requests.rs
+++ b/src/raw/requests.rs
@@ -5,8 +5,7 @@ use crate::{
     collect_first,
     pd::PdClient,
     request::{
-        Collect, CollectSingleKey, DefaultProcessor, KvRequest, Merge, Process, Shardable,
-        SingleKey,
+        Collect, CollectFirst, DefaultProcessor, KvRequest, Merge, Process, Shardable, SingleKey,
     },
     store::{store_stream_for_keys, store_stream_for_ranges, RegionStore},
     transaction::HasLocks,

--- a/src/raw/requests.rs
+++ b/src/raw/requests.rs
@@ -5,7 +5,7 @@ use crate::{
     collect_first,
     pd::PdClient,
     request::{
-        Collect, CollectFirst, DefaultProcessor, KvRequest, Merge, Process, Shardable, SingleKey,
+        Collect, CollectSingle, DefaultProcessor, KvRequest, Merge, Process, Shardable, SingleKey,
     },
     store::{store_stream_for_keys, store_stream_for_ranges, RegionStore},
     transaction::HasLocks,

--- a/src/raw/requests.rs
+++ b/src/raw/requests.rs
@@ -357,7 +357,7 @@ mod test {
     use crate::{
         backoff::{DEFAULT_REGION_BACKOFF, OPTIMISTIC_BACKOFF},
         mock::{MockKvClient, MockPdClient},
-        request::{Plan, PlanContext},
+        request::Plan,
         Key,
     };
     use futures::executor;
@@ -395,12 +395,10 @@ mod test {
         };
         let plan = crate::request::PlanBuilder::new(client.clone(), scan)
             .resolve_lock(OPTIMISTIC_BACKOFF)
-            .multi_region()
-            .retry_region(DEFAULT_REGION_BACKOFF)
+            .retry_multi_region(DEFAULT_REGION_BACKOFF)
             .merge(Collect)
             .plan();
-        let scan =
-            executor::block_on(async { plan.execute(PlanContext::default()).await }).unwrap();
+        let scan = executor::block_on(async { plan.execute().await }).unwrap();
 
         assert_eq!(scan.len(), 10);
         // FIXME test the keys returned.

--- a/src/raw/requests.rs
+++ b/src/raw/requests.rs
@@ -384,8 +384,10 @@ mod test {
 
                 let mut resp = kvrpcpb::RawScanResponse::default();
                 for i in req.start_key[0]..req.end_key[0] {
-                    let mut kv = kvrpcpb::KvPair::default();
-                    kv.key = vec![i];
+                    let kv = kvrpcpb::KvPair {
+                        key: vec![i],
+                        ..Default::default()
+                    };
                     resp.kvs.push(kv);
                 }
 

--- a/src/raw/requests.rs
+++ b/src/raw/requests.rs
@@ -393,7 +393,7 @@ mod test {
             key_only: true,
             ..Default::default()
         };
-        let plan = crate::request::PlanBuilder::new(client.clone(), scan)
+        let plan = crate::request::PlanBuilder::new(client, scan)
             .resolve_lock(OPTIMISTIC_BACKOFF)
             .retry_multi_region(DEFAULT_REGION_BACKOFF)
             .merge(Collect)

--- a/src/raw/requests.rs
+++ b/src/raw/requests.rs
@@ -258,11 +258,7 @@ impl Shardable for kvrpcpb::RawBatchScanRequest {
         pd_client: &Arc<impl PdClient>,
         read_through_cache: bool,
     ) -> BoxStream<'static, Result<(Self::Shard, Store)>> {
-        store_stream_for_ranges(
-            self.ranges.clone(),
-            pd_client.clone(),
-            read_through_cache,
-        )
+        store_stream_for_ranges(self.ranges.clone(), pd_client.clone(), read_through_cache)
     }
 
     fn apply_shard(&mut self, shard: Self::Shard, store: &Store) -> Result<()> {

--- a/src/region.rs
+++ b/src/region.rs
@@ -1,3 +1,5 @@
+// Copyright 2021 TiKV Project Authors. Licensed under Apache-2.0.
+
 use crate::{Error, Key, Result};
 use derive_new::new;
 use tikv_client_proto::{kvrpcpb, metapb};

--- a/src/region.rs
+++ b/src/region.rs
@@ -29,6 +29,8 @@ pub struct Region {
     pub leader: Option<metapb::Peer>,
 }
 
+impl Eq for Region {}
+
 impl Region {
     pub fn contains(&self, key: &Key) -> bool {
         let key: &[u8] = key.into();

--- a/src/region.rs
+++ b/src/region.rs
@@ -24,14 +24,14 @@ pub struct RegionVerId {
 ///
 /// In TiKV all data is partitioned by range. Each partition is called a region.
 #[derive(new, Clone, Default, Debug, PartialEq)]
-pub struct Region {
+pub struct RegionWithLeader {
     pub region: metapb::Region,
     pub leader: Option<metapb::Peer>,
 }
 
-impl Eq for Region {}
+impl Eq for RegionWithLeader {}
 
-impl Region {
+impl RegionWithLeader {
     pub fn contains(&self, key: &Key) -> bool {
         let key: &[u8] = key.into();
         let start_key = self.region.get_start_key();

--- a/src/region_cache.rs
+++ b/src/region_cache.rs
@@ -85,7 +85,7 @@ impl RegionCache<Cluster> {
         let region_cache_guard = self.region_cache.read().await;
         let ver_id = region_cache_guard.id_to_ver_id.get(&id);
         if let Some(ver_id) = ver_id {
-            let region = region_cache_guard.ver_id_to_region.get(&ver_id).unwrap();
+            let region = region_cache_guard.ver_id_to_region.get(ver_id).unwrap();
             return Ok(region.clone());
         }
 
@@ -109,13 +109,13 @@ impl RegionCache<Cluster> {
     }
 
     /// Force read through (query from PD) and update cache
-    pub async fn read_through_region_by_id(&self, id: RegionId) -> Result<Region> {
+    async fn read_through_region_by_id(&self, id: RegionId) -> Result<Region> {
         let region = self.inner_client.clone().get_region_by_id(id).await?;
         self.add_region(region.clone()).await;
         Ok(region)
     }
 
-    pub async fn read_through_store_by_id(&self, id: StoreId) -> Result<Store> {
+    async fn read_through_store_by_id(&self, id: StoreId) -> Result<Store> {
         let store = self.inner_client.clone().get_store(id).await?;
         self.store_cache.write().await.insert(id, store.clone());
         Ok(store)

--- a/src/region_cache.rs
+++ b/src/region_cache.rs
@@ -1,0 +1,98 @@
+// Copyright 2021 TiKV Project Authors. Licensed under Apache-2.0.
+
+use crate::{
+    pd::RetryClient,
+    region::{Region, RegionId},
+    Key, Result,
+};
+use std::{
+    collections::{BTreeMap, HashMap},
+    sync::Arc,
+};
+use tikv_client_pd::Cluster;
+
+pub struct RegionCache<Cl = Cluster> {
+    /// Start key -> Region
+    ///
+    /// Invariant: there are no intersecting regions in the map at any time.
+    cache_by_key: BTreeMap<Key, Region>,
+    /// Region ID -> Region. Note: regions with identical ID doesn't necessarily
+    /// mean they are the same, they can be different regions across time. For
+    /// example, when a region is splitted one of the new regions may have
+    /// the same ID but a different RegionVerId.
+    cache_by_id: HashMap<RegionId, Region>,
+    inner_client: Arc<RetryClient<Cl>>,
+}
+
+impl<Cl> RegionCache<Cl> {
+    pub fn new(inner_client: Arc<RetryClient<Cl>>) -> RegionCache<Cl> {
+        RegionCache {
+            cache_by_key: BTreeMap::new(),
+            cache_by_id: HashMap::new(),
+            inner_client,
+        }
+    }
+}
+
+impl RegionCache<Cluster> {
+    // Retrieve cache entry by key. If there's no entry, query PD and update cache.
+    pub async fn get_region_by_key(&mut self, key: &Key) -> Result<Region> {
+        let res = self.cache_by_key.range(..=key).next_back();
+        match res {
+            Some((_, candidate_region)) if candidate_region.contains(key) => {
+                Ok(candidate_region.clone())
+            }
+            _ => self.read_through_region_for_key(key.clone()).await,
+        }
+    }
+
+    // Retrieve cache entry by RegionId. If there's no entry, query PD and update cache.
+    pub async fn get_region_by_id(&mut self, id: RegionId) -> Result<Region> {
+        match self.cache_by_id.get(&id) {
+            Some(region) => Ok(region.clone()),
+            None => self.read_through_region_for_id(id).await,
+        }
+    }
+
+    /// Force read through (query from PD) and update cache
+    pub async fn read_through_region_for_key(&mut self, key: Key) -> Result<Region> {
+        let region = self.inner_client.clone().get_region(key.into()).await?;
+        self.add_region(region.clone());
+        Ok(region)
+    }
+
+    /// Force read through (query from PD) and update cache
+    pub async fn read_through_region_for_id(&mut self, id: RegionId) -> Result<Region> {
+        let region = self.inner_client.clone().get_region_by_id(id).await?;
+        self.add_region(region.clone());
+        Ok(region)
+    }
+
+    pub fn add_region(&mut self, region: Region) {
+        let end_key = region.end_key();
+        let mut to_be_removed: Vec<(RegionId, Key)> = Vec::new();
+        let mut search_range = if end_key.is_empty() {
+            self.cache_by_key.range(..)
+        } else {
+            self.cache_by_key.range(..end_key)
+        };
+        while let Some((_, region_in_cache)) = search_range.next_back() {
+            if region_in_cache.region.end_key > region.region.start_key {
+                to_be_removed.push((
+                    region_in_cache.id(),
+                    region_in_cache.region.start_key.clone().into(),
+                ));
+            } else {
+                break;
+            }
+        }
+
+        for (id, start_key) in to_be_removed {
+            self.cache_by_id.remove(&id);
+            self.cache_by_key.remove(&start_key);
+        }
+
+        self.cache_by_id.insert(region.id(), region.clone());
+        self.cache_by_key.insert(region.start_key(), region);
+    }
+}

--- a/src/region_cache.rs
+++ b/src/region_cache.rs
@@ -5,7 +5,6 @@ use crate::{
     region::{Region, RegionId, RegionVerId, StoreId},
     Key, Result,
 };
-use async_recursion::async_recursion;
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
     sync::Arc,

--- a/src/region_cache.rs
+++ b/src/region_cache.rs
@@ -99,10 +99,7 @@ impl<C: RetryClientTrait> RegionCache<C> {
             }
 
             // check concurrent requests
-            let mut notify = None;
-            if let Some(n) = region_cache_guard.on_my_way_id.get(&id) {
-                notify = Some(n.clone());
-            }
+            let notify = region_cache_guard.on_my_way_id.get(&id).cloned();
             drop(region_cache_guard);
 
             if let Some(n) = notify {

--- a/src/request/mod.rs
+++ b/src/request/mod.rs
@@ -6,11 +6,11 @@ use crate::{
 };
 use async_trait::async_trait;
 use derive_new::new;
-use tikv_client_store::{HasError, Request};
+use tikv_client_store::{HasKeyErrors, Request};
 
 pub use self::{
     plan::{
-        Collect, CollectAndMatchKey, CollectError, CollectFirst, DefaultProcessor, Dispatch,
+        Collect, CollectAndMatchKey, CollectError, CollectSingle, DefaultProcessor, Dispatch,
         ExtractError, HasKeys, Merge, MergeResponse, Plan, PreserveKey, Process, ProcessResponse,
         ResolveLock, RetryableMultiRegion,
     },
@@ -27,7 +27,7 @@ mod shard;
 #[async_trait]
 pub trait KvRequest: Request + Sized + Clone + Sync + Send + 'static {
     /// The expected response to the request.
-    type Response: HasError + HasLocks + Clone + Send + 'static;
+    type Response: HasKeyErrors + HasLocks + Clone + Send + 'static;
 }
 
 #[derive(Clone, Debug, new, Eq, PartialEq)]
@@ -84,8 +84,8 @@ mod test {
         #[derive(Clone)]
         struct MockRpcResponse;
 
-        impl HasError for MockRpcResponse {
-            fn error(&mut self) -> Option<Error> {
+        impl HasKeyErrors for MockRpcResponse {
+            fn key_errors(&mut self) -> Option<Vec<Error>> {
                 None
             }
         }

--- a/src/request/mod.rs
+++ b/src/request/mod.rs
@@ -10,9 +10,9 @@ use tikv_client_store::{HasError, Request};
 
 pub use self::{
     plan::{
-        Collect, CollectAndMatchKey, CollectError, DefaultProcessor, Dispatch, ExtractError,
-        HasKeys, Merge, MergeResponse, Plan, PreserveKey, Process, ProcessResponse, ResolveLock,
-        RetryRegion, RetryableMultiRegion,
+        Collect, CollectAndMatchKey, CollectError, CollectSingleKey, DefaultProcessor, Dispatch,
+        ExtractError, HasKeys, Merge, MergeResponse, Plan, PreserveKey, Process, ProcessResponse,
+        ResolveLock, RetryableMultiRegion,
     },
     plan_builder::{PlanBuilder, SingleKey},
     shard::Shardable,

--- a/src/request/mod.rs
+++ b/src/request/mod.rs
@@ -10,7 +10,7 @@ use tikv_client_store::{HasError, Request};
 
 pub use self::{
     plan::{
-        Collect, CollectAndMatchKey, CollectError, CollectSingleKey, DefaultProcessor, Dispatch,
+        Collect, CollectAndMatchKey, CollectError, CollectFirst, DefaultProcessor, Dispatch,
         ExtractError, HasKeys, Merge, MergeResponse, Plan, PreserveKey, Process, ProcessResponse,
         ResolveLock, RetryableMultiRegion,
     },

--- a/src/request/mod.rs
+++ b/src/request/mod.rs
@@ -92,7 +92,7 @@ mod test {
 
         impl HasRegionError for MockRpcResponse {
             fn region_error(&mut self) -> Option<Error> {
-                Some(Error::RegionNotFound { region_id: 1 })
+                Some(Error::RegionNotFoundInResponse { region_id: 1 })
             }
         }
 

--- a/src/request/mod.rs
+++ b/src/request/mod.rs
@@ -91,8 +91,8 @@ mod test {
         }
 
         impl HasRegionError for MockRpcResponse {
-            fn region_error(&mut self) -> Option<Error> {
-                Some(Error::RegionNotFoundInResponse { region_id: 1 })
+            fn region_error(&mut self) -> Option<tikv_client_proto::errorpb::Error> {
+                Some(tikv_client_proto::errorpb::Error::default())
             }
         }
 

--- a/src/request/mod.rs
+++ b/src/request/mod.rs
@@ -133,10 +133,9 @@ mod test {
             fn shards(
                 &self,
                 pd_client: &std::sync::Arc<impl crate::pd::PdClient>,
-                read_through_cache: bool,
             ) -> futures::stream::BoxStream<
                 'static,
-                crate::Result<(Self::Shard, crate::store::Store)>,
+                crate::Result<(Self::Shard, crate::store::RegionStore)>,
             > {
                 // Increases by 1 for each call.
                 let mut test_invoking_count = self.test_invoking_count.lock().unwrap();
@@ -144,14 +143,13 @@ mod test {
                 store_stream_for_keys(
                     Some(Key::from("mock_key".to_owned())).into_iter(),
                     pd_client.clone(),
-                    read_through_cache,
                 )
             }
 
             fn apply_shard(
                 &mut self,
                 _shard: Self::Shard,
-                _store: &crate::store::Store,
+                _store: &crate::store::RegionStore,
             ) -> crate::Result<()> {
                 Ok(())
             }

--- a/src/request/plan.rs
+++ b/src/request/plan.rs
@@ -208,6 +208,34 @@ pub struct RetryRegion<P: Plan, PdC: PdClient> {
     pub backoff: Backoff,
 }
 
+impl<P: Plan, PdC: PdClient> RetryRegion<P, PdC> {
+    fn handle_cache_by_region_error(&self, error: Error) -> Result<()> {
+        match error {
+            Error::MultipleErrors(errors) => {
+                for e in errors {
+                    self.handle_cache_by_region_error(e)?;
+                }
+                Ok(())
+            }
+            Error::RegionError(region_error) => {
+                if !region_error.message.is_empty() {
+                    return Err(Error::StringError(format!(
+                        "region error: {}",
+                        region_error.message
+                    )));
+                }
+                todo!();
+                if let Some(e) = region_error.not_leader {}
+                Ok(())
+            }
+            // Error::RegionForKeyNotFound { key } => {} // TODO: should we retry it here?
+            // Error::RegionNotFound { region_id } => {}
+            // Error::LeaderNotFound { region_id } => {}
+            x => Err(x),
+        }
+    }
+}
+
 impl<P: Plan, PdC: PdClient> Clone for RetryRegion<P, PdC> {
     fn clone(&self) -> Self {
         RetryRegion {

--- a/src/request/plan.rs
+++ b/src/request/plan.rs
@@ -275,13 +275,15 @@ impl<In: Clone + Send + Sync + 'static, P: Plan<Result = Vec<Result<In>>>, M: Me
 #[derive(Clone, Copy)]
 pub struct Collect;
 
+/// A merge strategy that only takes the first element. It's used for requests
+/// that should have exactly one response, e.g. a get request.
 #[derive(Clone, Copy)]
-pub struct CollectSingleKey;
+pub struct CollectFirst;
 
 #[macro_export]
 macro_rules! collect_first {
     ($type_: ty) => {
-        impl Merge<$type_> for CollectSingleKey {
+        impl Merge<$type_> for CollectFirst {
             type Out = $type_;
 
             fn merge(&self, mut input: Vec<Result<$type_>>) -> Result<Self::Out> {

--- a/src/request/plan_builder.rs
+++ b/src/request/plan_builder.rs
@@ -147,7 +147,11 @@ impl<PdC: PdClient, R: KvRequest + SingleKey> PlanBuilder<PdC, Dispatch<R>, NoTa
     /// Target the request at a single region.
     pub async fn single_region(self) -> Result<PlanBuilder<PdC, Dispatch<R>, Targetted>> {
         let key = self.plan.request.key();
-        let store = self.pd_client.clone().store_for_key(key.into()).await?;
+        let store = self
+            .pd_client
+            .clone()
+            .store_for_key(key.into(), true)
+            .await?;
         set_single_region_store(self.plan, store, self.pd_client)
     }
 }

--- a/src/request/plan_builder.rs
+++ b/src/request/plan_builder.rs
@@ -13,7 +13,7 @@ use crate::{
     Result,
 };
 use std::{marker::PhantomData, sync::Arc};
-use tikv_client_store::HasError;
+use tikv_client_store::{HasKeyErrors, HasRegionError, HasRegionErrors};
 
 /// Builder type for plans (see that module for more).
 pub struct PlanBuilder<PdC: PdClient, P: Plan, Ph: PlanBuilderPhase> {
@@ -110,7 +110,7 @@ impl<PdC: PdClient, P: Plan, Ph: PlanBuilderPhase> PlanBuilder<PdC, P, Ph> {
 
 impl<PdC: PdClient, P: Plan + Shardable> PlanBuilder<PdC, P, NoTarget>
 where
-    P::Result: HasError,
+    P::Result: HasKeyErrors + HasRegionError,
 {
     /// Split the request into shards sending a request to the region of each shard.
     pub fn retry_multi_region(
@@ -153,7 +153,7 @@ impl<PdC: PdClient, R: KvRequest> PlanBuilder<PdC, Dispatch<R>, NoTarget> {
 
 impl<PdC: PdClient, P: Plan + HasKeys> PlanBuilder<PdC, P, NoTarget>
 where
-    P::Result: HasError,
+    P::Result: HasKeyErrors,
 {
     pub fn preserve_keys(self) -> PlanBuilder<PdC, PreserveKey<P>, NoTarget> {
         PlanBuilder {
@@ -166,7 +166,7 @@ where
 
 impl<PdC: PdClient, P: Plan> PlanBuilder<PdC, P, Targetted>
 where
-    P::Result: HasError,
+    P::Result: HasKeyErrors + HasRegionErrors,
 {
     pub fn extract_error(self) -> PlanBuilder<PdC, ExtractError<P>, Targetted> {
         PlanBuilder {

--- a/src/request/plan_builder.rs
+++ b/src/request/plan_builder.rs
@@ -5,8 +5,8 @@ use crate::{
     backoff::Backoff,
     pd::PdClient,
     request::{
-        DefaultProcessor, Dispatch, ExtractError, HasKeys, KvRequest, Merge, MergeResponse,
-        MultiRegion, Plan, Process, ProcessResponse, ResolveLock, RetryRegion, Shardable,
+        DefaultProcessor, Dispatch, ExtractError, HasKeys, KvRequest, Merge, MergeResponse, Plan,
+        Process, ProcessResponse, ResolveLock, RetryRegion, RetryableMultiRegion, Shardable,
     },
     store::Store,
     transaction::HasLocks,
@@ -131,12 +131,16 @@ where
     P::Result: HasError,
 {
     /// Split the request into shards sending a request to the region of each shard.
-    pub fn multi_region(self) -> PlanBuilder<PdC, MultiRegion<P, PdC>, Targetted> {
+    pub fn retry_multi_region(
+        self,
+        backoff: Backoff,
+    ) -> PlanBuilder<PdC, RetryableMultiRegion<P, PdC>, Targetted> {
         PlanBuilder {
             pd_client: self.pd_client.clone(),
-            plan: MultiRegion {
+            plan: RetryableMultiRegion {
                 inner: self.plan,
                 pd_client: self.pd_client,
+                backoff,
             },
             phantom: PhantomData,
         }

--- a/src/request/plan_builder.rs
+++ b/src/request/plan_builder.rs
@@ -182,7 +182,8 @@ fn set_single_region_store<PdC: PdClient, R: KvRequest>(
     store: RegionStore,
     pd_client: Arc<PdC>,
 ) -> Result<PlanBuilder<PdC, Dispatch<R>, Targetted>> {
-    plan.request.set_context(store.region.context()?);
+    plan.request
+        .set_context(store.region_with_leader.context()?);
     plan.kv_client = Some(store.client);
     Ok(PlanBuilder {
         plan,

--- a/src/request/shard.rs
+++ b/src/request/shard.rs
@@ -117,7 +117,11 @@ macro_rules! shardable_range {
             ) -> BoxStream<'static, crate::Result<(Self::Shard, crate::store::Store)>> {
                 let start_key = self.start_key.clone().into();
                 let end_key = self.end_key.clone().into();
-                crate::store::store_stream_for_range((start_key, end_key), pd_client.clone(), read_through_cache)
+                crate::store::store_stream_for_range(
+                    (start_key, end_key),
+                    pd_client.clone(),
+                    read_through_cache,
+                )
             }
 
             fn apply_shard(

--- a/src/request/shard.rs
+++ b/src/request/shard.rs
@@ -3,7 +3,7 @@
 use crate::{
     pd::PdClient,
     request::{Dispatch, HasKeys, KvRequest, Plan, PreserveKey, ResolveLock, RetryRegion},
-    store::Store,
+    store::RegionStore,
     Result,
 };
 use futures::stream::BoxStream;
@@ -16,12 +16,11 @@ macro_rules! impl_inner_shardable {
         fn shards(
             &self,
             pd_client: &Arc<impl PdClient>,
-            read_through_cache: bool,
-        ) -> BoxStream<'static, Result<(Self::Shard, Store)>> {
-            self.inner.shards(pd_client, read_through_cache)
+        ) -> BoxStream<'static, Result<(Self::Shard, RegionStore)>> {
+            self.inner.shards(pd_client)
         }
 
-        fn apply_shard(&mut self, shard: Self::Shard, store: &Store) -> Result<()> {
+        fn apply_shard(&mut self, shard: Self::Shard, store: &RegionStore) -> Result<()> {
             self.inner.apply_shard(shard, store)
         }
     };
@@ -33,10 +32,9 @@ pub trait Shardable {
     fn shards(
         &self,
         pd_client: &Arc<impl PdClient>,
-        read_through_cache: bool,
-    ) -> BoxStream<'static, Result<(Self::Shard, Store)>>;
+    ) -> BoxStream<'static, Result<(Self::Shard, RegionStore)>>;
 
-    fn apply_shard(&mut self, shard: Self::Shard, store: &Store) -> Result<()>;
+    fn apply_shard(&mut self, shard: Self::Shard, store: &RegionStore) -> Result<()>;
 }
 
 impl<Req: KvRequest + Shardable> Shardable for Dispatch<Req> {
@@ -45,12 +43,11 @@ impl<Req: KvRequest + Shardable> Shardable for Dispatch<Req> {
     fn shards(
         &self,
         pd_client: &Arc<impl PdClient>,
-        read_through_cache: bool,
-    ) -> BoxStream<'static, Result<(Self::Shard, Store)>> {
-        self.request.shards(pd_client, read_through_cache)
+    ) -> BoxStream<'static, Result<(Self::Shard, RegionStore)>> {
+        self.request.shards(pd_client)
     }
 
-    fn apply_shard(&mut self, shard: Self::Shard, store: &Store) -> Result<()> {
+    fn apply_shard(&mut self, shard: Self::Shard, store: &RegionStore) -> Result<()> {
         self.kv_client = Some(store.client.clone());
         self.request.apply_shard(shard, store)
     }
@@ -77,24 +74,19 @@ macro_rules! shardable_keys {
             fn shards(
                 &self,
                 pd_client: &std::sync::Arc<impl crate::pd::PdClient>,
-                read_through_cache: bool,
             ) -> futures::stream::BoxStream<
                 'static,
-                crate::Result<(Self::Shard, crate::store::Store)>,
+                crate::Result<(Self::Shard, crate::store::RegionStore)>,
             > {
                 let mut keys = self.keys.clone();
                 keys.sort();
-                crate::store::store_stream_for_keys(
-                    keys.into_iter(),
-                    pd_client.clone(),
-                    read_through_cache,
-                )
+                crate::store::store_stream_for_keys(keys.into_iter(), pd_client.clone())
             }
 
             fn apply_shard(
                 &mut self,
                 shard: Self::Shard,
-                store: &crate::store::Store,
+                store: &crate::store::RegionStore,
             ) -> crate::Result<()> {
                 self.set_context(store.region.context()?);
                 self.set_keys(shard.into_iter().map(Into::into).collect());
@@ -113,21 +105,16 @@ macro_rules! shardable_range {
             fn shards(
                 &self,
                 pd_client: &Arc<impl crate::pd::PdClient>,
-                read_through_cache: bool,
-            ) -> BoxStream<'static, crate::Result<(Self::Shard, crate::store::Store)>> {
+            ) -> BoxStream<'static, crate::Result<(Self::Shard, crate::store::RegionStore)>> {
                 let start_key = self.start_key.clone().into();
                 let end_key = self.end_key.clone().into();
-                crate::store::store_stream_for_range(
-                    (start_key, end_key),
-                    pd_client.clone(),
-                    read_through_cache,
-                )
+                crate::store::store_stream_for_range((start_key, end_key), pd_client.clone())
             }
 
             fn apply_shard(
                 &mut self,
                 shard: Self::Shard,
-                store: &crate::store::Store,
+                store: &crate::store::RegionStore,
             ) -> crate::Result<()> {
                 self.set_context(store.region.context()?);
 

--- a/src/request/shard.rs
+++ b/src/request/shard.rs
@@ -85,7 +85,7 @@ macro_rules! shardable_key {
                 mut shard: Self::Shard,
                 store: &crate::store::RegionStore,
             ) -> crate::Result<()> {
-                self.set_context(store.region.context()?);
+                self.set_context(store.region_with_leader.context()?);
                 assert!(shard.len() == 1);
                 self.set_key(shard.pop().unwrap());
                 Ok(())
@@ -117,7 +117,7 @@ macro_rules! shardable_keys {
                 shard: Self::Shard,
                 store: &crate::store::RegionStore,
             ) -> crate::Result<()> {
-                self.set_context(store.region.context()?);
+                self.set_context(store.region_with_leader.context()?);
                 self.set_keys(shard.into_iter().map(Into::into).collect());
                 Ok(())
             }
@@ -145,7 +145,7 @@ macro_rules! shardable_range {
                 shard: Self::Shard,
                 store: &crate::store::RegionStore,
             ) -> crate::Result<()> {
-                self.set_context(store.region.context()?);
+                self.set_context(store.region_with_leader.context()?);
 
                 self.set_start_key(shard.0.into());
                 self.set_end_key(shard.1.into());

--- a/src/store.rs
+++ b/src/store.rs
@@ -10,7 +10,7 @@ use std::{
 use tikv_client_proto::kvrpcpb;
 use tikv_client_store::{KvClient, KvConnect, TikvConnect};
 
-#[derive(new)]
+#[derive(new, Clone)]
 pub struct Store {
     pub region: Region,
     pub client: Arc<dyn KvClient + Send + Sync>,

--- a/src/transaction/buffer.rs
+++ b/src/transaction/buffer.rs
@@ -401,10 +401,7 @@ mod tests {
             ))
             .unwrap()
             .collect::<Vec<_>>(),
-            vec![KvPair(
-                Key::from(b"key1".to_vec()),
-                Value::from(b"value".to_vec()),
-            ),]
+            vec![KvPair(Key::from(b"key1".to_vec()), b"value".to_vec(),),]
         );
     }
 

--- a/src/transaction/client.rs
+++ b/src/transaction/client.rs
@@ -221,8 +221,8 @@ impl Client {
         }
 
         // resolve locks
-        // FIXME: this is inefficient
-        resolve_locks(locks, self.pd.clone(), true).await?;
+        // FIXME: (1) this is inefficient (2) when region error occurred
+        resolve_locks(locks, self.pd.clone()).await?;
 
         // update safepoint to PD
         let res: bool = self

--- a/src/transaction/client.rs
+++ b/src/transaction/client.rs
@@ -1,7 +1,15 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
 use super::{requests::new_scan_lock_request, resolve_locks};
-use crate::{Result, backoff::{DEFAULT_REGION_BACKOFF, OPTIMISTIC_BACKOFF}, config::Config, pd::{PdClient, PdRpcClient}, request::{Plan, PlanContext}, timestamp::TimestampExt, transaction::{Snapshot, Transaction, TransactionOptions}};
+use crate::{
+    backoff::{DEFAULT_REGION_BACKOFF, OPTIMISTIC_BACKOFF},
+    config::Config,
+    pd::{PdClient, PdRpcClient},
+    request::{Plan, PlanContext},
+    timestamp::TimestampExt,
+    transaction::{Snapshot, Transaction, TransactionOptions},
+    Result,
+};
 use std::{mem, sync::Arc};
 use tikv_client_proto::{kvrpcpb, pdpb::Timestamp};
 

--- a/src/transaction/client.rs
+++ b/src/transaction/client.rs
@@ -5,7 +5,7 @@ use crate::{
     backoff::{DEFAULT_REGION_BACKOFF, OPTIMISTIC_BACKOFF},
     config::Config,
     pd::{PdClient, PdRpcClient},
-    request::{Plan, PlanContext},
+    request::Plan,
     timestamp::TimestampExt,
     transaction::{Snapshot, Transaction, TransactionOptions},
     Result,
@@ -199,11 +199,10 @@ impl Client {
 
             let plan = crate::request::PlanBuilder::new(self.pd.clone(), req)
                 .resolve_lock(OPTIMISTIC_BACKOFF)
-                .multi_region()
-                .retry_region(DEFAULT_REGION_BACKOFF)
+                .retry_multi_region(DEFAULT_REGION_BACKOFF)
                 .merge(crate::request::Collect)
                 .plan();
-            let res: Vec<kvrpcpb::LockInfo> = plan.execute(PlanContext::default()).await?;
+            let res: Vec<kvrpcpb::LockInfo> = plan.execute().await?;
 
             if res.is_empty() {
                 break;

--- a/src/transaction/lock.rs
+++ b/src/transaction/lock.rs
@@ -101,7 +101,7 @@ async fn resolve_lock_with_retry(
     for i in 0..RESOLVE_LOCK_RETRY_LIMIT {
         debug!("resolving locks: attempt {}", (i + 1));
         let store = pd_client.clone().store_for_key(key.into()).await?;
-        let ver_id = store.region.ver_id();
+        let ver_id = store.region_with_leader.ver_id();
         let request = requests::new_resolve_lock_request(start_version, commit_version);
         // The unique place where single-region is used
         let plan = crate::request::PlanBuilder::new(pd_client.clone(), request)

--- a/src/transaction/lock.rs
+++ b/src/transaction/lock.rs
@@ -146,8 +146,10 @@ mod tests {
         let client = Arc::new(MockPdClient::new(MockKvClient::with_dispatch_hook(
             |_: &dyn Any| {
                 fail::fail_point!("region-error", |_| {
-                    let mut resp = kvrpcpb::ResolveLockResponse::default();
-                    resp.region_error = Some(errorpb::Error::default());
+                    let resp = kvrpcpb::ResolveLockResponse {
+                        region_error: Some(errorpb::Error::default()),
+                        ..Default::default()
+                    };
                     Ok(Box::new(resp) as Box<dyn Any>)
                 });
                 Ok(Box::new(kvrpcpb::ResolveLockResponse::default()) as Box<dyn Any>)

--- a/src/transaction/lock.rs
+++ b/src/transaction/lock.rs
@@ -4,7 +4,7 @@ use crate::{
     backoff::{Backoff, DEFAULT_REGION_BACKOFF, OPTIMISTIC_BACKOFF},
     pd::PdClient,
     region::RegionVerId,
-    request::{Plan, PlanContext},
+    request::Plan,
     timestamp::TimestampExt,
     transaction::requests,
     Error, Result,
@@ -68,7 +68,7 @@ pub async fn resolve_locks(
                     .retry_region(DEFAULT_REGION_BACKOFF)
                     .post_process_default()
                     .plan();
-                let commit_version = plan.execute(PlanContext::default()).await?;
+                let commit_version = plan.execute().await?;
                 commit_versions.insert(lock.lock_version, commit_version);
                 commit_version
             }
@@ -113,7 +113,7 @@ async fn resolve_lock_with_retry(
             .retry_region(Backoff::no_backoff())
             .extract_error()
             .plan();
-        match plan.execute(PlanContext::default()).await {
+        match plan.execute().await {
             Ok(_) => {
                 return Ok(ver_id);
             }

--- a/src/transaction/lock.rs
+++ b/src/transaction/lock.rs
@@ -4,7 +4,7 @@ use crate::{
     backoff::{Backoff, DEFAULT_REGION_BACKOFF, OPTIMISTIC_BACKOFF},
     pd::PdClient,
     region::RegionVerId,
-    request::{CollectFirst, Plan},
+    request::{CollectSingle, Plan},
     timestamp::TimestampExt,
     transaction::requests,
     Error, Result,
@@ -65,7 +65,7 @@ pub async fn resolve_locks(
                 let plan = crate::request::PlanBuilder::new(pd_client.clone(), request)
                     .resolve_lock(OPTIMISTIC_BACKOFF)
                     .retry_multi_region(DEFAULT_REGION_BACKOFF)
-                    .merge(CollectFirst)
+                    .merge(CollectSingle)
                     .post_process_default()
                     .plan();
                 let commit_version = plan.execute().await?;

--- a/src/transaction/lock.rs
+++ b/src/transaction/lock.rs
@@ -4,7 +4,7 @@ use crate::{
     backoff::{Backoff, DEFAULT_REGION_BACKOFF, OPTIMISTIC_BACKOFF},
     pd::PdClient,
     region::RegionVerId,
-    request::{CollectSingleKey, Plan},
+    request::{CollectFirst, Plan},
     timestamp::TimestampExt,
     transaction::requests,
     Error, Result,
@@ -65,7 +65,7 @@ pub async fn resolve_locks(
                 let plan = crate::request::PlanBuilder::new(pd_client.clone(), request)
                     .resolve_lock(OPTIMISTIC_BACKOFF)
                     .retry_multi_region(DEFAULT_REGION_BACKOFF)
-                    .merge(CollectSingleKey)
+                    .merge(CollectFirst)
                     .post_process_default()
                     .plan();
                 let commit_version = plan.execute().await?;

--- a/src/transaction/requests.rs
+++ b/src/transaction/requests.rs
@@ -229,11 +229,7 @@ impl Shardable for kvrpcpb::PrewriteRequest {
     ) -> BoxStream<'static, Result<(Self::Shard, Store)>> {
         let mut mutations = self.mutations.clone();
         mutations.sort_by(|a, b| a.key.cmp(&b.key));
-        store_stream_for_keys(
-            mutations.into_iter(),
-            pd_client.clone(),
-            read_through_cache,
-        )
+        store_stream_for_keys(mutations.into_iter(), pd_client.clone(), read_through_cache)
     }
 
     fn apply_shard(&mut self, shard: Self::Shard, store: &Store) -> Result<()> {
@@ -357,11 +353,7 @@ impl Shardable for kvrpcpb::PessimisticLockRequest {
     ) -> BoxStream<'static, Result<(Self::Shard, Store)>> {
         let mut mutations = self.mutations.clone();
         mutations.sort_by(|a, b| a.key.cmp(&b.key));
-        store_stream_for_keys(
-            mutations.into_iter(),
-            pd_client.clone(),
-            read_through_cache,
-        )
+        store_stream_for_keys(mutations.into_iter(), pd_client.clone(), read_through_cache)
     }
 
     fn apply_shard(&mut self, shard: Self::Shard, store: &Store) -> Result<()> {

--- a/src/transaction/requests.rs
+++ b/src/transaction/requests.rs
@@ -4,7 +4,7 @@ use crate::{
     collect_first,
     pd::PdClient,
     request::{
-        Collect, CollectSingleKey, DefaultProcessor, HasKeys, KvRequest, Merge, Process, Shardable,
+        Collect, CollectFirst, DefaultProcessor, HasKeys, KvRequest, Merge, Process, Shardable,
         SingleKey,
     },
     store::{store_stream_for_keys, store_stream_for_range_by_start_key, RegionStore},

--- a/src/transaction/requests.rs
+++ b/src/transaction/requests.rs
@@ -4,7 +4,7 @@ use crate::{
     collect_first,
     pd::PdClient,
     request::{
-        Collect, CollectFirst, DefaultProcessor, HasKeys, KvRequest, Merge, Process, Shardable,
+        Collect, CollectSingle, DefaultProcessor, HasKeys, KvRequest, Merge, Process, Shardable,
         SingleKey,
     },
     store::{store_stream_for_keys, store_stream_for_range_by_start_key, RegionStore},

--- a/src/transaction/requests.rs
+++ b/src/transaction/requests.rs
@@ -225,10 +225,15 @@ impl Shardable for kvrpcpb::PrewriteRequest {
     fn shards(
         &self,
         pd_client: &Arc<impl PdClient>,
+        read_through_cache: bool,
     ) -> BoxStream<'static, Result<(Self::Shard, Store)>> {
         let mut mutations = self.mutations.clone();
         mutations.sort_by(|a, b| a.key.cmp(&b.key));
-        store_stream_for_keys(mutations.into_iter(), pd_client.clone())
+        store_stream_for_keys(
+            mutations.into_iter(),
+            pd_client.clone(),
+            read_through_cache,
+        )
     }
 
     fn apply_shard(&mut self, shard: Self::Shard, store: &Store) -> Result<()> {
@@ -348,10 +353,15 @@ impl Shardable for kvrpcpb::PessimisticLockRequest {
     fn shards(
         &self,
         pd_client: &Arc<impl PdClient>,
+        read_through_cache: bool,
     ) -> BoxStream<'static, Result<(Self::Shard, Store)>> {
         let mut mutations = self.mutations.clone();
         mutations.sort_by(|a, b| a.key.cmp(&b.key));
-        store_stream_for_keys(mutations.into_iter(), pd_client.clone())
+        store_stream_for_keys(
+            mutations.into_iter(),
+            pd_client.clone(),
+            read_through_cache,
+        )
     }
 
     fn apply_shard(&mut self, shard: Self::Shard, store: &Store) -> Result<()> {
@@ -428,8 +438,13 @@ impl Shardable for kvrpcpb::ScanLockRequest {
     fn shards(
         &self,
         pd_client: &Arc<impl PdClient>,
+        read_through_cache: bool,
     ) -> BoxStream<'static, Result<(Self::Shard, Store)>> {
-        store_stream_for_range_by_start_key(self.start_key.clone().into(), pd_client.clone())
+        store_stream_for_range_by_start_key(
+            self.start_key.clone().into(),
+            pd_client.clone(),
+            read_through_cache,
+        )
     }
 
     fn apply_shard(&mut self, shard: Self::Shard, store: &Store) -> Result<()> {

--- a/src/transaction/requests.rs
+++ b/src/transaction/requests.rs
@@ -1,9 +1,11 @@
 // Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
 
 use crate::{
+    collect_first,
     pd::PdClient,
     request::{
-        Collect, DefaultProcessor, HasKeys, KvRequest, Merge, Process, Shardable, SingleKey,
+        Collect, CollectSingleKey, DefaultProcessor, HasKeys, KvRequest, Merge, Process, Shardable,
+        SingleKey,
     },
     store::{store_stream_for_keys, store_stream_for_range_by_start_key, RegionStore},
     timestamp::TimestampExt,
@@ -13,7 +15,10 @@ use crate::{
 };
 use futures::stream::BoxStream;
 use std::{collections::HashMap, iter, sync::Arc};
-use tikv_client_proto::{kvrpcpb, pdpb::Timestamp};
+use tikv_client_proto::{
+    kvrpcpb::{self, TxnHeartBeatResponse},
+    pdpb::Timestamp,
+};
 
 // implement HasLocks for a response type that has a `pairs` field,
 // where locks can be extracted from both the `pairs` and `error` fields
@@ -67,6 +72,8 @@ impl KvRequest for kvrpcpb::GetRequest {
     type Response = kvrpcpb::GetResponse;
 }
 
+shardable_key!(kvrpcpb::GetRequest);
+collect_first!(kvrpcpb::GetResponse);
 impl SingleKey for kvrpcpb::GetRequest {
     fn key(&self) -> &Vec<u8> {
         &self.key
@@ -154,6 +161,10 @@ pub fn new_resolve_lock_request(
     req
 }
 
+// Note: ResolveLockRequest is a special one: it can be sent to a specified
+// region without keys. So it's not Shardable. And we don't automatically retry
+// on its region errors (in the Plan level). The region error must be manually
+// handled (in the upper level).
 impl KvRequest for kvrpcpb::ResolveLockRequest {
     type Response = kvrpcpb::ResolveLockResponse;
 }
@@ -170,6 +181,8 @@ impl KvRequest for kvrpcpb::CleanupRequest {
     type Response = kvrpcpb::CleanupResponse;
 }
 
+shardable_key!(kvrpcpb::CleanupRequest);
+collect_first!(kvrpcpb::CleanupResponse);
 impl SingleKey for kvrpcpb::CleanupRequest {
     fn key(&self) -> &Vec<u8> {
         &self.key
@@ -466,6 +479,26 @@ impl KvRequest for kvrpcpb::TxnHeartBeatRequest {
     type Response = kvrpcpb::TxnHeartBeatResponse;
 }
 
+impl Shardable for kvrpcpb::TxnHeartBeatRequest {
+    type Shard = Vec<Vec<u8>>;
+
+    fn shards(
+        &self,
+        pd_client: &Arc<impl PdClient>,
+    ) -> BoxStream<'static, Result<(Self::Shard, RegionStore)>> {
+        crate::store::store_stream_for_keys(std::iter::once(self.key().clone()), pd_client.clone())
+    }
+
+    fn apply_shard(&mut self, mut shard: Self::Shard, store: &RegionStore) -> Result<()> {
+        self.set_context(store.region.context()?);
+        assert!(shard.len() == 1);
+        self.primary_lock = shard.pop().unwrap();
+        Ok(())
+    }
+}
+
+collect_first!(TxnHeartBeatResponse);
+
 impl SingleKey for kvrpcpb::TxnHeartBeatRequest {
     fn key(&self) -> &Vec<u8> {
         &self.primary_lock
@@ -482,6 +515,24 @@ impl Process<kvrpcpb::TxnHeartBeatResponse> for DefaultProcessor {
 
 impl KvRequest for kvrpcpb::CheckTxnStatusRequest {
     type Response = kvrpcpb::CheckTxnStatusResponse;
+}
+
+impl Shardable for kvrpcpb::CheckTxnStatusRequest {
+    type Shard = Vec<Vec<u8>>;
+
+    fn shards(
+        &self,
+        pd_client: &Arc<impl PdClient>,
+    ) -> BoxStream<'static, Result<(Self::Shard, RegionStore)>> {
+        crate::store::store_stream_for_keys(std::iter::once(self.key().clone()), pd_client.clone())
+    }
+
+    fn apply_shard(&mut self, mut shard: Self::Shard, store: &RegionStore) -> Result<()> {
+        self.set_context(store.region.context()?);
+        assert!(shard.len() == 1);
+        self.set_primary_key(shard.pop().unwrap());
+        Ok(())
+    }
 }
 
 impl SingleKey for kvrpcpb::CheckTxnStatusRequest {

--- a/src/transaction/requests.rs
+++ b/src/transaction/requests.rs
@@ -245,7 +245,7 @@ impl Shardable for kvrpcpb::PrewriteRequest {
     }
 
     fn apply_shard(&mut self, shard: Self::Shard, store: &RegionStore) -> Result<()> {
-        self.set_context(store.region.context()?);
+        self.set_context(store.region_with_leader.context()?);
 
         // Only need to set secondary keys if we're sending the primary key.
         if self.use_async_commit && !self.mutations.iter().any(|m| m.key == self.primary_lock) {
@@ -368,7 +368,7 @@ impl Shardable for kvrpcpb::PessimisticLockRequest {
     }
 
     fn apply_shard(&mut self, shard: Self::Shard, store: &RegionStore) -> Result<()> {
-        self.set_context(store.region.context()?);
+        self.set_context(store.region_with_leader.context()?);
         self.set_mutations(shard);
         Ok(())
     }
@@ -446,7 +446,7 @@ impl Shardable for kvrpcpb::ScanLockRequest {
     }
 
     fn apply_shard(&mut self, shard: Self::Shard, store: &RegionStore) -> Result<()> {
-        self.set_context(store.region.context()?);
+        self.set_context(store.region_with_leader.context()?);
         self.set_start_key(shard);
         Ok(())
     }
@@ -490,7 +490,7 @@ impl Shardable for kvrpcpb::TxnHeartBeatRequest {
     }
 
     fn apply_shard(&mut self, mut shard: Self::Shard, store: &RegionStore) -> Result<()> {
-        self.set_context(store.region.context()?);
+        self.set_context(store.region_with_leader.context()?);
         assert!(shard.len() == 1);
         self.primary_lock = shard.pop().unwrap();
         Ok(())
@@ -528,7 +528,7 @@ impl Shardable for kvrpcpb::CheckTxnStatusRequest {
     }
 
     fn apply_shard(&mut self, mut shard: Self::Shard, store: &RegionStore) -> Result<()> {
-        self.set_context(store.region.context()?);
+        self.set_context(store.region_with_leader.context()?);
         assert!(shard.len() == 1);
         self.set_primary_key(shard.pop().unwrap());
         Ok(())

--- a/src/transaction/transaction.rs
+++ b/src/transaction/transaction.rs
@@ -4,7 +4,7 @@ use crate::{
     backoff::{Backoff, DEFAULT_REGION_BACKOFF},
     pd::{PdClient, PdRpcClient},
     request::{
-        Collect, CollectAndMatchKey, CollectError, CollectFirst, Plan, PlanBuilder, RetryOptions,
+        Collect, CollectAndMatchKey, CollectError, CollectSingle, Plan, PlanBuilder, RetryOptions,
     },
     timestamp::TimestampExt,
     transaction::{buffer::Buffer, lowering::*},
@@ -120,7 +120,7 @@ impl<PdC: PdClient> Transaction<PdC> {
                 let plan = PlanBuilder::new(rpc, request)
                     .resolve_lock(retry_options.lock_backoff)
                     .retry_multi_region(DEFAULT_REGION_BACKOFF)
-                    .merge(CollectFirst)
+                    .merge(CollectSingle)
                     .post_process_default()
                     .plan();
                 plan.execute().await
@@ -659,7 +659,7 @@ impl<PdC: PdClient> Transaction<PdC> {
         let plan = PlanBuilder::new(self.rpc.clone(), request)
             .resolve_lock(self.options.retry_options.lock_backoff.clone())
             .retry_multi_region(self.options.retry_options.region_backoff.clone())
-            .merge(CollectFirst)
+            .merge(CollectSingle)
             .post_process_default()
             .plan();
         plan.execute().await
@@ -816,7 +816,7 @@ impl<PdC: PdClient> Transaction<PdC> {
                 );
                 let plan = PlanBuilder::new(rpc.clone(), request)
                     .retry_multi_region(region_backoff.clone())
-                    .merge(CollectFirst)
+                    .merge(CollectSingle)
                     .plan();
                 plan.execute().await?;
             }

--- a/src/transaction/transaction.rs
+++ b/src/transaction/transaction.rs
@@ -4,8 +4,7 @@ use crate::{
     backoff::{Backoff, DEFAULT_REGION_BACKOFF},
     pd::{PdClient, PdRpcClient},
     request::{
-        Collect, CollectAndMatchKey, CollectError, CollectSingleKey, Plan, PlanBuilder,
-        RetryOptions,
+        Collect, CollectAndMatchKey, CollectError, CollectFirst, Plan, PlanBuilder, RetryOptions,
     },
     timestamp::TimestampExt,
     transaction::{buffer::Buffer, lowering::*},
@@ -121,7 +120,7 @@ impl<PdC: PdClient> Transaction<PdC> {
                 let plan = PlanBuilder::new(rpc, request)
                     .resolve_lock(retry_options.lock_backoff)
                     .retry_multi_region(DEFAULT_REGION_BACKOFF)
-                    .merge(CollectSingleKey)
+                    .merge(CollectFirst)
                     .post_process_default()
                     .plan();
                 plan.execute().await
@@ -660,7 +659,7 @@ impl<PdC: PdClient> Transaction<PdC> {
         let plan = PlanBuilder::new(self.rpc.clone(), request)
             .resolve_lock(self.options.retry_options.lock_backoff.clone())
             .retry_multi_region(self.options.retry_options.region_backoff.clone())
-            .merge(CollectSingleKey)
+            .merge(CollectFirst)
             .post_process_default()
             .plan();
         plan.execute().await
@@ -817,7 +816,7 @@ impl<PdC: PdClient> Transaction<PdC> {
                 );
                 let plan = PlanBuilder::new(rpc.clone(), request)
                     .retry_multi_region(region_backoff.clone())
-                    .merge(CollectSingleKey)
+                    .merge(CollectFirst)
                     .plan();
                 plan.execute().await?;
             }

--- a/src/transaction/transaction.rs
+++ b/src/transaction/transaction.rs
@@ -1251,10 +1251,10 @@ mod tests {
         let heartbeats_cloned = heartbeats.clone();
         let pd_client = Arc::new(MockPdClient::new(MockKvClient::with_dispatch_hook(
             move |req: &dyn Any| {
-                if let Some(_) = req.downcast_ref::<kvrpcpb::TxnHeartBeatRequest>() {
+                if req.downcast_ref::<kvrpcpb::TxnHeartBeatRequest>().is_some() {
                     heartbeats_cloned.fetch_add(1, Ordering::SeqCst);
                     Ok(Box::new(kvrpcpb::TxnHeartBeatResponse::default()) as Box<dyn Any>)
-                } else if let Some(_) = req.downcast_ref::<kvrpcpb::PrewriteRequest>() {
+                } else if req.downcast_ref::<kvrpcpb::PrewriteRequest>().is_some() {
                     Ok(Box::new(kvrpcpb::PrewriteResponse::default()) as Box<dyn Any>)
                 } else {
                     Ok(Box::new(kvrpcpb::CommitResponse::default()) as Box<dyn Any>)
@@ -1285,12 +1285,15 @@ mod tests {
         let heartbeats_cloned = heartbeats.clone();
         let pd_client = Arc::new(MockPdClient::new(MockKvClient::with_dispatch_hook(
             move |req: &dyn Any| {
-                if let Some(_) = req.downcast_ref::<kvrpcpb::TxnHeartBeatRequest>() {
+                if req.downcast_ref::<kvrpcpb::TxnHeartBeatRequest>().is_some() {
                     heartbeats_cloned.fetch_add(1, Ordering::SeqCst);
                     Ok(Box::new(kvrpcpb::TxnHeartBeatResponse::default()) as Box<dyn Any>)
-                } else if let Some(_) = req.downcast_ref::<kvrpcpb::PrewriteRequest>() {
+                } else if req.downcast_ref::<kvrpcpb::PrewriteRequest>().is_some() {
                     Ok(Box::new(kvrpcpb::PrewriteResponse::default()) as Box<dyn Any>)
-                } else if let Some(_) = req.downcast_ref::<kvrpcpb::PessimisticLockRequest>() {
+                } else if req
+                    .downcast_ref::<kvrpcpb::PessimisticLockRequest>()
+                    .is_some()
+                {
                     Ok(Box::new(kvrpcpb::PessimisticLockResponse::default()) as Box<dyn Any>)
                 } else {
                     Ok(Box::new(kvrpcpb::CommitResponse::default()) as Box<dyn Any>)

--- a/src/transaction/transaction.rs
+++ b/src/transaction/transaction.rs
@@ -522,8 +522,8 @@ impl<PdC: PdClient> Transaction<PdC> {
                 }
             }
             TransactionKind::Pessimistic(_) => {
-                let keys: Vec<Key> = keys.into_iter().map(|k| k.into()).collect();
-                self.pessimistic_lock(keys.into_iter(), false).await?;
+                self.pessimistic_lock(keys.into_iter().map(|k| k.into()), false)
+                    .await?;
             }
         }
         Ok(())

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -89,7 +89,7 @@ async fn ensure_region_split(
 pub fn pd_addrs() -> Vec<String> {
     env::var(ENV_PD_ADDRS)
         .unwrap_or_else(|_| "127.0.0.1:2379".to_owned())
-        .split(",")
+        .split(',')
         .map(From::from)
         .collect()
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -88,7 +88,13 @@ async fn ensure_region_split(
 
 pub fn pd_addrs() -> Vec<String> {
     env::var(ENV_PD_ADDRS)
-        .unwrap_or_else(|_| "127.0.0.1:2379".to_owned())
+        .unwrap_or_else(|_| {
+            info!(
+                "Environment variable {} is not found. Using {:?} as default.",
+                ENV_PD_ADDRS, "127.0.0.1:2379"
+            );
+            "127.0.0.1:2379".to_owned()
+        })
         .split(',')
         .map(From::from)
         .collect()

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -88,7 +88,7 @@ async fn ensure_region_split(
 
 pub fn pd_addrs() -> Vec<String> {
     env::var(ENV_PD_ADDRS)
-        .expect(&format!("Expected {}:", ENV_PD_ADDRS))
+        .unwrap_or_else(|_| "127.0.0.1:2379".to_owned())
         .split(",")
         .map(From::from)
         .collect()

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -697,7 +697,7 @@ async fn txn_get_for_update() -> Result<()> {
     assert!(t1.get_for_update(key1.clone()).await?.unwrap() == value1);
     t1.commit().await?;
 
-    assert!(t2.batch_get(keys.clone()).await?.collect::<Vec<_>>().len() == 0);
+    assert!(t2.batch_get(keys.clone()).await?.count() == 0);
     let res: HashMap<_, _> = t2
         .batch_get_for_update(keys.clone())
         .await?
@@ -711,7 +711,7 @@ async fn txn_get_for_update() -> Result<()> {
     assert!(t3.get_for_update(key1).await?.is_none());
     assert!(t3.commit().await.is_err());
 
-    assert!(t4.batch_get_for_update(keys).await?.len() == 0);
+    assert!(t4.batch_get_for_update(keys).await?.is_empty());
     assert!(t4.commit().await.is_err());
 
     Ok(())

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -359,7 +359,7 @@ async fn txn_bank_transfer() -> Result<()> {
             .await?;
         txn.put(bob.clone(), bob_balance.to_be_bytes().to_vec())
             .await?;
-        let _ = txn.commit().await;
+        txn.commit().await?;
     }
 
     // check

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -322,7 +322,6 @@ async fn txn_read() -> Result<()> {
 // FIXME: the test is temporarily ingnored since it's easy to fail when scheduling is frequent.
 #[tokio::test]
 #[serial]
-#[ignore]
 async fn txn_bank_transfer() -> Result<()> {
     init().await?;
     let client = TransactionClient::new(pd_addrs()).await?;
@@ -360,7 +359,7 @@ async fn txn_bank_transfer() -> Result<()> {
             .await?;
         txn.put(bob.clone(), bob_balance.to_be_bytes().to_vec())
             .await?;
-        txn.commit().await?;
+        let _ = txn.commit().await;
     }
 
     // check

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -309,8 +309,8 @@ async fn txn_read() -> Result<()> {
     .collect::<Vec<_>>();
 
     let mut txn = client.begin_pessimistic().await?;
-    let res = txn.batch_get(keys.clone()).await?.collect::<Vec<_>>();
-    assert_eq!(res.len(), keys.len());
+    let res = txn.batch_get(keys.clone()).await?;
+    assert_eq!(res.count(), keys.len());
 
     let res = txn.batch_get_for_update(keys.clone()).await?;
     assert_eq!(res.len(), keys.len());

--- a/tikv-client-common/Cargo.toml
+++ b/tikv-client-common/Cargo.toml
@@ -15,6 +15,7 @@ lazy_static = "1"
 log = "0.4"
 regex = "1"
 tikv-client-proto = { version = "0.0.99", path = "../tikv-client-proto" }
+tokio = "1"
 
 [dev-dependencies]
 clap = "2"
@@ -22,4 +23,4 @@ fail = { version = "0.4", features = [ "failpoints" ] }
 proptest = "1"
 proptest-derive = "0.3"
 tempfile = "3"
-tokio = "1.0"
+tokio = "1"

--- a/tikv-client-common/src/errors.rs
+++ b/tikv-client-common/src/errors.rs
@@ -55,9 +55,12 @@ pub enum Error {
     /// Wraps `tikv_client_proto::kvrpcpb::KeyError`
     #[error("{0:?}")]
     KeyError(tikv_client_proto::kvrpcpb::KeyError),
-    /// Multiple errors
+    /// Multiple errors generated from the ExtractError plan.
     #[error("Multiple errors: {0:?}")]
-    MultipleErrors(Vec<Error>),
+    ExtractedErrors(Vec<Error>),
+    /// Multiple key errors
+    #[error("Multiple key errors: {0:?}")]
+    MultipleKeyErrors(Vec<Error>),
     /// Invalid ColumnFamily
     #[error("Unsupported column family {}", _0)]
     ColumnFamilyError(String),

--- a/tikv-client-common/src/errors.rs
+++ b/tikv-client-common/src/errors.rs
@@ -33,6 +33,10 @@ pub enum Error {
         "The operation is not supported in current mode, please consider using RawClient with or without atomic mode"
     )]
     UnsupportedMode,
+    #[error("There is no current_regions in the EpochNotMatch error")]
+    NoCurrentRegions,
+    #[error("The specified entry is not found in the region cache")]
+    EntryNotFoundInRegionCache,
     /// Wraps a `std::io::Error`.
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),

--- a/tikv-client-common/src/errors.rs
+++ b/tikv-client-common/src/errors.rs
@@ -63,9 +63,9 @@ pub enum Error {
     /// No region is found for the given key.
     #[error("Region is not found for key: {:?}", key)]
     RegionForKeyNotFound { key: Vec<u8> },
-    /// No region is found for the given id.
-    #[error("Region {} is not found", region_id)]
-    RegionNotFound { region_id: u64 },
+    /// No region is found for the given id. note: distinguish it with the RegionNotFound error in errorpb.
+    #[error("Region {} is not found in the response", region_id)]
+    RegionNotFoundInResponse { region_id: u64 },
     /// No leader is found for the given id.
     #[error("Leader of region {} is not found", region_id)]
     LeaderNotFound { region_id: u64 },

--- a/tikv-client-common/src/errors.rs
+++ b/tikv-client-common/src/errors.rs
@@ -57,6 +57,9 @@ pub enum Error {
     /// Invalid ColumnFamily
     #[error("Unsupported column family {}", _0)]
     ColumnFamilyError(String),
+    /// Can't join tokio tasks
+    #[error("Failed to join tokio tasks")]
+    JoinError(#[from] tokio::task::JoinError),
     /// No region is found for the given key.
     #[error("Region is not found for key: {:?}", key)]
     RegionForKeyNotFound { key: Vec<u8> },

--- a/tikv-client-store/src/errors.rs
+++ b/tikv-client-store/src/errors.rs
@@ -182,13 +182,12 @@ impl<T: HasRegionError, E> HasRegionError for Result<T, E> {
 
 impl<T: HasRegionError> HasRegionError for Vec<T> {
     fn region_error(&mut self) -> Option<Error> {
-        for t in self {
-            if let Some(e) = t.region_error() {
-                return Some(e);
-            }
+        let errors: Vec<_> = self.iter_mut().filter_map(|x| x.region_error()).collect();
+        if errors.is_empty() {
+            None
+        } else {
+            Some(Error::MultipleErrors(errors))
         }
-
-        None
     }
 }
 

--- a/tikv-client-store/src/errors.rs
+++ b/tikv-client-store/src/errors.rs
@@ -6,12 +6,12 @@ use tikv_client_proto::kvrpcpb;
 
 // Those that can have a single region error
 pub trait HasRegionError {
-    fn region_error(&mut self) -> Option<Error>;
+    fn region_error(&mut self) -> Option<tikv_client_proto::errorpb::Error>;
 }
 
 // Those that can have multiple region errors
 pub trait HasRegionErrors {
-    fn region_errors(&mut self) -> Option<Vec<Error>>;
+    fn region_errors(&mut self) -> Option<Vec<tikv_client_proto::errorpb::Error>>;
 }
 
 pub trait HasKeyErrors {
@@ -19,7 +19,7 @@ pub trait HasKeyErrors {
 }
 
 impl<T: HasRegionError> HasRegionErrors for T {
-    fn region_errors(&mut self) -> Option<Vec<Error>> {
+    fn region_errors(&mut self) -> Option<Vec<tikv_client_proto::errorpb::Error>> {
         self.region_error().map(|e| vec![e])
     }
 }
@@ -27,7 +27,7 @@ impl<T: HasRegionError> HasRegionErrors for T {
 macro_rules! has_region_error {
     ($type:ty) => {
         impl HasRegionError for $type {
-            fn region_error(&mut self) -> Option<Error> {
+            fn region_error(&mut self) -> Option<tikv_client_proto::errorpb::Error> {
                 if self.has_region_error() {
                     Some(self.take_region_error().into())
                 } else {
@@ -187,13 +187,13 @@ impl<T: HasKeyErrors> HasKeyErrors for Vec<T> {
 }
 
 impl<T: HasRegionError, E> HasRegionError for Result<T, E> {
-    fn region_error(&mut self) -> Option<Error> {
+    fn region_error(&mut self) -> Option<tikv_client_proto::errorpb::Error> {
         self.as_mut().ok().and_then(|t| t.region_error())
     }
 }
 
 impl<T: HasRegionError> HasRegionErrors for Vec<T> {
-    fn region_errors(&mut self) -> Option<Vec<Error>> {
+    fn region_errors(&mut self) -> Option<Vec<tikv_client_proto::errorpb::Error>> {
         let errors: Vec<_> = self.iter_mut().filter_map(|x| x.region_error()).collect();
         if errors.is_empty() {
             None

--- a/tikv-client-store/src/lib.rs
+++ b/tikv-client-store/src/lib.rs
@@ -7,7 +7,7 @@ mod request;
 #[doc(inline)]
 pub use crate::{
     client::{KvClient, KvConnect, TikvConnect},
-    errors::{HasError, HasRegionError},
+    errors::{HasKeyErrors, HasRegionError, HasRegionErrors},
     request::Request,
 };
 pub use tikv_client_common::{security::SecurityManager, Error, Result};


### PR DESCRIPTION
The PR adds a minimal region cache implementation. It's far away from maturity. It's intended to discuss how the structure should look.

Related issue: #299 

## Main changes:
- Place the region cache as a component in `PdRpcClient`. `PdRpcClient` -> region cache -> retry client (the low level pd client)
- Make single-region plan a special case of multi-region plan

Credit to #116, #121 and #139. Since there have been some refactoring after the previous work, I didn't continue development based on those commits.

## Naive manual benchmark

Environment: single machine, 1 PD, 3 TiKV, default scheduler + shuffle-region + shuffle-leader
Workload: 6 threads, 512 workers,  50% single-key-read, 50% single-key-write

- zipfian distribution, pessimistic txns

master: TPS: 1943.9. Latency: mean: 41ms, P99: 1018ms, maximum: 1815ms
This PR: TPS 2108.5. Latency: mean: 12ms, P99: 108ms, maximum: 1061ms

- uniform distribution, optimistic txns

master: TPS: 4279.4, mean: 70ms, P99: 1048ms, maximum: 2601ms
This PR: TPS: 21129.8, mean: 22ms, P99: 44ms, maximum: 286ms

## Todo
- [x] Remove `read_through_cache` parameters, if we can always know the invalid cache entry
- [x] Treat single-region as a special case of multi-region
- [ ] Test
- [ ] Save unnecessary PD requests if they are querying the same region
- [ ] Finer grained error handling
- [ ] Naming