### PR TITLE
Make the results of batch_get sendable

### DIFF
--- a/src/transaction/buffer.rs
+++ b/src/transaction/buffer.rs
@@ -69,7 +69,7 @@ impl Buffer {
         f: F,
     ) -> Result<impl Iterator<Item = KvPair>>
     where
-        F: FnOnce(Box<dyn Iterator<Item = Key>>) -> Fut,
+        F: FnOnce(Box<dyn Iterator<Item = Key> + Send>) -> Fut,
         Fut: Future<Output = Result<Vec<KvPair>>>,
     {
         let (cached_results, undetermined_keys) = {


### PR DESCRIPTION
This is part of the work to bring Py client up-to-date: https://github.com/tikv/client-py/pull/13