### PR TITLE
Add method of gettimestamp for transaction

### DIFF
--- a/src/transaction/client.rs
+++ b/src/transaction/client.rs
@@ -183,7 +183,9 @@ impl Client {
 
     /// Request garbage collection (GC) of the TiKV cluster.
     ///
-    /// GC deletes MVCC records whose timestamp is lower than the given `safepoint`.
+    /// GC deletes MVCC records whose timestamp is lower than the given `safepoint`. We must guarantee
+    ///  that all transactions started before this timestamp had committed. We can keep an active
+    /// transaction list in application to decide the minimal start timestamp of them.
     ///
     /// For each key, the last mutation record (unless it's a deletion) before `safepoint` is retained.
     ///

--- a/src/transaction/client.rs
+++ b/src/transaction/client.rs
@@ -185,7 +185,7 @@ impl Client {
     ///
     /// GC deletes MVCC records whose timestamp is lower than the given `safepoint`. We must guarantee
     ///  that all transactions started before this timestamp had committed. We can keep an active
-    /// transaction list in application to decide the minimal start timestamp of them.
+    /// transaction list in application to decide which is the minimal start timestamp of them.
     ///
     /// For each key, the last mutation record (unless it's a deletion) before `safepoint` is retained.
     ///

--- a/src/transaction/transaction.rs
+++ b/src/transaction/transaction.rs
@@ -635,7 +635,7 @@ impl<PdC: PdClient> Transaction<PdC> {
         res
     }
 
-    /// Get the start timestamp of this transaction begin
+    /// Get the start timestamp of this transaction.
     pub fn get_start_timestamp(&self) -> Timestamp {
         self.timestamp.clone()
     }

--- a/src/transaction/transaction.rs
+++ b/src/transaction/transaction.rs
@@ -636,7 +636,7 @@ impl<PdC: PdClient> Transaction<PdC> {
     }
 
     /// Get the start timestamp of this transaction.
-    pub fn get_start_timestamp(&self) -> Timestamp {
+    pub fn start_timestamp(&self) -> Timestamp {
         self.timestamp.clone()
     }
 

--- a/src/transaction/transaction.rs
+++ b/src/transaction/transaction.rs
@@ -635,6 +635,11 @@ impl<PdC: PdClient> Transaction<PdC> {
         res
     }
 
+    /// Get the start timestamp of this transaction begin
+    pub fn get_start_timestamp(&self) -> Timestamp {
+        self.timestamp.clone()
+    }
+
     /// Send a heart beat message to keep the transaction alive on the server and update its TTL.
     ///
     /// Returns the TTL set on the transaction's locks by TiKV.


### PR DESCRIPTION
Signed-off-by: Little-Wallace <bupt2013211450@gmail.com>

to close: https://github.com/tikv/client-rust/issues/302 

We need a method to get started time of transaction, so that we can know that what is the time point of the earliest started transaction which has still not commit or rollback.