### PR TITLE
doc: use the tikv-slim mode in tiup >= 1.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,15 +21,16 @@ test: unit-test integration-test
 doc: 
 	cargo doc --workspace --exclude tikv-client-proto --document-private-items --no-deps
 
-docker-pd:
-	docker run -d -v $(shell pwd)/config:/config --net=host --name pd --rm pingcap/pd:latest --name "pd" --data-dir "pd" --client-urls "http://127.0.0.1:2379" --advertise-client-urls "http://127.0.0.1:2379" --config /config/pd.toml
+# Deprecated
+# docker-pd:
+# 	docker run -d -v $(shell pwd)/config:/config --net=host --name pd --rm pingcap/pd:latest --name "pd" --data-dir "pd" --client-urls "http://127.0.0.1:2379" --advertise-client-urls "http://127.0.0.1:2379" --config /config/pd.toml
 
-docker-kv:
-	docker run -d -v $(shell pwd)/config:/config --net=host --name kv --rm --ulimit nofile=90000:90000 pingcap/tikv:latest --pd-endpoints "127.0.0.1:2379" --addr "127.0.0.1:2378" --data-dir "kv" --config /config/tikv.toml
+# docker-kv:
+# 	docker run -d -v $(shell pwd)/config:/config --net=host --name kv --rm --ulimit nofile=90000:90000 pingcap/tikv:latest --pd-endpoints "127.0.0.1:2379" --addr "127.0.0.1:2378" --data-dir "kv" --config /config/tikv.toml
 
-docker: docker-pd docker-kv
+# docker: docker-pd docker-kv
 
 tiup:
-	tiup playground nightly --db 0 --tiflash 0 --monitor false --kv.config $(shell pwd)/config/tikv.toml --pd.config $(shell pwd)/config/pd.toml &
+	tiup playground nightly --mode tikv-slim --kv 3 --monitor false --kv.config $(shell pwd)/config/tikv.toml --pd.config $(shell pwd)/config/pd.toml &
 
 all: check doc test

--- a/README.md
+++ b/README.md
@@ -115,10 +115,10 @@ We welcome your contributions! Contributing code is great, we also appreciate fi
 
 We use the standard Cargo workflows, e.g., `cargo build` to build and `cargo test` to run unit tests. You will need to use a nightly Rust toolchain to build and run tests.
 
-Running integration tests or manually testing the client with a TiKV cluster is a little bit more involved. The easiest way is to use [TiUp](https://github.com/pingcap/tiup) to initialise a cluster on your local machine:
+Running integration tests or manually testing the client with a TiKV cluster is a little bit more involved. The easiest way is to use [TiUp](https://github.com/pingcap/tiup) (>= 1.5) to initialise a cluster on your local machine:
 
 ```
-tiup playground nightly --db 0 --tiflash 0 --monitor false
+tiup playground nightly --mode tikv-slim
 ```
 
 Then if you want to run integration tests:

--- a/getting-started.md
+++ b/getting-started.md
@@ -79,7 +79,7 @@ curl --proto '=https' --tlsv1.2 -sSf https://tiup-mirrors.pingcap.com/install.sh
 then, to start a local TiKV 'cluster' for testing,
 
 ```
-tiup playground nightly --kv-only
+tiup playground nightly --mode tikv-slim
 ```
 
 For more information about TiUP, see their [docs](https://docs.pingcap.com/tidb/stable/production-deployment-using-tiup).


### PR DESCRIPTION
Since tiup 1.5, we can use a simpler parameter to start a tikv-only cluster.