### PR TITLE
chore: bump grpc-rs to 0.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ either = "1.6"
 fail = "0.4"
 futures = { version = "0.3", features = ["async-await", "thread-pool"] }
 futures-timer = "3.0"
-grpcio = { version = "0.9", features = [ "secure", "prost-codec", "use-bindgen", "openssl-vendored" ], default-features = false }
+grpcio = { version = "0.10", features = [ "prost-codec", "openssl-vendored" ], default-features = false }
 lazy_static = "1"
 log = "0.4"
 prometheus = { version = "0.12", features = [ "push", "process" ], default-features = false } 

--- a/mock-tikv/Cargo.toml
+++ b/mock-tikv/Cargo.toml
@@ -6,6 +6,6 @@ edition = "2018"
 [dependencies]
 derive-new = "0.5"
 futures = "0.3"
-grpcio = { version = "0.9", features = [ "secure", "prost-codec", "use-bindgen" ], default-features = false }
+grpcio = { version = "0.10", features = [ "prost-codec" ], default-features = false }
 log = "0.4"
 tikv-client-proto = { path = "../tikv-client-proto"}

--- a/src/kv/bound_range.rs
+++ b/src/kv/bound_range.rs
@@ -151,6 +151,8 @@ impl BoundRange {
 }
 
 impl RangeBounds<Key> for BoundRange {
+    // clippy will act differently on nightly and stable, so we allow `needless_match` here.
+    #[allow(clippy::needless_match)]
     fn start_bound(&self) -> Bound<&Key> {
         match &self.from {
             Bound::Included(f) => Bound::Included(f),

--- a/tikv-client-common/Cargo.toml
+++ b/tikv-client-common/Cargo.toml
@@ -10,7 +10,7 @@ description = "Common components of the TiKV Rust client"
 [dependencies]
 thiserror = "1"
 futures = { version = "0.3", features = ["compat", "async-await", "thread-pool"] }
-grpcio = { version = "0.9", features = [ "secure", "prost-codec", "use-bindgen" ], default-features = false }
+grpcio = { version = "0.10", features = [ "prost-codec" ], default-features = false }
 lazy_static = "1"
 log = "0.4"
 regex = "1"

--- a/tikv-client-pd/Cargo.toml
+++ b/tikv-client-pd/Cargo.toml
@@ -10,7 +10,7 @@ description = "Low level PD components for the TiKV Rust client"
 [dependencies]
 async-trait = "0.1"
 futures = { version = "0.3", features = ["compat", "async-await", "thread-pool"] }
-grpcio = { version = "0.9", features = [ "secure", "prost-codec", "use-bindgen" ], default-features = false }
+grpcio = { version = "0.10", features = [ "prost-codec" ], default-features = false }
 log = "0.4"
 tikv-client-common = { version = "0.1.0", path = "../tikv-client-common" }
 tikv-client-proto = { version = "0.1.0", path = "../tikv-client-proto" }

--- a/tikv-client-proto/Cargo.toml
+++ b/tikv-client-proto/Cargo.toml
@@ -13,8 +13,8 @@ protobuf-build = { version = "0.12", default-features = false, features = ["grpc
 
 [dependencies]
 protobuf = "2.8"
-prost = { version = "0.7" }
-prost-derive = { version = "0.7" }
+prost = { version = "0.9" }
+prost-derive = { version = "0.9" }
 futures = "0.3"
-grpcio = { version = "0.9", default-features = false, features = ["secure", "prost-codec", "use-bindgen"] }
+grpcio = { version = "0.10", features = [ "prost-codec" ], default-features = false }
 lazy_static = { version = "1" }

--- a/tikv-client-store/Cargo.toml
+++ b/tikv-client-store/Cargo.toml
@@ -11,7 +11,7 @@ description = "Low level TiKV node components of the TiKV Rust client"
 async-trait = "0.1"
 derive-new = "0.5"
 futures = { version = "0.3", features = ["compat", "async-await", "thread-pool"] }
-grpcio = { version = "0.9", features = ["secure", "prost-codec", "use-bindgen"], default-features = false }
+grpcio = { version = "0.10", features = [ "prost-codec" ], default-features = false }
 log = "0.4"
 tikv-client-common = { version = "0.1.0", path = "../tikv-client-common" }
 tikv-client-proto = { version = "0.1.0", path = "../tikv-client-proto" }

--- a/tikv-client-store/src/request.rs
+++ b/tikv-client-store/src/request.rs
@@ -38,9 +38,7 @@ macro_rules! impl_request {
                 self
             }
 
-            fn set_context(&mut self, context: kvrpcpb::Context) {
-                self.set_context(context);
-            }
+            fn set_context(&mut self, _context: kvrpcpb::Context) {}
         }
     };
 }

--- a/tikv-client-store/src/request.rs
+++ b/tikv-client-store/src/request.rs
@@ -38,7 +38,9 @@ macro_rules! impl_request {
                 self
             }
 
-            fn set_context(&mut self, _context: kvrpcpb::Context) {}
+            fn set_context(&mut self, context: kvrpcpb::Context) {
+                kvrpcpb::$name::set_context(self, context)
+            }
         }
     };
 }


### PR DESCRIPTION
Signed-off-by: Alex Chi <iskyzh@gmail.com>

The `secure` and `use-bindgen` features are removed in https://github.com/tikv/grpc-rs/pull/558

<del>Also fixes https://github.com/tikv/client-rust/issues/340</del>