### PR TITLE
don't update cache if scan is key_only

### DIFF
--- a/src/transaction/buffer.rs
+++ b/src/transaction/buffer.rs
@@ -110,6 +110,7 @@ impl Buffer {
         &mut self,
         range: BoundRange,
         limit: u32,
+        update_cache: bool,
         f: F,
     ) -> Result<impl Iterator<Item = KvPair>>
     where
@@ -147,8 +148,10 @@ impl Buffer {
         }
 
         // update local buffer
-        for (k, v) in &results {
-            self.update_cache(k.clone(), Some(v.clone()));
+        if update_cache {
+            for (k, v) in &results {
+                self.update_cache(k.clone(), Some(v.clone()));
+            }
         }
 
         let mut res = results

--- a/src/transaction/transaction.rs
+++ b/src/transaction/transaction.rs
@@ -690,6 +690,7 @@ impl<PdC: PdClient> Transaction<PdC> {
             .scan_and_fetch(
                 range.into(),
                 limit,
+                !key_only,
                 move |new_range, new_limit| async move {
                     let request = new_scan_request(new_range, timestamp, new_limit, key_only);
                     let plan = PlanBuilder::new(rpc, request)

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -395,7 +395,7 @@ async fn raw_req() -> Result<()> {
     assert_eq!(res[1].1, "v2".as_bytes());
 
     // k1,k2; batch_put then batch_get
-    let _ = client
+    client
         .batch_put(vec![
             ("k3".to_owned(), "v3".to_owned()),
             ("k4".to_owned(), "v4".to_owned()),
@@ -437,7 +437,7 @@ async fn raw_req() -> Result<()> {
     assert_eq!(res.len(), 0);
 
     // empty; batch_put then scan
-    let _ = client
+    client
         .batch_put(vec![
             ("k3".to_owned(), "v3".to_owned()),
             ("k5".to_owned(), "v5".to_owned()),

--- a/tests/mock_tikv_tests.rs
+++ b/tests/mock_tikv_tests.rs
@@ -24,8 +24,8 @@ mod test {
         assert_eq!(res.unwrap(), None);
 
         // empty; put then batch_get
-        let _ = client.put("k1".to_owned(), "v1".to_owned()).await.unwrap();
-        let _ = client.put("k2".to_owned(), "v2".to_owned()).await.unwrap();
+        client.put("k1".to_owned(), "v1".to_owned()).await.unwrap();
+        client.put("k2".to_owned(), "v2".to_owned()).await.unwrap();
 
         let res = client
             .batch_get(vec!["k1".to_owned(), "k2".to_owned(), "k3".to_owned()])
@@ -36,7 +36,7 @@ mod test {
         assert_eq!(res[1].1, "v2".as_bytes());
 
         // k1,k2; batch_put then batch_get
-        let _ = client
+        client
             .batch_put(vec![
                 KvPair::new("k3".to_owned(), "v3".to_owned()),
                 KvPair::new("k4".to_owned(), "v4".to_owned()),


### PR DESCRIPTION
A scan should not update the cache if it does not get values.