### PR TITLE
Fix region cache update error when handle not leader

### DIFF
--- a/src/region_cache.rs
+++ b/src/region_cache.rs
@@ -207,9 +207,7 @@ impl<C: RetryClientTrait> RegionCache<C> {
         leader: metapb::Peer,
     ) -> Result<()> {
         let mut cache = self.region_cache.write().await;
-        let region_entry = cache
-            .ver_id_to_region
-            .get_mut(&ver_id);
+        let region_entry = cache.ver_id_to_region.get_mut(&ver_id);
         if let Some(region) = region_entry {
             region.leader = Some(leader);
         }

--- a/src/region_cache.rs
+++ b/src/region_cache.rs
@@ -209,9 +209,11 @@ impl<C: RetryClientTrait> RegionCache<C> {
         let mut cache = self.region_cache.write().await;
         let region_entry = cache
             .ver_id_to_region
-            .get_mut(&ver_id)
-            .ok_or(Error::EntryNotFoundInRegionCache)?;
-        region_entry.leader = Some(leader);
+            .get_mut(&ver_id);
+        if let Some(region) = region_entry {
+            region.leader = Some(leader);
+        }
+
         Ok(())
     }
 


### PR DESCRIPTION
The `region cache map` may be updated by concurrency when do `handle_region_error`, this may result in a lot of `EntrynotFoundInRegionCache` error. 
We should check if region entry exists, ignore update leader if entry is none. The entry cache will be filled up in the next get region reqeust.