### PR TITLE
Fix inconsistent region cache access in chained access

### DIFF
--- a/src/pd/client.rs
+++ b/src/pd/client.rs
@@ -70,7 +70,7 @@ pub trait PdClient: Send + Sync + 'static {
     fn group_keys_by_region<K, K2>(
         self: Arc<Self>,
         keys: impl Iterator<Item = K> + Send + Sync + 'static,
-    ) -> BoxStream<'static, Result<(RegionId, Vec<K2>)>>
+    ) -> BoxStream<'static, Result<(RegionWithLeader, Vec<K2>)>>
     where
         K: AsRef<Key> + Into<K2> + Send + Sync + 'static,
         K2: Send + Sync + 'static,
@@ -81,7 +81,6 @@ pub trait PdClient: Send + Sync + 'static {
             async move {
                 if let Some(key) = keys.next() {
                     let region = this.region_for_key(key.as_ref()).await?;
-                    let id = region.id();
                     let mut grouped = vec![key.into()];
                     while let Some(key) = keys.peek() {
                         if !region.contains(key.as_ref()) {
@@ -89,7 +88,7 @@ pub trait PdClient: Send + Sync + 'static {
                         }
                         grouped.push(keys.next().unwrap().into());
                     }
-                    Ok(Some((keys, (id, grouped))))
+                    Ok(Some((keys, (region, grouped))))
                 } else {
                     Ok(None)
                 }
@@ -133,7 +132,7 @@ pub trait PdClient: Send + Sync + 'static {
     fn group_ranges_by_region(
         self: Arc<Self>,
         mut ranges: Vec<kvrpcpb::KeyRange>,
-    ) -> BoxStream<'static, Result<(RegionId, Vec<kvrpcpb::KeyRange>)>> {
+    ) -> BoxStream<'static, Result<(RegionWithLeader, Vec<kvrpcpb::KeyRange>)>> {
         ranges.reverse();
         stream_fn(Some(ranges), move |ranges| {
             let this = self.clone();
@@ -147,7 +146,6 @@ pub trait PdClient: Send + Sync + 'static {
                     let start_key: Key = range.start_key.clone().into();
                     let end_key: Key = range.end_key.clone().into();
                     let region = this.region_for_key(&start_key).await?;
-                    let id = region.id();
                     let region_start = region.start_key();
                     let region_end = region.end_key();
                     let mut grouped = vec![];
@@ -160,7 +158,7 @@ pub trait PdClient: Send + Sync + 'static {
                             start_key: region_end.into(),
                             end_key: end_key.into(),
                         });
-                        return Ok(Some((Some(ranges), (id, grouped))));
+                        return Ok(Some((Some(ranges), (region, grouped))));
                     }
                     grouped.push(range);
 
@@ -180,11 +178,11 @@ pub trait PdClient: Send + Sync + 'static {
                                 start_key: region_end.into(),
                                 end_key: end_key.into(),
                             });
-                            return Ok(Some((Some(ranges), (id, grouped))));
+                            return Ok(Some((Some(ranges), (region, grouped))));
                         }
                         grouped.push(range);
                     }
-                    Ok(Some((Some(ranges), (id, grouped))))
+                    Ok(Some((Some(ranges), (region, grouped))))
                 } else {
                     Ok(None)
                 }
@@ -452,7 +450,7 @@ pub mod test {
         let ranges3 = stream.next().unwrap().unwrap();
         let ranges4 = stream.next().unwrap().unwrap();
 
-        assert_eq!(ranges1.0, 1);
+        assert_eq!(ranges1.0.id(), 1);
         assert_eq!(
             ranges1.1,
             vec![
@@ -466,7 +464,7 @@ pub mod test {
                 }
             ]
         );
-        assert_eq!(ranges2.0, 2);
+        assert_eq!(ranges2.0.id(), 2);
         assert_eq!(
             ranges2.1,
             vec![kvrpcpb::KeyRange {
@@ -474,7 +472,7 @@ pub mod test {
                 end_key: k3
             }]
         );
-        assert_eq!(ranges3.0, 1);
+        assert_eq!(ranges3.0.id(), 1);
         assert_eq!(
             ranges3.1,
             vec![kvrpcpb::KeyRange {
@@ -482,7 +480,7 @@ pub mod test {
                 end_key: k_split.clone()
             }]
         );
-        assert_eq!(ranges4.0, 2);
+        assert_eq!(ranges4.0.id(), 2);
         assert_eq!(
             ranges4.1,
             vec![kvrpcpb::KeyRange {

--- a/src/store.rs
+++ b/src/store.rs
@@ -39,10 +39,10 @@ where
     pd_client
         .clone()
         .group_keys_by_region(key_data)
-        .and_then(move |(region_id, key)| {
+        .and_then(move |(region, key)| {
             pd_client
                 .clone()
-                .store_for_id(region_id)
+                .map_region_to_store(region)
                 .map_ok(move |store| (key, store))
         })
         .boxed()
@@ -106,10 +106,10 @@ pub fn store_stream_for_ranges<PdC: PdClient>(
     pd_client
         .clone()
         .group_ranges_by_region(ranges)
-        .and_then(move |(region_id, range)| {
+        .and_then(move |(region, range)| {
             pd_client
                 .clone()
-                .store_for_id(region_id)
+                .map_region_to_store(region)
                 .map_ok(move |store| (range, store))
         })
         .boxed()


### PR DESCRIPTION
I add some logs to debug the client to find the `Key xxx is out of region [xxx]` error the server returned as follows:

```
region 140

version:34
start_key: 785F000000000000FF00015F4D5F613233FF3132353135323000FE
end_key: 785F000000000000FF00015F4D5F613431FF3735303030333533FF0000000000000000F7

version:35 
start_key: 785F000000000000FF00015F4D5F613333FF3632353030313835FF0000000000000000F7
end_key: 785F000000000000FF00015F4D5F613431FF3735303030333533FF0000000000000000F7


30/05/2022 09:14:06.772 key_error, region_ver_id:RegionVerId { id: 140, conf_ver: 5, ver: 35 } error [KeyError(KeyError { locked: None, retryable: "", abort: "Error(Txn(Error(Mvcc(Error(Kv(Error(Other(\"[components/tikv_kv/src/raftstore_impls.rs:75]: \\\"[components/raftstore/src/store/region_snapshot.rs:228]: Key 785F000000000000FF00015F4D5F613333FF3132353032313200FE is out of [region 140] [785F000000000000FF00015F4D5F613333FF3632353030313835FF0000000000000000F7, 785F000000000000FF00015F4D5F613431FF3735303030333533FF0000000000000000F7)\\\"\"))))))))", conflict: None, already_exist: None, deadlock: None, commit_ts_expired: None, txn_not_found: None, commit_ts_too_large: None, assertion_failed: None })]
```
The log shows the key in the error log `785F000000000000FF00015F4D5F613333FF3132353032313200FE` is out of region 140 version 35, but within the version 34.

Because of between the chained access to region cache is out of the critical zone, and region in cache may be updated to a new version, which can result in the `Key is out of region` error.


Signed-off-by: yongman <yming0221@gmail.com>