### PR TITLE
Build tool min version

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 This crate provides an easy-to-use client for [TiKV](https://github.com/tikv/tikv), a distributed, transactional key-value database written in Rust.
 
-This crate lets you connect to a TiKV cluster and use either a transactional or raw (simple get/put style without transactional consistency guarantees) API to access and update your data.
+This crate lets you connect to a TiKV(>= v5.0.0) cluster and use either a transactional or raw (simple get/put style without transactional consistency guarantees) API to access and update your data.
 
 The TiKV Rust client is an open source (Apache 2) project maintained by the TiKV Authors. We welcome contributions, see below for more info.
 
@@ -22,7 +22,10 @@ The TiKV client is a Rust library (crate). To use this crate in your project, ad
 tikv-client = "0.1.0"
 ```
 
-The minimum supported version of Rust is 1.40. The minimum supported version of TiKV is 5.0.
+### Prerequisites
+- CMake >= 3.12.0
+- Rust >= 1.56.1
+- GCC >= 6.3.0
 
 The general flow of using the client crate is to create either a raw or transaction client object (which can be configured) then send commands using the client object, or use it to create transactions objects. In the latter case, the transaction is built up using various commands and then committed (or rolled back).
 

--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ tikv-client = "0.1.0"
 ```
 
 ### Prerequisites
-- CMake >= 3.12.0
-- Rust >= 1.56.1
-- GCC >= 6.3.0
+- [`CMake`](https://cmake.org/) >= 3.12.0 - Build tool (required for [`enabling parallel build gRPC`](https://cmake.org/cmake/help/latest/envvar/CMAKE_BUILD_PARALLEL_LEVEL.html))
+- [`Rust`](https://www.rust-lang.org/) >= 1.56.1 - Build tool (required for hashbrown-v0.12.1)
+- [`GCC`](https://gcc.gnu.org/) >= 6.3.0 - Build tool (required for [`gRPC C++`](https://github.com/grpc/grpc/tree/master/src/cpp))
 
 The general flow of using the client crate is to create either a raw or transaction client object (which can be configured) then send commands using the client object, or use it to create transactions objects. In the latter case, the transaction is built up using various commands and then committed (or rolled back).
 

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ tikv-client = "0.1.0"
 ```
 
 ### Prerequisites
-- [`cmake`](https://cmake.org/) >= `3.12.0`, required for [`building gRPC in parallel`](https://cmake.org/cmake/help/latest/envvar/CMAKE_BUILD_PARALLEL_LEVEL.html))
-- [`gcc`](https://gcc.gnu.org/) >= `6.3.0`, required for [`building gRPC`](https://github.com/grpc/grpc/tree/master/src/cpp))
+- [`cmake`](https://cmake.org/) >= `3.12.0`, required for [`building gRPC in parallel`](https://cmake.org/cmake/help/latest/envvar/CMAKE_BUILD_PARALLEL_LEVEL.html)
+- [`gcc`](https://gcc.gnu.org/) >= `6.3.0`, required for [`building gRPC`](https://github.com/grpc/grpc/tree/master/src/cpp)
 - [`rust`](https://www.rust-lang.org/) >= `1.56.1`, required for `hashbrown-v0.12.1`
 
 The general flow of using the client crate is to create either a raw or transaction client object (which can be configured) then send commands using the client object, or use it to create transactions objects. In the latter case, the transaction is built up using various commands and then committed (or rolled back).

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 This crate provides an easy-to-use client for [TiKV](https://github.com/tikv/tikv), a distributed, transactional key-value database written in Rust.
 
-This crate lets you connect to a TiKV(>= v5.0.0) cluster and use either a transactional or raw (simple get/put style without transactional consistency guarantees) API to access and update your data.
+This crate lets you connect to a TiKV(>= `v5.0.0`) cluster and use either a transactional or raw (simple get/put style without transactional consistency guarantees) API to access and update your data.
 
 The TiKV Rust client is an open source (Apache 2) project maintained by the TiKV Authors. We welcome contributions, see below for more info.
 
@@ -23,9 +23,9 @@ tikv-client = "0.1.0"
 ```
 
 ### Prerequisites
-- [`CMake`](https://cmake.org/) >= 3.12.0 - Build tool (required for [`enabling parallel build gRPC`](https://cmake.org/cmake/help/latest/envvar/CMAKE_BUILD_PARALLEL_LEVEL.html))
-- [`Rust`](https://www.rust-lang.org/) >= 1.56.1 - Build tool (required for hashbrown-v0.12.1)
-- [`GCC`](https://gcc.gnu.org/) >= 6.3.0 - Build tool (required for [`gRPC C++`](https://github.com/grpc/grpc/tree/master/src/cpp))
+- [`cmake`](https://cmake.org/) >= `3.12.0`, required for [`building gRPC in parallel`](https://cmake.org/cmake/help/latest/envvar/CMAKE_BUILD_PARALLEL_LEVEL.html))
+- [`gcc`](https://gcc.gnu.org/) >= `6.3.0`, required for [`building gRPC`](https://github.com/grpc/grpc/tree/master/src/cpp))
+- [`rust`](https://www.rust-lang.org/) >= `1.56.1`, required for `hashbrown-v0.12.1`
 
 The general flow of using the client crate is to create either a raw or transaction client object (which can be configured) then send commands using the client object, or use it to create transactions objects. In the latter case, the transaction is built up using various commands and then committed (or rolled back).
 

--- a/getting-started.md
+++ b/getting-started.md
@@ -10,8 +10,6 @@ tokio = { version = "1.5", features = ["full"] }
 
 Note that you need to use Tokio. The TiKV client has an async API and therefore you need an async runtime in your program to use it. At the moment, Tokio is used internally in the client and so you must use Tokio in your code too. We plan to become more flexible in future versions.
 
-The minimum supported version of Rust is 1.40. The minimum supported version of TiKV is 5.0.
-
 The general flow of using the client crate is to create either a raw or transaction client object (which can be configured) then send commands using the client object, or use it to create transactions objects. In the latter case, the transaction is built up using various commands and then committed (or rolled back).
 
 ## Examples


### PR DESCRIPTION
Compilation of Client-Rust is supported by some dependencies. Before compiling, we need more details about the minimum version of different dependencies.

Close: #356