### PR TITLE
Modify pessimistic backoff

### DIFF
--- a/src/backoff.rs
+++ b/src/backoff.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 
 pub const DEFAULT_REGION_BACKOFF: Backoff = Backoff::no_jitter_backoff(2, 500, 10);
 pub const OPTIMISTIC_BACKOFF: Backoff = Backoff::no_jitter_backoff(2, 500, 10);
-pub const PESSIMISTIC_BACKOFF: Backoff = Backoff::no_backoff();
+pub const PESSIMISTIC_BACKOFF: Backoff = Backoff::no_jitter_backoff(2, 500, 10);
 
 /// When a request is retried, we can backoff for some time to avoid saturating the network.
 ///


### PR DESCRIPTION
close #366 
The default pessimistic backoff is mistakenly set. Though the new setting may not be optimal.