### PR TITLE
Add new stream scan APIs for transaction

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ futures-timer = "3.0"
 grpcio = { version = "0.10", features = [ "prost-codec", "openssl-vendored" ], default-features = false }
 lazy_static = "1"
 log = "0.4"
+ordered-stream = "0.1.1"
 prometheus = { version = "0.12", features = [ "push", "process" ], default-features = false } 
 rand = "0.8"
 regex = "1"

--- a/src/backoff.rs
+++ b/src/backoff.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 
 pub const DEFAULT_REGION_BACKOFF: Backoff = Backoff::no_jitter_backoff(2, 500, 10);
 pub const OPTIMISTIC_BACKOFF: Backoff = Backoff::no_jitter_backoff(2, 500, 10);
-pub const PESSIMISTIC_BACKOFF: Backoff = Backoff::no_backoff();
+pub const PESSIMISTIC_BACKOFF: Backoff = Backoff::no_jitter_backoff(2, 500, 10);
 
 /// When a request is retried, we can backoff for some time to avoid saturating the network.
 ///

--- a/src/kv/key.rs
+++ b/src/kv/key.rs
@@ -82,6 +82,13 @@ impl Key {
         self.0.is_empty()
     }
 
+    #[inline]
+    pub fn next_key(&self) -> Self {
+        let mut key = self.clone();
+        key.0.push(0);
+        key
+    }
+
     /// Return whether the last byte of key is 0.
     #[inline]
     pub(super) fn zero_terminated(&self) -> bool {

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -171,6 +171,10 @@ impl PdClient for MockPdClient {
         Ok(region)
     }
 
+    async fn region_for_endkey(&self, key: &Key) -> Result<RegionWithLeader> {
+        self.region_for_key(key).await
+    }
+
     async fn region_for_id(&self, id: RegionId) -> Result<RegionWithLeader> {
         match id {
             1 => Ok(Self::region1()),

--- a/src/transaction/buffer.rs
+++ b/src/transaction/buffer.rs
@@ -467,12 +467,13 @@ impl Buffer {
 
     /// Unlock the given key if locked.
     pub async fn unlock(&mut self, key: &Key) {
-        if let Some(value) = self.entry_map.write().await.get_mut(key) {
+        let mut entry_map = self.entry_map.write().await;
+        if let Some(value) = entry_map.get_mut(key) {
             if let BufferEntry::Locked(v) = value {
                 if let Some(v) = v {
                     *value = BufferEntry::Cached(v.take());
                 } else {
-                    self.entry_map.write().await.remove(key);
+                    entry_map.remove(key);
                 }
             }
         }

--- a/src/transaction/buffer.rs
+++ b/src/transaction/buffer.rs
@@ -15,8 +15,6 @@ use std::{
 };
 use tikv_client_proto::{kvrpcpb, pdpb::Timestamp};
 
-const DEFAULT_BATCH_SIZE: u32 = 16;
-
 pub struct Scanner<PdC: PdClient = PdRpcClient> {
     pdc: Arc<PdC>,
     timestamp: Timestamp,
@@ -49,7 +47,7 @@ impl<PdC: PdClient> Scanner<PdC> {
             pdc,
             timestamp,
             range,
-            batch_size: batch_size.max(DEFAULT_BATCH_SIZE),
+            batch_size,
             current: 0,
             limit,
             cache: Vec::new(),
@@ -186,6 +184,7 @@ impl Buffer {
         pdc: Arc<PdC>,
         range: BoundRange,
         timestamp: Timestamp,
+        batch_size: u32,
         limit: u32,
         update_cache: bool,
         reverse: bool,
@@ -206,7 +205,7 @@ impl Buffer {
             pdc,
             timestamp,
             range,
-            DEFAULT_BATCH_SIZE,
+            batch_size,
             redundant_limit,
             reverse,
             !update_cache,

--- a/src/transaction/buffer.rs
+++ b/src/transaction/buffer.rs
@@ -53,7 +53,7 @@ impl<PdC: PdClient> Scanner<PdC> {
         Self {
             pdc,
             timestamp,
-            range: range.clone(),
+            range,
             batch_size,
             current: 0,
             limit,
@@ -83,7 +83,7 @@ impl<PdC: PdClient> Scanner<PdC> {
         let (mut region_start, mut region_end) = region_store.region_with_leader.range();
         if !self.reverse {
             region_start = self.next_start_key.clone();
-            if !end_key.is_none() && !region_end.is_empty() && region_end > end_key.clone().unwrap()
+            if end_key.is_some() && !region_end.is_empty() && region_end > end_key.clone().unwrap()
             {
                 region_end = end_key.clone().unwrap();
             }
@@ -128,7 +128,7 @@ impl<PdC: PdClient> Scanner<PdC> {
                         || end_key.is_some() && self.next_start_key >= end_key.unwrap()))
                     || (self.reverse
                         && (region_start.is_empty()
-                            || start_key.len() > 0 && start_key >= self.next_end_key))
+                            || !start_key.is_empty() && start_key >= self.next_end_key))
                 {
                     self.eof = true;
                 }
@@ -382,9 +382,9 @@ impl Buffer {
 
             // check the last key if out of range
             if !scanner.reverse
-                && (scanner.next_end_key.len() > 0 && ret.key() >= scanner.next_end_key.as_ref())
+                && (!scanner.next_end_key.is_empty() && ret.key() >= scanner.next_end_key.as_ref())
                 || scanner.reverse
-                    && (scanner.next_start_key.len() > 0
+                    && (!scanner.next_start_key.is_empty()
                         && ret.key() < scanner.next_start_key.as_ref())
             {
                 scanner.eof = true;

--- a/src/transaction/snapshot.rs
+++ b/src/transaction/snapshot.rs
@@ -2,6 +2,7 @@
 
 use crate::{BoundRange, Key, KvPair, Result, Transaction, Value};
 use derive_new::new;
+use futures::Stream;
 use slog::Logger;
 
 /// A read-only transaction which reads at the given timestamp.
@@ -49,6 +50,16 @@ impl Snapshot {
         self.transaction.scan(range, limit).await
     }
 
+    /// Scan a range, return at most `limit` key-value pairs that lying in the range in stream.
+    pub async fn scan_stream(
+        &mut self,
+        range: impl Into<BoundRange>,
+        limit: u32,
+    ) -> Result<impl Stream<Item = KvPair>> {
+        debug!(self.logger, "invoking scan_stream request on snapshot");
+        self.transaction.scan_stream(range, limit).await
+    }
+
     /// Scan a range, return at most `limit` keys that lying in the range.
     pub async fn scan_keys(
         &mut self,
@@ -59,6 +70,16 @@ impl Snapshot {
         self.transaction.scan_keys(range, limit).await
     }
 
+    /// Scan a range, return at most `limit` keys that lying in the range in stream.
+    pub async fn scan_keys_stream(
+        &mut self,
+        range: impl Into<BoundRange>,
+        limit: u32,
+    ) -> Result<impl Stream<Item = Key>> {
+        debug!(self.logger, "invoking scan_keys_stream request on snapshot");
+        self.transaction.scan_keys_stream(range, limit).await
+    }
+
     /// Similar to scan, but in the reverse direction.
     pub async fn scan_reverse(
         &mut self,
@@ -67,6 +88,19 @@ impl Snapshot {
     ) -> Result<impl Iterator<Item = KvPair>> {
         debug!(self.logger, "invoking scan_reverse request on snapshot");
         self.transaction.scan_reverse(range, limit).await
+    }
+
+    /// Similar to scan, but in the reverse direction in stream.
+    pub async fn scan_reverse_stream(
+        &mut self,
+        range: impl Into<BoundRange>,
+        limit: u32,
+    ) -> Result<impl Stream<Item = KvPair>> {
+        debug!(
+            self.logger,
+            "invoking scan_reverse_stream request on snapshot"
+        );
+        self.transaction.scan_reverse_stream(range, limit).await
     }
 
     /// Similar to scan_keys, but in the reverse direction.
@@ -80,5 +114,20 @@ impl Snapshot {
             "invoking scan_keys_reverse request on snapshot"
         );
         self.transaction.scan_keys_reverse(range, limit).await
+    }
+
+    /// Similar to scan_keys, but in the reverse direction in stream.
+    pub async fn scan_keys_reverse_stream(
+        &mut self,
+        range: impl Into<BoundRange>,
+        limit: u32,
+    ) -> Result<impl Stream<Item = Key>> {
+        debug!(
+            self.logger,
+            "invoking scan_keys_reverse_stream request on snapshot"
+        );
+        self.transaction
+            .scan_keys_reverse_stream(range, limit)
+            .await
     }
 }

--- a/src/transaction/transaction.rs
+++ b/src/transaction/transaction.rs
@@ -346,6 +346,9 @@ impl<PdC: PdClient> Transaction<PdC> {
         self.scan_inner(range, limit, false, false).await
     }
 
+    /// Create a 'scan' request.
+    ///
+    /// Similar to [`scan`](Transaction::scan), but return a stream.
     pub async fn scan_stream(
         &mut self,
         range: impl Into<BoundRange>,
@@ -394,6 +397,9 @@ impl<PdC: PdClient> Transaction<PdC> {
             .map(KvPair::into_key))
     }
 
+    /// Create a 'scan_keys' request.
+    ///
+    /// Similar to [`scan_keys`](Transaction::scan_keys), but return stream.
     pub async fn scan_keys_stream(
         &mut self,
         range: impl Into<BoundRange>,
@@ -418,6 +424,9 @@ impl<PdC: PdClient> Transaction<PdC> {
         self.scan_inner(range, limit, false, true).await
     }
 
+    /// Create a 'scan_reverse' request.
+    ///
+    /// Similar to [`scan_reverse`](Transaction::scan_reverse), but return stream.
     pub async fn scan_reverse_stream(
         &mut self,
         range: impl Into<BoundRange>,
@@ -445,6 +454,9 @@ impl<PdC: PdClient> Transaction<PdC> {
             .map(KvPair::into_key))
     }
 
+    /// Create a 'scan_keys_reverse' request.
+    ///
+    /// Similar to [`scan_keys_reverse`](Transaction::scan_keys_reverse), but return stream.
     pub async fn scan_keys_reverse_stream(
         &mut self,
         range: impl Into<BoundRange>,

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -17,6 +17,7 @@ use futures::prelude::*;
 use rand::{seq::IteratorRandom, thread_rng, Rng};
 use serial_test::serial;
 use std::{
+    assert_eq,
     collections::{HashMap, HashSet},
     convert::TryInto,
     iter,
@@ -885,6 +886,74 @@ async fn txn_scan() -> Result<()> {
 
 #[tokio::test]
 #[serial]
+async fn txn_scan_stream() -> Result<()> {
+    init().await?;
+    let client = TransactionClient::new_with_config(pd_addrs(), Default::default(), None).await?;
+
+    let v = b"data".to_vec();
+
+    let option = TransactionOptions::new_pessimistic()
+        .drop_check(tikv_client::CheckLevel::Warn)
+        .scan_batch_size(16);
+    let mut t = client.begin_with_options(option.clone()).await?;
+    // put 1000 keys
+    for i in 0..1000 {
+        let mut key = "scan_key:".to_string().into_bytes();
+        let i: u32 = i;
+        key.extend_from_slice(&i.to_be_bytes());
+        t.put(Key::from(key), v.clone()).await?;
+    }
+    t.commit().await?;
+
+    let mut t2 = client.begin_with_options(option.clone()).await?;
+
+    let prefix = "scan_key:".to_string().into_bytes();
+    let mut start_key = prefix.clone();
+    start_key.extend_from_slice(&0u32.to_be_bytes());
+    let mut end_key = prefix.clone();
+    end_key.extend_from_slice(&1000u32.to_be_bytes());
+    let bound_range: BoundRange = (Key::from(start_key)..=Key::from(end_key)).into();
+
+    let mut iter = t2.scan(bound_range.clone(), u32::MAX).await?;
+    let mut idx: u32 = 0;
+    while let Some(kv) = iter.next() {
+        let mut key = "scan_key:".to_string().into_bytes();
+        key.extend_from_slice(&idx.to_be_bytes());
+        assert_eq!(kv.0, Key::from(key));
+        idx += 1;
+    }
+    assert_eq!(idx, 1000);
+
+    let mut iter = t2.scan_stream(bound_range.clone(), u32::MAX).await?;
+    idx = 0;
+    while let Some(kv) = iter.next().await {
+        let mut key = "scan_key:".to_string().into_bytes();
+        key.extend_from_slice(&idx.to_be_bytes());
+        assert_eq!(kv.0, Key::from(key));
+        idx += 1;
+    }
+    assert_eq!(idx, 1000);
+    t2.commit().await?;
+
+    // cleanup
+    let mut t3 = client.begin_with_options(option).await?;
+    let mut iter = t3.scan_keys_stream(bound_range, u32::MAX).await?;
+    idx = 0;
+    while let Some(k) = iter.next().await {
+        let mut key = "scan_key:".to_string().into_bytes();
+        key.extend_from_slice(&idx.to_be_bytes());
+        assert_eq!(k, Key::from(key));
+        idx += 1;
+        t3.delete(k).await?;
+    }
+    assert_eq!(idx, 1000);
+    t3.commit().await?;
+
+    Ok(())
+}
+
+#[tokio::test]
+#[serial]
 async fn txn_scan_reverse() -> Result<()> {
     init().await?;
     let client = TransactionClient::new_with_config(pd_addrs(), Default::default(), None).await?;
@@ -899,7 +968,6 @@ async fn txn_scan_reverse() -> Result<()> {
         (Key::from(k1.clone()), v1.clone()),
     ];
 
-    // pessimistic
     let option = TransactionOptions::new_pessimistic().drop_check(tikv_client::CheckLevel::Warn);
     let mut t = client.begin_with_options(option.clone()).await?;
     t.put(k1.clone(), v1).await?;
@@ -916,6 +984,65 @@ async fn txn_scan_reverse() -> Result<()> {
     assert_eq!(resp, reverse_resp);
     t2.commit().await?;
 
+    Ok(())
+}
+
+#[tokio::test]
+#[serial]
+async fn txn_scan_reverse_stream() -> Result<()> {
+    init().await?;
+    let client = TransactionClient::new_with_config(pd_addrs(), Default::default(), None).await?;
+
+    let v = b"data".to_vec();
+
+    let option = TransactionOptions::new_pessimistic()
+        .drop_check(tikv_client::CheckLevel::Warn)
+        .scan_batch_size(16);
+    let mut t = client.begin_with_options(option.clone()).await?;
+    // put 1000 keys
+    for i in 0..1000 {
+        let mut key = "scan_key:".to_string().into_bytes();
+        let i: u32 = i;
+        key.extend_from_slice(&i.to_be_bytes());
+        t.put(Key::from(key), v.clone()).await?;
+    }
+    t.commit().await?;
+
+    let mut t2 = client.begin_with_options(option.clone()).await?;
+
+    let prefix = "scan_key:".to_string().into_bytes();
+    let mut start_key = prefix.clone();
+    start_key.extend_from_slice(&0u32.to_be_bytes());
+    let mut end_key = prefix.clone();
+    end_key.extend_from_slice(&1000u32.to_be_bytes());
+    let bound_range: BoundRange = (Key::from(start_key)..=Key::from(end_key)).into();
+
+    let mut iter = t2
+        .scan_reverse_stream(bound_range.clone(), u32::MAX)
+        .await?;
+    let mut idx: u32 = 1000;
+    while let Some(kv) = iter.next().await {
+        let mut key = "scan_key:".to_string().into_bytes();
+        idx -= 1;
+        key.extend_from_slice(&idx.to_be_bytes());
+        assert_eq!(kv.0, Key::from(key));
+    }
+    assert_eq!(idx, 0);
+    t2.commit().await?;
+
+    // cleanup
+    let mut t3 = client.begin_with_options(option).await?;
+    let mut iter = t3.scan_keys_reverse_stream(bound_range, u32::MAX).await?;
+    idx = 1000;
+    while let Some(k) = iter.next().await {
+        let mut key = "scan_key:".to_string().into_bytes();
+        idx -= 1;
+        key.extend_from_slice(&idx.to_be_bytes());
+        assert_eq!(k, Key::from(key));
+        t3.delete(k).await?;
+    }
+    assert_eq!(idx, 0);
+    t3.commit().await?;
     Ok(())
 }
 


### PR DESCRIPTION
Add new `scan_stream`, `scan_keys_stream`, `scan_reverse_stream`, `scan_keys_reverse_stream` APIs for transaction scan.
Use these APIs, scan request will be invoke request to one region at a time in a configurable batch size, which is more reasonable when user scan range is wide-range, such as all key space.