### PR TITLE
ci: Fix CI errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,7 @@ jobs:
         with:
           command: fmt
           args: --all -- --check
+
   clippy:
     name: clippy
     runs-on: ubuntu-latest
@@ -54,6 +55,11 @@ jobs:
           toolchain: nightly
           components: clippy
           override: true
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v1
+        with:
+          version: '3.x'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Rust Cache
         uses: Swatinem/rust-cache@v1.4.0
       - uses: actions-rs/clippy-check@v1
@@ -61,6 +67,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --all-targets --all-features -- -D clippy::all
           name: Clippy Output
+
   unit-test:
     name: unit test
     env:
@@ -73,10 +80,16 @@ jobs:
           profile: minimal
           toolchain: nightly
           override: true
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v1
+        with:
+          version: '3.x'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Rust Cache
         uses: Swatinem/rust-cache@v1.4.0
       - name: unit test
         run: make unit-test
+
   integration-test:
     name: integration test
     env:
@@ -89,6 +102,11 @@ jobs:
           profile: minimal
           toolchain: nightly
           override: true
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v1
+        with:
+          version: '3.x'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Rust Cache
         uses: Swatinem/rust-cache@v1.4.0
       - name: install tiup

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,11 @@ jobs:
           profile: minimal
           toolchain: nightly
           override: true
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v1
+        with:
+          version: '3.x'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Rust Cache
         uses: Swatinem/rust-cache@v1.4.0
       - uses: actions-rs/cargo@v1

--- a/examples/raw.rs
+++ b/examples/raw.rs
@@ -35,7 +35,7 @@ async fn main() -> Result<()> {
     //
     // Here we set the key `TiKV` to have the value `Rust` associated with it.
     client.put(KEY.to_owned(), VALUE.to_owned()).await.unwrap(); // Returns a `tikv_client::Error` on failure.
-    println!("Put key {:?}, value {:?}.", KEY, VALUE);
+    println!("Put key {KEY:?}, value {VALUE:?}.");
 
     // Unlike a standard Rust HashMap all calls take owned values. This is because under the hood
     // protobufs must take ownership of the data. If we only took a borrow we'd need to internally
@@ -48,7 +48,7 @@ async fn main() -> Result<()> {
     // types are supported as well, but it all ends up as `Vec<u8>` in the end.
     let value: Option<Value> = client.get(KEY.to_owned()).await?;
     assert_eq!(value, Some(Value::from(VALUE.to_owned())));
-    println!("Get key `{}` returned value {:?}.", KEY, value);
+    println!("Get key `{KEY}` returned value {value:?}.");
 
     // You can also set the `ColumnFamily` used by the request.
     // This is *advanced usage* and should have some special considerations.
@@ -56,7 +56,7 @@ async fn main() -> Result<()> {
         .delete(KEY.to_owned())
         .await
         .expect("Could not delete value");
-    println!("Key: `{}` deleted", KEY);
+    println!("Key: `{KEY}` deleted");
 
     // Here we check if the key has been deleted from the key-value store.
     let value: Option<Value> = client
@@ -80,7 +80,7 @@ async fn main() -> Result<()> {
         .batch_get(keys.clone())
         .await
         .expect("Could not get values");
-    println!("Found values: {:?} for keys: {:?}", values, keys);
+    println!("Found values: {values:?} for keys: {keys:?}");
 
     // Scanning a range of keys is also possible giving it two bounds
     // it will returns all entries between these two.
@@ -96,7 +96,7 @@ async fn main() -> Result<()> {
         &keys,
         &[Key::from("k1".to_owned()), Key::from("k2".to_owned()),]
     );
-    println!("Scaning from {:?} to {:?} gives: {:?}", start, end, keys);
+    println!("Scanning from {start:?} to {end:?} gives: {keys:?}");
 
     let k1 = "k1";
     let k2 = "k2";
@@ -126,10 +126,7 @@ async fn main() -> Result<()> {
             "v3".to_owned()
         ]
     );
-    println!(
-        "Scaning batch scan from {:?} gives: {:?}",
-        batch_scan_keys, vals
-    );
+    println!("Scanning batch scan from {batch_scan_keys:?} gives: {vals:?}");
 
     // Cleanly exit.
     Ok(())

--- a/examples/transaction.rs
+++ b/examples/transaction.rs
@@ -52,7 +52,7 @@ async fn scan(client: &Client, range: impl Into<BoundRange>, limit: u32) {
     txn.scan(range, limit)
         .await
         .expect("Could not scan key-value pairs in range")
-        .for_each(|pair| println!("{:?}", pair));
+        .for_each(|pair| println!("{pair:?}"));
     txn.commit().await.expect("Could not commit transaction");
 }
 

--- a/mock-tikv/src/pd.rs
+++ b/mock-tikv/src/pd.rs
@@ -32,7 +32,7 @@ impl MockPd {
     fn store() -> tikv_client_proto::metapb::Store {
         // TODO: start_timestamp?
         tikv_client_proto::metapb::Store {
-            address: format!("localhost:{}", MOCK_TIKV_PORT),
+            address: format!("localhost:{MOCK_TIKV_PORT}"),
             ..Default::default()
         }
     }
@@ -58,7 +58,7 @@ impl Pd for MockPd {
     ) {
         let member = Member {
             name: "mock tikv".to_owned(),
-            client_urls: vec![format!("localhost:{}", MOCK_PD_PORT)],
+            client_urls: vec![format!("localhost:{MOCK_PD_PORT}")],
             ..Default::default()
         };
         let resp = GetMembersResponse {

--- a/src/kv/mod.rs
+++ b/src/kv/mod.rs
@@ -17,7 +17,7 @@ struct HexRepr<'a>(pub &'a [u8]);
 impl<'a> fmt::Display for HexRepr<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         for byte in self.0 {
-            write!(f, "{:02X}", byte)?;
+            write!(f, "{byte:02X}")?;
         }
         Ok(())
     }

--- a/src/pd/client.rs
+++ b/src/pd/client.rs
@@ -285,7 +285,7 @@ fn thread_name(prefix: &str) -> String {
     thread::current()
         .name()
         .and_then(|name| name.split("::").skip(1).last())
-        .map(|tag| format!("{}::{}", prefix, tag))
+        .map(|tag| format!("{prefix}::{tag}"))
         .unwrap_or_else(|| prefix.to_owned())
 }
 

--- a/src/region_cache.rs
+++ b/src/region_cache.rs
@@ -111,8 +111,7 @@ impl<C: RetryClientTrait> RegionCache<C> {
             }
         }
         Err(Error::StringError(format!(
-            "Concurrent PD requests failed for {} times",
-            MAX_RETRY_WAITING_CONCURRENT_REQUEST
+            "Concurrent PD requests failed for {MAX_RETRY_WAITING_CONCURRENT_REQUEST} times"
         )))
     }
 

--- a/src/request/plan.rs
+++ b/src/request/plan.rs
@@ -155,7 +155,7 @@ where
                     )
                     .await
                 }
-                None => Err(Error::RegionError(e)),
+                None => Err(Error::RegionError(Box::new(e))),
             }
         } else {
             Ok(vec![Ok(resp)])
@@ -213,7 +213,7 @@ where
             || e.has_raft_entry_too_large()
             || e.has_max_timestamp_not_synced()
         {
-            Err(Error::RegionError(e))
+            Err(Error::RegionError(Box::new(e)))
         } else {
             // TODO: pass the logger around
             // info!("unknwon region error: {:?}", e);
@@ -475,7 +475,10 @@ where
             Err(Error::ExtractedErrors(errors))
         } else if let Some(errors) = result.region_errors() {
             Err(Error::ExtractedErrors(
-                errors.into_iter().map(Error::RegionError).collect(),
+                errors
+                    .into_iter()
+                    .map(|e| Error::RegionError(Box::new(e)))
+                    .collect(),
             ))
         } else {
             Ok(result)

--- a/src/transaction/lock.rs
+++ b/src/transaction/lock.rs
@@ -159,7 +159,7 @@ mod tests {
                     };
                     Ok(Box::new(resp) as Box<dyn Any>)
                 });
-                Ok(Box::new(kvrpcpb::ResolveLockResponse::default()) as Box<dyn Any>)
+                Ok(Box::<kvrpcpb::ResolveLockResponse>::default() as Box<dyn Any>)
             },
         )));
 

--- a/src/transaction/transaction.rs
+++ b/src/transaction/transaction.rs
@@ -1326,7 +1326,7 @@ impl<PdC: PdClient> Committer<PdC> {
         if self.write_size > TXN_COMMIT_BATCH_SIZE {
             let size_mb = self.write_size as f64 / 1024.0 / 1024.0;
             lock_ttl = (TTL_FACTOR * size_mb.sqrt()) as u64;
-            lock_ttl = lock_ttl.min(MAX_TTL).max(DEFAULT_LOCK_TTL);
+            lock_ttl = lock_ttl.clamp(DEFAULT_LOCK_TTL, MAX_TTL);
         }
         lock_ttl
     }
@@ -1388,11 +1388,11 @@ mod tests {
             move |req: &dyn Any| {
                 if req.downcast_ref::<kvrpcpb::TxnHeartBeatRequest>().is_some() {
                     heartbeats_cloned.fetch_add(1, Ordering::SeqCst);
-                    Ok(Box::new(kvrpcpb::TxnHeartBeatResponse::default()) as Box<dyn Any>)
+                    Ok(Box::<kvrpcpb::TxnHeartBeatResponse>::default() as Box<dyn Any>)
                 } else if req.downcast_ref::<kvrpcpb::PrewriteRequest>().is_some() {
-                    Ok(Box::new(kvrpcpb::PrewriteResponse::default()) as Box<dyn Any>)
+                    Ok(Box::<kvrpcpb::PrewriteResponse>::default() as Box<dyn Any>)
                 } else {
-                    Ok(Box::new(kvrpcpb::CommitResponse::default()) as Box<dyn Any>)
+                    Ok(Box::<kvrpcpb::CommitResponse>::default() as Box<dyn Any>)
                 }
             },
         )));
@@ -1432,16 +1432,16 @@ mod tests {
             move |req: &dyn Any| {
                 if req.downcast_ref::<kvrpcpb::TxnHeartBeatRequest>().is_some() {
                     heartbeats_cloned.fetch_add(1, Ordering::SeqCst);
-                    Ok(Box::new(kvrpcpb::TxnHeartBeatResponse::default()) as Box<dyn Any>)
+                    Ok(Box::<kvrpcpb::TxnHeartBeatResponse>::default() as Box<dyn Any>)
                 } else if req.downcast_ref::<kvrpcpb::PrewriteRequest>().is_some() {
-                    Ok(Box::new(kvrpcpb::PrewriteResponse::default()) as Box<dyn Any>)
+                    Ok(Box::<kvrpcpb::PrewriteResponse>::default() as Box<dyn Any>)
                 } else if req
                     .downcast_ref::<kvrpcpb::PessimisticLockRequest>()
                     .is_some()
                 {
-                    Ok(Box::new(kvrpcpb::PessimisticLockResponse::default()) as Box<dyn Any>)
+                    Ok(Box::<kvrpcpb::PessimisticLockResponse>::default() as Box<dyn Any>)
                 } else {
-                    Ok(Box::new(kvrpcpb::CommitResponse::default()) as Box<dyn Any>)
+                    Ok(Box::<kvrpcpb::CommitResponse>::default() as Box<dyn Any>)
                 }
             },
         )));

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -187,7 +187,7 @@ async fn raw_bank_transfer() -> Result<()> {
     let mut sum: u32 = 0;
     for person in &people {
         let init = rng.gen::<u8>() as u32;
-        sum += init as u32;
+        sum += init;
         client
             .put(person.clone(), init.to_be_bytes().to_vec())
             .await?;
@@ -335,7 +335,7 @@ async fn txn_bank_transfer() -> Result<()> {
     let mut sum: u32 = 0;
     for person in &people {
         let init = rng.gen::<u8>() as u32;
-        sum += init as u32;
+        sum += init;
         txn.put(person.clone(), init.to_be_bytes().to_vec()).await?;
     }
     txn.commit().await?;

--- a/tests/mock_tikv_tests.rs
+++ b/tests/mock_tikv_tests.rs
@@ -15,7 +15,7 @@ mod test {
         let mut tikv_server = start_mock_tikv_server();
         let _pd_server = start_mock_pd_server();
 
-        let client = RawClient::new(vec![format!("localhost:{}", MOCK_PD_PORT)], None)
+        let client = RawClient::new(vec![format!("localhost:{MOCK_PD_PORT}")], None)
             .await
             .unwrap();
 

--- a/tikv-client-common/src/errors.rs
+++ b/tikv-client-common/src/errors.rs
@@ -48,13 +48,13 @@ pub enum Error {
     Canceled(#[from] futures::channel::oneshot::Canceled),
     /// Errors caused by changes of region information
     #[error("Region error: {0:?}")]
-    RegionError(tikv_client_proto::errorpb::Error),
+    RegionError(Box<tikv_client_proto::errorpb::Error>),
     /// Whether the transaction is committed or not is undetermined
     #[error("Whether the transaction is committed or not is undetermined")]
     UndeterminedError(Box<Error>),
     /// Wraps `tikv_client_proto::kvrpcpb::KeyError`
     #[error("{0:?}")]
-    KeyError(tikv_client_proto::kvrpcpb::KeyError),
+    KeyError(Box<tikv_client_proto::kvrpcpb::KeyError>),
     /// Multiple errors generated from the ExtractError plan.
     #[error("Multiple errors: {0:?}")]
     ExtractedErrors(Vec<Error>),
@@ -97,13 +97,13 @@ pub enum Error {
 
 impl From<tikv_client_proto::errorpb::Error> for Error {
     fn from(e: tikv_client_proto::errorpb::Error) -> Error {
-        Error::RegionError(e)
+        Error::RegionError(Box::new(e))
     }
 }
 
 impl From<tikv_client_proto::kvrpcpb::KeyError> for Error {
     fn from(e: tikv_client_proto::kvrpcpb::KeyError) -> Error {
-        Error::KeyError(e)
+        Error::KeyError(Box::new(e))
     }
 }
 


### PR DESCRIPTION
Signed-off-by: Ping Yu <yuping@pingcap.com>

### Changes
- Add `protoc` installation to CI workflows.
- Fix clippy errors/warnings

Clippy errors/warnings:


```bash
error: the `Err`-variant returned from this function is very large
  --> tikv-client-common/src/security.rs:18:46
   |
18 | fn check_pem_file(tag: &str, path: &Path) -> Result<File> {
   |                                              ^^^^^^^^^^^^
   |
  ::: tikv-client-common/src/errors.rs:51:5
   |
51 |     RegionError(tikv_client_proto::errorpb::Error),
   |     ---------------------------------------------- the variant `RegionError` contains at least 416 bytes
...
57 |     KeyError(tikv_client_proto::kvrpcpb::KeyError),
   |     ---------------------------------------------- the largest variant contains at least 480 bytes
   |
   = help: try reducing the size of `errors::Error`, for example by boxing large elements or replacing it with `Box<errors::Error>`
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#result_large_err
   = note: `-D clippy::result-large-err` implied by `-D clippy::all`
```


```bash
error: `Box::new(_)` of default value
    --> src/transaction/transaction.rs:1435:24
     |
1435 |                     Ok(Box::new(kvrpcpb::TxnHeartBeatResponse::default()) as Box<dyn Any>)
     |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `Box::<tikv_client_proto::kvrpcpb::TxnHeartBeatResponse>::default()`
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#box_default
     = note: `-D clippy::box-default` implied by `-D clippy::all`
```


```bash
error: variables can be used directly in the `format!` string
  --> src/kv/mod.rs:20:13
   |
20 |             write!(f, "{:02X}", byte)?;
   |             ^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
   = note: `-D clippy::uninlined-format-args` implied by `-D clippy::all`
help: change this to
   |
20 -             write!(f, "{:02X}", byte)?;
20 +             write!(f, "{byte:02X}")?;
   |
```