### PR TITLE
*: Support API v2 (part 1)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,6 +145,8 @@ pub use crate::raw::Client as RawClient;
 #[doc(inline)]
 pub use crate::raw::ColumnFamily;
 #[doc(inline)]
+pub use crate::request::codec;
+#[doc(inline)]
 pub use crate::request::RetryOptions;
 #[doc(inline)]
 pub use crate::timestamp::Timestamp;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,6 +94,8 @@
 
 pub mod backoff;
 #[doc(hidden)]
+pub mod proto; // export `proto` to enable user customized codec
+#[doc(hidden)]
 pub mod raw;
 pub mod request;
 #[doc(hidden)]
@@ -104,7 +106,6 @@ mod compat;
 mod config;
 mod kv;
 mod pd;
-mod proto;
 mod region;
 mod region_cache;
 mod stats;

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -18,7 +18,7 @@ use crate::proto::metapb::RegionEpoch;
 use crate::proto::metapb::{self};
 use crate::region::RegionId;
 use crate::region::RegionWithLeader;
-use crate::request::codec::ApiV1Codec;
+use crate::request::codec::ApiV1TxnCodec;
 use crate::store::KvClient;
 use crate::store::KvConnect;
 use crate::store::RegionStore;
@@ -31,7 +31,7 @@ use crate::Timestamp;
 
 /// Create a `PdRpcClient` with it's internals replaced with mocks so that the
 /// client can be tested without doing any RPC calls.
-pub async fn pd_rpc_client() -> PdRpcClient<ApiV1Codec, MockKvConnect, MockCluster> {
+pub async fn pd_rpc_client() -> PdRpcClient<ApiV1TxnCodec, MockKvConnect, MockCluster> {
     let config = Config::default();
     PdRpcClient::new(
         config.clone(),
@@ -44,7 +44,7 @@ pub async fn pd_rpc_client() -> PdRpcClient<ApiV1Codec, MockKvConnect, MockClust
             ))
         },
         false,
-        Some(ApiV1Codec::default()),
+        Some(ApiV1TxnCodec::default()),
     )
     .await
     .unwrap()
@@ -75,14 +75,14 @@ pub struct MockCluster;
 
 pub struct MockPdClient {
     client: MockKvClient,
-    codec: ApiV1Codec,
+    codec: ApiV1TxnCodec,
 }
 
 impl MockPdClient {
     pub fn new(client: MockKvClient) -> MockPdClient {
         MockPdClient {
             client,
-            codec: ApiV1Codec::default(),
+            codec: ApiV1TxnCodec::default(),
         }
     }
 }
@@ -113,7 +113,7 @@ impl MockPdClient {
     pub fn default() -> MockPdClient {
         MockPdClient {
             client: MockKvClient::default(),
-            codec: ApiV1Codec::default(),
+            codec: ApiV1TxnCodec::default(),
         }
     }
 
@@ -177,7 +177,7 @@ impl MockPdClient {
 
 #[async_trait]
 impl PdClient for MockPdClient {
-    type Codec = ApiV1Codec;
+    type Codec = ApiV1TxnCodec;
     type KvClient = MockKvClient;
 
     async fn map_region_to_store(self: Arc<Self>, region: RegionWithLeader) -> Result<RegionStore> {

--- a/src/mock.rs
+++ b/src/mock.rs
@@ -18,6 +18,7 @@ use crate::proto::metapb::RegionEpoch;
 use crate::proto::metapb::{self};
 use crate::region::RegionId;
 use crate::region::RegionWithLeader;
+use crate::request::codec::ApiV1Codec;
 use crate::store::KvClient;
 use crate::store::KvConnect;
 use crate::store::RegionStore;
@@ -30,7 +31,7 @@ use crate::Timestamp;
 
 /// Create a `PdRpcClient` with it's internals replaced with mocks so that the
 /// client can be tested without doing any RPC calls.
-pub async fn pd_rpc_client() -> PdRpcClient<MockKvConnect, MockCluster> {
+pub async fn pd_rpc_client() -> PdRpcClient<ApiV1Codec, MockKvConnect, MockCluster> {
     let config = Config::default();
     PdRpcClient::new(
         config.clone(),
@@ -43,6 +44,7 @@ pub async fn pd_rpc_client() -> PdRpcClient<MockKvConnect, MockCluster> {
             ))
         },
         false,
+        Some(ApiV1Codec::default()),
     )
     .await
     .unwrap()
@@ -71,9 +73,18 @@ pub struct MockKvConnect;
 
 pub struct MockCluster;
 
-#[derive(new)]
 pub struct MockPdClient {
     client: MockKvClient,
+    codec: ApiV1Codec,
+}
+
+impl MockPdClient {
+    pub fn new(client: MockKvClient) -> MockPdClient {
+        MockPdClient {
+            client,
+            codec: ApiV1Codec::default(),
+        }
+    }
 }
 
 #[async_trait]
@@ -102,6 +113,7 @@ impl MockPdClient {
     pub fn default() -> MockPdClient {
         MockPdClient {
             client: MockKvClient::default(),
+            codec: ApiV1Codec::default(),
         }
     }
 
@@ -165,6 +177,7 @@ impl MockPdClient {
 
 #[async_trait]
 impl PdClient for MockPdClient {
+    type Codec = ApiV1Codec;
     type KvClient = MockKvClient;
 
     async fn map_region_to_store(self: Arc<Self>, region: RegionWithLeader) -> Result<RegionStore> {
@@ -210,4 +223,8 @@ impl PdClient for MockPdClient {
     }
 
     async fn invalidate_region_cache(&self, _ver_id: crate::region::RegionVerId) {}
+
+    fn get_codec(&self) -> &Self::Codec {
+        &self.codec
+    }
 }

--- a/src/raw/client.rs
+++ b/src/raw/client.rs
@@ -15,7 +15,7 @@ use crate::pd::PdClient;
 use crate::pd::PdRpcClient;
 use crate::proto::metapb;
 use crate::raw::lowering::*;
-use crate::request::codec::{ApiV1Codec, Codec, EncodedRequest};
+use crate::request::codec::{ApiV1RawCodec, Codec, EncodedRequest};
 use crate::request::Collect;
 use crate::request::CollectSingle;
 use crate::request::Plan;
@@ -36,7 +36,7 @@ const MAX_RAW_KV_SCAN_LIMIT: u32 = 10240;
 ///
 /// The returned results of raw request methods are [`Future`](std::future::Future)s that must be
 /// awaited to execute.
-pub struct Client<Cod = ApiV1Codec, PdC = PdRpcClient<Cod>>
+pub struct Client<Cod = ApiV1RawCodec, PdC = PdRpcClient<Cod>>
 where
     Cod: Codec,
     PdC: PdClient<Codec = Cod>,
@@ -59,7 +59,7 @@ impl Clone for Client {
     }
 }
 
-impl Client<ApiV1Codec, PdRpcClient> {
+impl Client<ApiV1RawCodec, PdRpcClient<ApiV1RawCodec>> {
     /// Create a raw [`Client`] and connect to the TiKV cluster.
     ///
     /// Because TiKV is managed by a [PD](https://github.com/pingcap/pd/) cluster, the endpoints for
@@ -106,7 +106,8 @@ impl Client<ApiV1Codec, PdRpcClient> {
     ) -> Result<Self> {
         let pd_endpoints: Vec<String> = pd_endpoints.into_iter().map(Into::into).collect();
         let rpc = Arc::new(
-            PdRpcClient::connect(&pd_endpoints, config, false, Some(ApiV1Codec::default())).await?,
+            PdRpcClient::connect(&pd_endpoints, config, false, Some(ApiV1RawCodec::default()))
+                .await?,
         );
         Ok(Client {
             rpc,

--- a/src/raw/requests.rs
+++ b/src/raw/requests.rs
@@ -13,6 +13,7 @@ use super::RawRpcRequest;
 use crate::collect_first;
 use crate::pd::PdClient;
 use crate::proto::kvrpcpb;
+use crate::proto::kvrpcpb::ApiVersion;
 use crate::proto::metapb;
 use crate::proto::tikvpb::tikv_client::TikvClient;
 use crate::request::plan::ResponseWithShard;
@@ -396,6 +397,10 @@ impl Request for RawCoprocessorRequest {
 
     fn set_context(&mut self, context: kvrpcpb::Context) {
         self.inner.set_context(context);
+    }
+
+    fn set_api_version(&mut self, api_version: ApiVersion) {
+        self.inner.set_api_version(api_version);
     }
 }
 

--- a/src/raw/requests.rs
+++ b/src/raw/requests.rs
@@ -162,7 +162,7 @@ impl Shardable for kvrpcpb::RawBatchPutRequest {
     }
 
     fn apply_shard(&mut self, shard: Self::Shard, store: &RegionStore) -> Result<()> {
-        self.context = Some(store.region_with_leader.context()?);
+        self.set_context(store.region_with_leader.context()?);
         self.pairs = shard;
         Ok(())
     }
@@ -293,7 +293,7 @@ impl Shardable for kvrpcpb::RawBatchScanRequest {
     }
 
     fn apply_shard(&mut self, shard: Self::Shard, store: &RegionStore) -> Result<()> {
-        self.context = Some(store.region_with_leader.context()?);
+        self.set_context(store.region_with_leader.context()?);
         self.ranges = shard;
         Ok(())
     }

--- a/src/raw/requests.rs
+++ b/src/raw/requests.rs
@@ -501,6 +501,7 @@ mod test {
     use crate::mock::MockKvClient;
     use crate::mock::MockPdClient;
     use crate::proto::kvrpcpb;
+    use crate::request::codec::EncodedRequest;
     use crate::request::Plan;
     use crate::Key;
 
@@ -535,7 +536,8 @@ mod test {
             key_only: true,
             ..Default::default()
         };
-        let plan = crate::request::PlanBuilder::new(client, scan)
+        let encoded_scan = EncodedRequest::new(scan, client.get_codec());
+        let plan = crate::request::PlanBuilder::new(client, encoded_scan)
             .resolve_lock(OPTIMISTIC_BACKOFF)
             .retry_multi_region(DEFAULT_REGION_BACKOFF)
             .merge(Collect)

--- a/src/request/codec.rs
+++ b/src/request/codec.rs
@@ -9,16 +9,21 @@ pub trait Codec: Clone + Sync + Send + 'static {
 }
 
 #[derive(Clone, Default)]
-pub struct ApiV1Codec {}
+pub struct ApiV1TxnCodec {}
 
-impl Codec for ApiV1Codec {}
+impl Codec for ApiV1TxnCodec {}
+
+#[derive(Clone, Default)]
+pub struct ApiV1RawCodec {}
+
+impl Codec for ApiV1RawCodec {}
 
 #[derive(Clone)]
-pub struct ApiV2Codec {
+pub struct ApiV2TxnCodec {
     _keyspace_id: u32,
 }
 
-impl ApiV2Codec {
+impl ApiV2TxnCodec {
     pub fn new(keyspace_id: u32) -> Self {
         Self {
             _keyspace_id: keyspace_id,
@@ -26,12 +31,14 @@ impl ApiV2Codec {
     }
 }
 
-impl Codec for ApiV2Codec {
+impl Codec for ApiV2TxnCodec {
     fn encode_request<R: KvRequest>(&self, req: &mut R) {
         req.set_api_version(kvrpcpb::ApiVersion::V2);
         // TODO: req.encode_request(self);
     }
 }
+
+// TODO: pub struct ApiV2RawCodec
 
 // EncodeRequest is just a type wrapper to avoid passing not encoded request to `PlanBuilder` by mistake.
 #[derive(Clone)]

--- a/src/request/codec.rs
+++ b/src/request/codec.rs
@@ -1,0 +1,37 @@
+// Copyright 2023 TiKV Project Authors. Licensed under Apache-2.0.
+
+use crate::proto::kvrpcpb;
+use crate::request::KvRequest;
+use std::borrow::Cow;
+
+pub trait Codec: Clone + Sync + Send + 'static {
+    fn encode_request<'a, R: KvRequest>(&self, req: &'a R) -> Cow<'a, R> {
+        Cow::Borrowed(req)
+    }
+}
+
+#[derive(Clone, Default)]
+pub struct ApiV1Codec {}
+
+impl Codec for ApiV1Codec {}
+
+#[derive(Clone)]
+pub struct ApiV2Codec {
+    _keyspace_id: u32,
+}
+
+impl ApiV2Codec {
+    pub fn new(keyspace_id: u32) -> Self {
+        Self {
+            _keyspace_id: keyspace_id,
+        }
+    }
+}
+
+impl Codec for ApiV2Codec {
+    fn encode_request<'a, R: KvRequest>(&self, req: &'a R) -> Cow<'a, R> {
+        let mut req = req.clone();
+        req.set_api_version(kvrpcpb::ApiVersion::V2);
+        Cow::Owned(req)
+    }
+}

--- a/src/request/mod.rs
+++ b/src/request/mod.rs
@@ -32,6 +32,7 @@ use crate::store::HasKeyErrors;
 use crate::store::Request;
 use crate::transaction::HasLocks;
 
+pub mod codec;
 pub mod plan;
 mod plan_builder;
 mod shard;
@@ -88,6 +89,7 @@ mod test {
     use crate::mock::MockKvClient;
     use crate::mock::MockPdClient;
     use crate::proto::kvrpcpb;
+    use crate::proto::kvrpcpb::ApiVersion;
     use crate::proto::pdpb::Timestamp;
     use crate::proto::tikvpb::tikv_client::TikvClient;
     use crate::store::store_stream_for_keys;
@@ -136,6 +138,10 @@ mod test {
             }
 
             fn set_context(&mut self, _: kvrpcpb::Context) {
+                unreachable!();
+            }
+
+            fn set_api_version(&mut self, _api_version: ApiVersion) {
                 unreachable!();
             }
         }

--- a/src/request/mod.rs
+++ b/src/request/mod.rs
@@ -146,9 +146,7 @@ mod test {
                 unreachable!();
             }
 
-            fn set_api_version(&mut self, _api_version: ApiVersion) {
-                unreachable!();
-            }
+            fn set_api_version(&mut self, _api_version: ApiVersion) {}
         }
 
         #[async_trait]

--- a/src/request/plan.rs
+++ b/src/request/plan.rs
@@ -17,6 +17,7 @@ use crate::pd::PdClient;
 use crate::proto::errorpb;
 use crate::proto::errorpb::EpochNotMatch;
 use crate::proto::kvrpcpb;
+use crate::request::codec::Codec;
 use crate::request::shard::HasNextBatch;
 use crate::request::KvRequest;
 use crate::request::NextBatch;
@@ -48,22 +49,27 @@ pub trait Plan: Sized + Clone + Sync + Send + 'static {
 
 /// The simplest plan which just dispatches a request to a specific kv server.
 #[derive(Clone)]
-pub struct Dispatch<Req: KvRequest> {
+pub struct Dispatch<Cod: Codec, Req: KvRequest> {
     pub request: Req,
     pub kv_client: Option<Arc<dyn KvClient + Send + Sync>>,
+    pub codec: Cod,
 }
 
 #[async_trait]
-impl<Req: KvRequest> Plan for Dispatch<Req> {
+impl<Cod: Codec, Req: KvRequest> Plan for Dispatch<Cod, Req> {
     type Result = Req::Response;
 
     async fn execute(&self) -> Result<Self::Result> {
+        // `encode_request` will clone the request, which would have high overhead.
+        // TODO: consider in-place encoding.
+        let req = self.codec.encode_request(&self.request);
+
         let stats = tikv_stats(self.request.label());
         let result = self
             .kv_client
             .as_ref()
             .expect("Unreachable: kv_client has not been initialised in Dispatch")
-            .dispatch(&self.request)
+            .dispatch(req.as_ref())
             .await;
         let result = stats.done(result);
         result.map(|r| {

--- a/src/request/shard.rs
+++ b/src/request/shard.rs
@@ -6,6 +6,7 @@ use futures::stream::BoxStream;
 
 use super::plan::PreserveShard;
 use crate::pd::PdClient;
+use crate::request::codec::Codec;
 use crate::request::plan::CleanupLocks;
 use crate::request::Dispatch;
 use crate::request::KvRequest;
@@ -80,7 +81,7 @@ pub trait NextBatch {
     fn next_batch(&mut self, _range: (Vec<u8>, Vec<u8>));
 }
 
-impl<Req: KvRequest + Shardable> Shardable for Dispatch<Req> {
+impl<Cod: Codec, Req: KvRequest + Shardable> Shardable for Dispatch<Cod, Req> {
     type Shard = Req::Shard;
 
     fn shards(
@@ -96,7 +97,7 @@ impl<Req: KvRequest + Shardable> Shardable for Dispatch<Req> {
     }
 }
 
-impl<Req: KvRequest + NextBatch> NextBatch for Dispatch<Req> {
+impl<Cod: Codec, Req: KvRequest + NextBatch> NextBatch for Dispatch<Cod, Req> {
     fn next_batch(&mut self, range: (Vec<u8>, Vec<u8>)) {
         self.request.next_batch(range);
     }

--- a/src/request/shard.rs
+++ b/src/request/shard.rs
@@ -6,7 +6,6 @@ use futures::stream::BoxStream;
 
 use super::plan::PreserveShard;
 use crate::pd::PdClient;
-use crate::request::codec::Codec;
 use crate::request::plan::CleanupLocks;
 use crate::request::Dispatch;
 use crate::request::KvRequest;
@@ -81,7 +80,7 @@ pub trait NextBatch {
     fn next_batch(&mut self, _range: (Vec<u8>, Vec<u8>));
 }
 
-impl<Cod: Codec, Req: KvRequest + Shardable> Shardable for Dispatch<Cod, Req> {
+impl<Req: KvRequest + Shardable> Shardable for Dispatch<Req> {
     type Shard = Req::Shard;
 
     fn shards(
@@ -97,7 +96,7 @@ impl<Cod: Codec, Req: KvRequest + Shardable> Shardable for Dispatch<Cod, Req> {
     }
 }
 
-impl<Cod: Codec, Req: KvRequest + NextBatch> NextBatch for Dispatch<Cod, Req> {
+impl<Req: KvRequest + NextBatch> NextBatch for Dispatch<Req> {
     fn next_batch(&mut self, range: (Vec<u8>, Vec<u8>)) {
         self.request.next_batch(range);
     }

--- a/src/request/shard.rs
+++ b/src/request/shard.rs
@@ -163,7 +163,7 @@ macro_rules! shardable_key {
                 mut shard: Self::Shard,
                 store: &$crate::store::RegionStore,
             ) -> $crate::Result<()> {
-                self.context = Some(store.region_with_leader.context()?);
+                self.set_context(store.region_with_leader.context()?);
                 assert!(shard.len() == 1);
                 self.key = shard.pop().unwrap();
                 Ok(())
@@ -196,7 +196,7 @@ macro_rules! shardable_keys {
                 shard: Self::Shard,
                 store: &$crate::store::RegionStore,
             ) -> $crate::Result<()> {
-                self.context = Some(store.region_with_leader.context()?);
+                self.set_context(store.region_with_leader.context()?);
                 self.keys = shard.into_iter().map(Into::into).collect();
                 Ok(())
             }
@@ -225,7 +225,7 @@ macro_rules! shardable_range {
                 shard: Self::Shard,
                 store: &$crate::store::RegionStore,
             ) -> $crate::Result<()> {
-                self.context = Some(store.region_with_leader.context()?);
+                self.set_context(store.region_with_leader.context()?);
 
                 self.start_key = shard.0.into();
                 self.end_key = shard.1.into();

--- a/src/store/request.rs
+++ b/src/store/request.rs
@@ -22,6 +22,7 @@ pub trait Request: Any + Sync + Send + 'static {
     fn label(&self) -> &'static str;
     fn as_any(&self) -> &dyn Any;
     fn set_context(&mut self, context: kvrpcpb::Context);
+    fn set_api_version(&mut self, api_version: kvrpcpb::ApiVersion);
 }
 
 macro_rules! impl_request {
@@ -53,6 +54,11 @@ macro_rules! impl_request {
 
             fn set_context(&mut self, context: kvrpcpb::Context) {
                 self.context = Some(context);
+            }
+
+            fn set_api_version(&mut self, api_version: kvrpcpb::ApiVersion) {
+                let context = self.context.get_or_insert(kvrpcpb::Context::default());
+                context.api_version = api_version.into();
             }
         }
     };

--- a/src/transaction/client.rs
+++ b/src/transaction/client.rs
@@ -152,7 +152,7 @@ impl<Cod: Codec> Client<Cod> {
     /// transaction.commit().await.unwrap();
     /// # });
     /// ```
-    pub async fn begin_optimistic(&self) -> Result<Transaction<PdRpcClient<Cod>>> {
+    pub async fn begin_optimistic(&self) -> Result<Transaction<Cod, PdRpcClient<Cod>>> {
         debug!("creating new optimistic transaction");
         let timestamp = self.current_timestamp().await?;
         Ok(self.new_transaction(timestamp, TransactionOptions::new_optimistic()))
@@ -175,7 +175,7 @@ impl<Cod: Codec> Client<Cod> {
     /// transaction.commit().await.unwrap();
     /// # });
     /// ```
-    pub async fn begin_pessimistic(&self) -> Result<Transaction<PdRpcClient<Cod>>> {
+    pub async fn begin_pessimistic(&self) -> Result<Transaction<Cod, PdRpcClient<Cod>>> {
         debug!("creating new pessimistic transaction");
         let timestamp = self.current_timestamp().await?;
         Ok(self.new_transaction(timestamp, TransactionOptions::new_pessimistic()))
@@ -201,7 +201,7 @@ impl<Cod: Codec> Client<Cod> {
     pub async fn begin_with_options(
         &self,
         options: TransactionOptions,
-    ) -> Result<Transaction<PdRpcClient<Cod>>> {
+    ) -> Result<Transaction<Cod, PdRpcClient<Cod>>> {
         debug!("creating new customized transaction");
         let timestamp = self.current_timestamp().await?;
         Ok(self.new_transaction(timestamp, options))
@@ -212,7 +212,7 @@ impl<Cod: Codec> Client<Cod> {
         &self,
         timestamp: Timestamp,
         options: TransactionOptions,
-    ) -> Snapshot<PdRpcClient<Cod>> {
+    ) -> Snapshot<Cod, PdRpcClient<Cod>> {
         debug!("creating new snapshot");
         Snapshot::new(self.new_transaction(timestamp, options.read_only()))
     }
@@ -311,7 +311,7 @@ impl<Cod: Codec> Client<Cod> {
         &self,
         timestamp: Timestamp,
         options: TransactionOptions,
-    ) -> Transaction<PdRpcClient<Cod>> {
+    ) -> Transaction<Cod, PdRpcClient<Cod>> {
         Transaction::new(timestamp, self.pd.clone(), options)
     }
 }

--- a/src/transaction/lock.rs
+++ b/src/transaction/lock.rs
@@ -17,6 +17,7 @@ use crate::proto::kvrpcpb;
 use crate::proto::kvrpcpb::TxnInfo;
 use crate::proto::pdpb::Timestamp;
 use crate::region::RegionVerId;
+use crate::request::codec::EncodedRequest;
 use crate::request::Collect;
 use crate::request::CollectSingle;
 use crate::request::Plan;
@@ -77,7 +78,8 @@ pub async fn resolve_locks(
             Some(&commit_version) => commit_version,
             None => {
                 let request = requests::new_cleanup_request(lock.primary_lock, lock.lock_version);
-                let plan = crate::request::PlanBuilder::new(pd_client.clone(), request)
+                let encoded_req = EncodedRequest::new(request, pd_client.get_codec());
+                let plan = crate::request::PlanBuilder::new(pd_client.clone(), encoded_req)
                     .resolve_lock(OPTIMISTIC_BACKOFF)
                     .retry_multi_region(DEFAULT_REGION_BACKOFF)
                     .merge(CollectSingle)
@@ -118,8 +120,9 @@ async fn resolve_lock_with_retry(
         let store = pd_client.clone().store_for_key(key.into()).await?;
         let ver_id = store.region_with_leader.ver_id();
         let request = requests::new_resolve_lock_request(start_version, commit_version);
+        let encoded_req = EncodedRequest::new(request, pd_client.get_codec());
         // The only place where single-region is used
-        let plan = crate::request::PlanBuilder::new(pd_client.clone(), request)
+        let plan = crate::request::PlanBuilder::new(pd_client.clone(), encoded_req)
             .single_region_with_store(store)
             .await?
             .resolve_lock(Backoff::no_backoff())
@@ -359,7 +362,8 @@ impl LockResolver {
             force_sync_commit,
             resolving_pessimistic_lock,
         );
-        let plan = crate::request::PlanBuilder::new(pd_client.clone(), req)
+        let encoded_req = EncodedRequest::new(req, pd_client.get_codec());
+        let plan = crate::request::PlanBuilder::new(pd_client.clone(), encoded_req)
             .retry_multi_region(DEFAULT_REGION_BACKOFF)
             .merge(CollectSingle)
             .extract_error()
@@ -383,7 +387,8 @@ impl LockResolver {
         txn_id: u64,
     ) -> Result<SecondaryLocksStatus> {
         let req = new_check_secondary_locks_request(keys, txn_id);
-        let plan = crate::request::PlanBuilder::new(pd_client.clone(), req)
+        let encoded_req = EncodedRequest::new(req, pd_client.get_codec());
+        let plan = crate::request::PlanBuilder::new(pd_client.clone(), encoded_req)
             .retry_multi_region(DEFAULT_REGION_BACKOFF)
             .extract_error()
             .merge(Collect)
@@ -399,7 +404,8 @@ impl LockResolver {
     ) -> Result<RegionVerId> {
         let ver_id = store.region_with_leader.ver_id();
         let request = requests::new_batch_resolve_lock_request(txn_infos.clone());
-        let plan = crate::request::PlanBuilder::new(pd_client.clone(), request)
+        let encoded_req = EncodedRequest::new(request, pd_client.get_codec());
+        let plan = crate::request::PlanBuilder::new(pd_client.clone(), encoded_req)
             .single_region_with_store(store.clone())
             .await?
             .extract_error()

--- a/src/transaction/lock.rs
+++ b/src/transaction/lock.rs
@@ -121,7 +121,6 @@ async fn resolve_lock_with_retry(
         let ver_id = store.region_with_leader.ver_id();
         let request = requests::new_resolve_lock_request(start_version, commit_version);
         let encoded_req = EncodedRequest::new(request, pd_client.get_codec());
-        // The only place where single-region is used
         let plan = crate::request::PlanBuilder::new(pd_client.clone(), encoded_req)
             .single_region_with_store(store)
             .await?

--- a/src/transaction/snapshot.rs
+++ b/src/transaction/snapshot.rs
@@ -2,7 +2,9 @@
 
 use derive_new::new;
 use log::debug;
+use std::marker::PhantomData;
 
+use crate::codec::ApiV1TxnCodec;
 use crate::pd::{PdClient, PdRpcClient};
 use crate::request::codec::Codec;
 use crate::BoundRange;
@@ -20,11 +22,12 @@ use crate::Value;
 ///
 /// See the [Transaction](struct@crate::Transaction) docs for more information on the methods.
 #[derive(new)]
-pub struct Snapshot<PdC: PdClient = PdRpcClient> {
-    transaction: Transaction<PdC>,
+pub struct Snapshot<Cod: Codec = ApiV1TxnCodec, PdC: PdClient = PdRpcClient<Cod>> {
+    transaction: Transaction<Cod, PdC>,
+    phantom: PhantomData<Cod>,
 }
 
-impl<Cod: Codec, PdC: PdClient<Codec = Cod>> Snapshot<PdC> {
+impl<Cod: Codec, PdC: PdClient<Codec = Cod>> Snapshot<Cod, PdC> {
     /// Get the value associated with the given key.
     pub async fn get(&mut self, key: impl Into<Key>) -> Result<Option<Value>> {
         debug!("invoking get request on snapshot");

--- a/src/transaction/snapshot.rs
+++ b/src/transaction/snapshot.rs
@@ -3,6 +3,8 @@
 use derive_new::new;
 use log::debug;
 
+use crate::pd::{PdClient, PdRpcClient};
+use crate::request::codec::Codec;
 use crate::BoundRange;
 use crate::Key;
 use crate::KvPair;
@@ -18,11 +20,11 @@ use crate::Value;
 ///
 /// See the [Transaction](struct@crate::Transaction) docs for more information on the methods.
 #[derive(new)]
-pub struct Snapshot {
-    transaction: Transaction,
+pub struct Snapshot<PdC: PdClient = PdRpcClient> {
+    transaction: Transaction<PdC>,
 }
 
-impl Snapshot {
+impl<Cod: Codec, PdC: PdClient<Codec = Cod>> Snapshot<PdC> {
     /// Get the value associated with the given key.
     pub async fn get(&mut self, key: impl Into<Key>) -> Result<Option<Value>> {
         debug!("invoking get request on snapshot");

--- a/src/transaction/transaction.rs
+++ b/src/transaction/transaction.rs
@@ -18,7 +18,7 @@ use crate::pd::PdClient;
 use crate::pd::PdRpcClient;
 use crate::proto::kvrpcpb;
 use crate::proto::pdpb::Timestamp;
-use crate::request::codec::Codec;
+use crate::request::codec::{Codec, EncodedRequest};
 use crate::request::Collect;
 use crate::request::CollectError;
 use crate::request::CollectSingle;
@@ -134,7 +134,7 @@ impl<Cod: Codec, PdC: PdClient<Codec = Cod>> Transaction<PdC> {
 
         self.buffer
             .get_or_else(key, |key| async move {
-                let request = new_get_request(key, timestamp);
+                let request = EncodedRequest::new(new_get_request(key, timestamp), rpc.get_codec());
                 let plan = PlanBuilder::new(rpc, request)
                     .resolve_lock(retry_options.lock_backoff)
                     .retry_multi_region(DEFAULT_REGION_BACKOFF)
@@ -265,7 +265,8 @@ impl<Cod: Codec, PdC: PdClient<Codec = Cod>> Transaction<PdC> {
         self.buffer
             .batch_get_or_else(keys.into_iter().map(|k| k.into()), move |keys| async move {
                 let request = new_batch_get_request(keys, timestamp);
-                let plan = PlanBuilder::new(rpc, request)
+                let encoded_req = EncodedRequest::new(request, rpc.get_codec());
+                let plan = PlanBuilder::new(rpc, encoded_req)
                     .resolve_lock(retry_options.lock_backoff)
                     .retry_multi_region(retry_options.region_backoff)
                     .merge(Collect)
@@ -692,7 +693,8 @@ impl<Cod: Codec, PdC: PdClient<Codec = Cod>> Transaction<PdC> {
             primary_key,
             self.start_instant.elapsed().as_millis() as u64 + MAX_TTL,
         );
-        let plan = PlanBuilder::new(self.rpc.clone(), request)
+        let encoded_req = EncodedRequest::new(request, self.rpc.get_codec());
+        let plan = PlanBuilder::new(self.rpc.clone(), encoded_req)
             .resolve_lock(self.options.retry_options.lock_backoff.clone())
             .retry_multi_region(self.options.retry_options.region_backoff.clone())
             .merge(CollectSingle)
@@ -722,7 +724,8 @@ impl<Cod: Codec, PdC: PdClient<Codec = Cod>> Transaction<PdC> {
                 move |new_range, new_limit| async move {
                     let request =
                         new_scan_request(new_range, timestamp, new_limit, key_only, reverse);
-                    let plan = PlanBuilder::new(rpc, request)
+                    let encoded_req = EncodedRequest::new(request, rpc.get_codec());
+                    let plan = PlanBuilder::new(rpc, encoded_req)
                         .resolve_lock(retry_options.lock_backoff)
                         .retry_multi_region(retry_options.region_backoff)
                         .merge(Collect)
@@ -777,7 +780,8 @@ impl<Cod: Codec, PdC: PdClient<Codec = Cod>> Transaction<PdC> {
             for_update_ts.clone(),
             need_value,
         );
-        let plan = PlanBuilder::new(self.rpc.clone(), request)
+        let encoded_req = EncodedRequest::new(request, self.rpc.get_codec());
+        let plan = PlanBuilder::new(self.rpc.clone(), encoded_req)
             .resolve_lock(self.options.retry_options.lock_backoff.clone())
             .preserve_shard()
             .retry_multi_region_preserve_results(self.options.retry_options.region_backoff.clone())
@@ -831,7 +835,8 @@ impl<Cod: Codec, PdC: PdClient<Codec = Cod>> Transaction<PdC> {
             start_version,
             for_update_ts,
         );
-        let plan = PlanBuilder::new(self.rpc.clone(), req)
+        let encoded_req = EncodedRequest::new(req, self.rpc.get_codec());
+        let plan = PlanBuilder::new(self.rpc.clone(), encoded_req)
             .resolve_lock(self.options.retry_options.lock_backoff.clone())
             .retry_multi_region(self.options.retry_options.region_backoff.clone())
             .extract_error()
@@ -901,7 +906,8 @@ impl<Cod: Codec, PdC: PdClient<Codec = Cod>> Transaction<PdC> {
                     primary_key.clone(),
                     start_instant.elapsed().as_millis() as u64 + MAX_TTL,
                 );
-                let plan = PlanBuilder::new(rpc.clone(), request)
+                let encoded_req = EncodedRequest::new(request, rpc.get_codec());
+                let plan = PlanBuilder::new(rpc.clone(), encoded_req)
                     .retry_multi_region(region_backoff.clone())
                     .merge(CollectSingle)
                     .plan();
@@ -1210,7 +1216,8 @@ impl<PdC: PdClient> Committer<PdC> {
             .collect();
         // FIXME set max_commit_ts and min_commit_ts
 
-        let plan = PlanBuilder::new(self.rpc.clone(), request)
+        let encoded_req = EncodedRequest::new(request, self.rpc.get_codec());
+        let plan = PlanBuilder::new(self.rpc.clone(), encoded_req)
             .resolve_lock(self.options.retry_options.lock_backoff.clone())
             .retry_multi_region(self.options.retry_options.region_backoff.clone())
             .merge(CollectError)
@@ -1250,7 +1257,8 @@ impl<PdC: PdClient> Committer<PdC> {
             self.start_version.clone(),
             commit_version.clone(),
         );
-        let plan = PlanBuilder::new(self.rpc.clone(), req)
+        let encoded_req = EncodedRequest::new(req, self.rpc.get_codec());
+        let plan = PlanBuilder::new(self.rpc.clone(), encoded_req)
             .resolve_lock(self.options.retry_options.lock_backoff.clone())
             .retry_multi_region(self.options.retry_options.region_backoff.clone())
             .extract_error()
@@ -1314,7 +1322,8 @@ impl<PdC: PdClient> Committer<PdC> {
                 .filter(|key| &primary_key != key);
             new_commit_request(keys, self.start_version, commit_version)
         };
-        let plan = PlanBuilder::new(self.rpc, req)
+        let encoded_req = EncodedRequest::new(req, self.rpc.get_codec());
+        let plan = PlanBuilder::new(self.rpc, encoded_req)
             .resolve_lock(self.options.retry_options.lock_backoff)
             .retry_multi_region(self.options.retry_options.region_backoff)
             .extract_error()
@@ -1335,7 +1344,8 @@ impl<PdC: PdClient> Committer<PdC> {
         match self.options.kind {
             TransactionKind::Optimistic => {
                 let req = new_batch_rollback_request(keys, self.start_version);
-                let plan = PlanBuilder::new(self.rpc, req)
+                let encoded_req = EncodedRequest::new(req, self.rpc.get_codec());
+                let plan = PlanBuilder::new(self.rpc, encoded_req)
                     .resolve_lock(self.options.retry_options.lock_backoff)
                     .retry_multi_region(self.options.retry_options.region_backoff)
                     .extract_error()
@@ -1344,7 +1354,8 @@ impl<PdC: PdClient> Committer<PdC> {
             }
             TransactionKind::Pessimistic(for_update_ts) => {
                 let req = new_pessimistic_rollback_request(keys, self.start_version, for_update_ts);
-                let plan = PlanBuilder::new(self.rpc, req)
+                let encoded_req = EncodedRequest::new(req, self.rpc.get_codec());
+                let plan = PlanBuilder::new(self.rpc, encoded_req)
                     .resolve_lock(self.options.retry_options.lock_backoff)
                     .retry_multi_region(self.options.retry_options.region_backoff)
                     .extract_error()

--- a/src/transaction/transaction.rs
+++ b/src/transaction/transaction.rs
@@ -18,6 +18,7 @@ use crate::pd::PdClient;
 use crate::pd::PdRpcClient;
 use crate::proto::kvrpcpb;
 use crate::proto::pdpb::Timestamp;
+use crate::request::codec::Codec;
 use crate::request::Collect;
 use crate::request::CollectError;
 use crate::request::CollectSingle;
@@ -83,7 +84,7 @@ pub struct Transaction<PdC: PdClient = PdRpcClient> {
     start_instant: Instant,
 }
 
-impl<PdC: PdClient> Transaction<PdC> {
+impl<Cod: Codec, PdC: PdClient<Codec = Cod>> Transaction<PdC> {
     pub(crate) fn new(
         timestamp: Timestamp,
         rpc: Arc<PdC>,


### PR DESCRIPTION
Ref: #359 

This PR is part of #353 to make the code review easier.

### Changes
- Implement the basic skeleton of codec.
- Support set api version of API v2 for request context.

### Coming PRs
- Encode request by adding keyspace prefix.
- Decode response by removing keyspace prefix.
- PD client interface for keyspace.
- Unit & integration tests for API v2.