### PR TITLE
Adding a reverse scan API for raw client

### DIFF
--- a/src/raw/client.rs
+++ b/src/raw/client.rs
@@ -503,7 +503,7 @@ impl<PdC: PdClient> Client<PdC> {
         self.scan_inner(range.into(), limit, false, false).await
     }
 
-    // Create a new 'scan' request but scans in "reverse" direction.
+    /// Create a new 'scan' request but scans in "reverse" direction.
     ///
     /// Once resolved this request will result in a `Vec` of key-value pairs that lies in the specified range.
     ///
@@ -511,8 +511,8 @@ impl<PdC: PdClient> Client<PdC> {
     /// only the first `limit` pairs are returned, ordered by the key.
     ///
     ///
-    /// Reverse Scan queries continuous kv pairs in range (endKey, startKey],
-    /// from startKey(upperBound) to endKey(lowerBound), up to limit pairs.
+    /// Reverse Scan queries continuous kv pairs in range [startKey, endKey),
+    /// from startKey(lowerBound) to endKey(upperBound) in reverse order, up to limit pairs.
     /// The returned keys are in reversed lexicographical order.
     /// If you want to include the endKey or exclude the startKey, push a '\0' to the key.
     /// It doesn't support Scanning from "", because locating the last Region is not yet implemented.
@@ -522,7 +522,7 @@ impl<PdC: PdClient> Client<PdC> {
     /// # use futures::prelude::*;
     /// # futures::executor::block_on(async {
     /// # let client = RawClient::new(vec!["192.168.0.100"]).await.unwrap();
-    /// let inclusive_range = "TiDB"..="TiKV";
+    /// let inclusive_range = "TiKV"..="TiDB";
     /// let req = client.scan_reverse(inclusive_range.into_owned(), 2);
     /// let result: Vec<KvPair> = req.await.unwrap();
     /// # });

--- a/src/raw/client.rs
+++ b/src/raw/client.rs
@@ -565,6 +565,39 @@ impl<PdC: PdClient> Client<PdC> {
             .collect())
     }
 
+    /// Create a new 'scan' request that only returns the keys in reverse order.
+    ///
+    /// Once resolved this request will result in a `Vec` of keys that lies in the specified range.
+    ///
+    /// If the number of eligible keys are greater than `limit`,
+    /// only the first `limit` pairs are returned, ordered by the key.
+    ///
+    ///
+    /// # Examples
+    /// ```rust,no_run
+    /// # use tikv_client::{Key, Config, RawClient, IntoOwnedRange};
+    /// # use futures::prelude::*;
+    /// # futures::executor::block_on(async {
+    /// # let client = RawClient::new(vec!["192.168.0.100"]).await.unwrap();
+    /// let inclusive_range = "TiKV"..="TiDB";
+    /// let req = client.scan_keys(inclusive_range.into_owned(), 2);
+    /// let result: Vec<Key> = req.await.unwrap();
+    /// # });
+    /// ```
+    pub async fn scan_keys_reverse(
+        &self,
+        range: impl Into<BoundRange>,
+        limit: u32,
+    ) -> Result<Vec<Key>> {
+        debug!("invoking raw scan_keys request");
+        Ok(self
+            .scan_inner(range, limit, true, true)
+            .await?
+            .into_iter()
+            .map(KvPair::into_key)
+            .collect())
+    }
+
     /// Create a new 'batch scan' request.
     ///
     /// Once resolved this request will result in a set of scanners over the given keys.

--- a/src/raw/lowering.rs
+++ b/src/raw/lowering.rs
@@ -84,6 +84,7 @@ pub fn new_raw_scan_request(
     range: BoundRange,
     limit: u32,
     key_only: bool,
+    reverse: bool,
     cf: Option<ColumnFamily>,
 ) -> kvrpcpb::RawScanRequest {
     let (start_key, end_key) = range.into_keys();
@@ -92,6 +93,7 @@ pub fn new_raw_scan_request(
         end_key.unwrap_or_default().into(),
         limit,
         key_only,
+        reverse,
         cf,
     )
 }

--- a/src/raw/requests.rs
+++ b/src/raw/requests.rs
@@ -282,8 +282,13 @@ pub fn new_raw_scan_request(
     cf: Option<ColumnFamily>,
 ) -> kvrpcpb::RawScanRequest {
     let mut req = kvrpcpb::RawScanRequest::default();
-    req.start_key = start_key;
-    req.end_key = end_key;
+    if !reverse {
+        req.start_key = start_key;
+        req.end_key = end_key;
+    } else {
+        req.start_key = end_key;
+        req.end_key = start_key;
+    }
     req.limit = limit;
     req.key_only = key_only;
     req.reverse = reverse;

--- a/src/raw/requests.rs
+++ b/src/raw/requests.rs
@@ -301,7 +301,7 @@ impl KvRequest for kvrpcpb::RawScanRequest {
     type Response = kvrpcpb::RawScanResponse;
 }
 
-range_request!(kvrpcpb::RawScanRequest); // TODO: support reverse raw scan.
+range_request!(kvrpcpb::RawScanRequest);
 shardable_range!(kvrpcpb::RawScanRequest);
 
 impl Merge<kvrpcpb::RawScanResponse> for Collect {

--- a/src/raw/requests.rs
+++ b/src/raw/requests.rs
@@ -278,6 +278,7 @@ pub fn new_raw_scan_request(
     end_key: Vec<u8>,
     limit: u32,
     key_only: bool,
+    reverse: bool,
     cf: Option<ColumnFamily>,
 ) -> kvrpcpb::RawScanRequest {
     let mut req = kvrpcpb::RawScanRequest::default();
@@ -285,6 +286,7 @@ pub fn new_raw_scan_request(
     req.end_key = end_key;
     req.limit = limit;
     req.key_only = key_only;
+    req.reverse = reverse;
     req.maybe_set_cf(cf);
 
     req

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -562,10 +562,10 @@ async fn raw_req() -> Result<()> {
     assert_eq!(res[6].1, "v5".as_bytes());
 
     // reverse scan
-    // By default end key is exclusive, so k5 is not included and start key in included
 
+    // By default end key is exclusive, so k5 is not included and start key in included
     let res = client
-        .scan_reverse("k5".to_owned().."k2".to_owned(), 5)
+        .scan_reverse("k2".to_owned().."k5".to_owned(), 5)
         .await?;
     assert_eq!(res.len(), 3);
     assert_eq!(res[0].1, "v4".as_bytes());
@@ -574,7 +574,7 @@ async fn raw_req() -> Result<()> {
 
     // by default end key in exclusive and start key is inclusive but now exclude start key
     let res = client
-        .scan_reverse("k5".to_owned()..="k2".to_owned(), 5)
+        .scan_reverse("k2\0".to_owned().."k5".to_owned(), 5)
         .await?;
     assert_eq!(res.len(), 2);
     assert_eq!(res[0].1, "v4".as_bytes());
@@ -583,7 +583,7 @@ async fn raw_req() -> Result<()> {
     // reverse scan
     // by default end key is exclusive and start key is inclusive but now include end key
     let res = client
-        .scan_reverse("k5\0".to_owned().."k2".to_owned(), 5)
+        .scan_reverse("k2".to_owned()..="k5".to_owned(), 5)
         .await?;
     assert_eq!(res.len(), 4);
     assert_eq!(res[0].1, "v5".as_bytes());
@@ -593,7 +593,7 @@ async fn raw_req() -> Result<()> {
 
     // by default end key is exclusive and start key is inclusive but now include end key and exclude start key
     let res = client
-        .scan_reverse("k5\0".to_owned()..="k2".to_owned(), 5)
+        .scan_reverse("k2\0".to_owned()..="k5".to_owned(), 5)
         .await?;
     assert_eq!(res.len(), 3);
     assert_eq!(res[0].1, "v5".as_bytes());
@@ -602,16 +602,20 @@ async fn raw_req() -> Result<()> {
 
     // limit results to first 2
     let res = client
-        .scan_reverse("k5".to_owned().."k2".to_owned(), 2)
+        .scan_reverse("k2".to_owned().."k5".to_owned(), 2)
         .await?;
     assert_eq!(res.len(), 2);
     assert_eq!(res[0].1, "v4".as_bytes());
     assert_eq!(res[1].1, "v3".as_bytes());
 
-    //let range = "k5"..; // Upperbound (k5, +inf). This is NOT SUPPORTED by TiKV.
-    let range = BoundRange::range_from(Key::from("k5".to_owned()));
+    // if endKey is not provided then it scan everything including end key
+    let range = BoundRange::range_from(Key::from("k2".to_owned()));
     let res = client.scan_reverse(range, 20).await?;
-    assert_eq!(res.len(), 0);
+    assert_eq!(res.len(), 4);
+    assert_eq!(res[0].1, "v5".as_bytes());
+    assert_eq!(res[1].1, "v4".as_bytes());
+    assert_eq!(res[2].1, "v3".as_bytes());
+    assert_eq!(res[3].1, "v2".as_bytes());
 
     Ok(())
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -760,6 +760,105 @@ async fn raw_write_million() -> Result<()> {
     r = client.scan(.., limit).await?;
     assert_eq!(r.len(), limit as usize);
 
+    // test scan_reverse
+    // test scan, key range from [0,0,0,0] to [255.0.0.0]
+    let mut limit = 2000;
+    let mut r = client.scan_reverse(.., limit).await?;
+    assert_eq!(r.len(), 256);
+    for (i, val) in r.iter().rev().enumerate() {
+        let k: Vec<u8> = val.0.clone().into();
+        assert_eq!(k[0], i as u8);
+    }
+    r = client.scan_reverse(vec![100, 0, 0, 0].., limit).await?;
+    assert_eq!(r.len(), 156);
+    for (i, val) in r.iter().rev().enumerate() {
+        let k: Vec<u8> = val.0.clone().into();
+        assert_eq!(k[0], i as u8 + 100);
+    }
+    r = client
+        .scan_reverse(vec![5, 0, 0, 0]..vec![200, 0, 0, 0], limit)
+        .await?;
+    assert_eq!(r.len(), 195);
+    for (i, val) in r.iter().rev().enumerate() {
+        let k: Vec<u8> = val.0.clone().into();
+        assert_eq!(k[0], i as u8 + 5);
+    }
+    r = client
+        .scan_reverse(vec![5, 0, 0, 0]..=vec![200, 0, 0, 0], limit)
+        .await?;
+    assert_eq!(r.len(), 196);
+    for (i, val) in r.iter().rev().enumerate() {
+        let k: Vec<u8> = val.0.clone().into();
+        assert_eq!(k[0], i as u8 + 5);
+    }
+    r = client
+        .scan_reverse(vec![5, 0, 0, 0]..=vec![255, 10, 0, 0], limit)
+        .await?;
+    assert_eq!(r.len(), 251);
+    for (i, val) in r.iter().rev().enumerate() {
+        let k: Vec<u8> = val.0.clone().into();
+        assert_eq!(k[0], i as u8 + 5);
+    }
+    r = client
+        .scan_reverse(vec![255, 1, 0, 0]..=vec![255, 10, 0, 0], limit)
+        .await?;
+    assert_eq!(r.len(), 0);
+    r = client.scan_reverse(..vec![0, 0, 0, 0], limit).await?;
+    assert_eq!(r.len(), 0);
+
+    limit = 3;
+    let mut r = client.scan_reverse(.., limit).await?;
+    let mut expected_start: u8 = 255 - limit as u8 + 1; // including endKey
+    assert_eq!(r.len(), limit as usize);
+    for (i, val) in r.iter().rev().enumerate() {
+        let k: Vec<u8> = val.0.clone().into();
+        assert_eq!(k[0], i as u8 + expected_start);
+    }
+    r = client.scan_reverse(vec![100, 0, 0, 0].., limit).await?;
+    expected_start = 255 - limit as u8 + 1; // including endKey
+    assert_eq!(r.len(), limit as usize);
+    for (i, val) in r.iter().rev().enumerate() {
+        let k: Vec<u8> = val.0.clone().into();
+        assert_eq!(k[0], i as u8 + expected_start);
+    }
+    r = client
+        .scan_reverse(vec![5, 0, 0, 0]..vec![200, 0, 0, 0], limit)
+        .await?;
+    expected_start = 200 - limit as u8;
+    assert_eq!(r.len(), limit as usize);
+    for (i, val) in r.iter().rev().enumerate() {
+        let k: Vec<u8> = val.0.clone().into();
+        assert_eq!(k[0], i as u8 + expected_start);
+    }
+    r = client
+        .scan_reverse(vec![5, 0, 0, 0]..=vec![200, 0, 0, 0], limit)
+        .await?;
+    expected_start = 200 - limit as u8 + 1; // including endKey
+    assert_eq!(r.len(), limit as usize);
+    for (i, val) in r.iter().rev().enumerate() {
+        let k: Vec<u8> = val.0.clone().into();
+        assert_eq!(k[0], i as u8 + expected_start);
+    }
+    r = client
+        .scan_reverse(vec![5, 0, 0, 0]..=vec![255, 10, 0, 0], limit)
+        .await?;
+    expected_start = 255 - limit as u8 + 1; // including endKey
+    assert_eq!(r.len(), limit as usize);
+    for (i, val) in r.iter().rev().enumerate() {
+        let k: Vec<u8> = val.0.clone().into();
+        assert_eq!(k[0], i as u8 + expected_start);
+    }
+    r = client
+        .scan_reverse(vec![255, 1, 0, 0]..=vec![255, 10, 0, 0], limit)
+        .await?;
+    assert_eq!(r.len(), 0);
+    r = client.scan_reverse(..vec![0, 0, 0, 0], limit).await?;
+    assert_eq!(r.len(), 0);
+
+    limit = 0;
+    r = client.scan_reverse(.., limit).await?;
+    assert_eq!(r.len(), limit as usize);
+
     // test batch_scan
     for batch_num in 1..4 {
         let _ = client


### PR DESCRIPTION
Issue : https://github.com/tikv/client-rust/issues/440

Problem statement : 
Adding a support for reverse scan public API in raw rust client.

Solution : 
1. Added a new public API in raw client.
2. Add flag all the way through until new raw scan request is created. The [tikv service scan API](https://tikv.github.io/doc/kvproto/kvrpcpb/struct.RawScanRequest.html) already has a field for reverse flag. Set it properly based on what caller is passing.

Tests : 
```
cargo build
cargo clippy && cargo fmt
cargo test


PD_ADDRS="127.0.0.1:2379" cargo test --package tikv-client --test integration_tests --features integration-tests
   Compiling tikv-client v0.3.0 (/Users/rrane/work/spiral-repos/client-rust)
    Finished test [unoptimized + debuginfo] target(s) in 10.41s
     Running tests/integration_tests.rs (target/debug/deps/integration_tests-e4cb8a4e124a5c59)

running 26 tests
test raw_bank_transfer ... ok
test raw_cas ... ok
test raw_req ... ok
test raw_ttl ... ok
test raw_write_million ... ok
test txn_bank_transfer ... ok
test txn_batch_mutate_optimistic ... ok
test txn_batch_mutate_pessimistic ... ok
test txn_crud ... ok
test txn_get_for_update ... ok
test txn_get_timestamp ... ok
test txn_insert_duplicate_keys ... ok
test txn_key_exists ... ok
test txn_lock_keys ... ok
test txn_lock_keys_error_handle ... ok
test txn_pessimistic ... ok
test txn_pessimistic_delete ... ok
test txn_pessimistic_heartbeat ... ok
test txn_pessimistic_rollback ... ok
test txn_read ... ok
test txn_scan ... ok
test txn_scan_reverse ... ok
test txn_scan_reverse_multi_regions ... ok
test txn_split_batch ... ok
test txn_unsafe_destroy_range ... ok
test txn_update_safepoint ... ok

test result: ok. 26 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 59.34s
```