### PR TITLE
Resolving the TLS url issue

### DIFF
--- a/src/common/security.rs
+++ b/src/common/security.rs
@@ -8,10 +8,10 @@ use std::time::Duration;
 
 use log::info;
 use regex::Regex;
-use tonic::transport::Certificate;
 use tonic::transport::Channel;
 use tonic::transport::ClientTlsConfig;
 use tonic::transport::Identity;
+use tonic::transport::{Certificate, Endpoint};
 
 use crate::internal_err;
 use crate::Result;
@@ -74,30 +74,43 @@ impl SecurityManager {
         addr: &str,
         factory: Factory,
     ) -> Result<Client>
-    where
-        Factory: FnOnce(Channel) -> Client,
+        where
+            Factory: FnOnce(Channel) -> Client,
     {
-        let addr = "http://".to_string() + &SCHEME_REG.replace(addr, "");
-
         info!("connect to rpc server at endpoint: {:?}", addr);
-
-        let mut builder = Channel::from_shared(addr)?
-            .tcp_keepalive(Some(Duration::from_secs(10)))
-            .keep_alive_timeout(Duration::from_secs(3));
-
-        if !self.ca.is_empty() {
-            let tls = ClientTlsConfig::new()
-                .ca_certificate(Certificate::from_pem(&self.ca))
-                .identity(Identity::from_pem(
-                    &self.cert,
-                    load_pem_file("private key", &self.key)?,
-                ));
-            builder = builder.tls_config(tls)?;
+        let channel = if !self.ca.is_empty() {
+            self.tls_channel(addr).await?
+        } else {
+            self.default_channel(addr).await?
         };
-
-        let ch = builder.connect().await?;
+        let ch = channel.connect().await?;
 
         Ok(factory(ch))
+    }
+
+    async fn tls_channel(&self, addr: &str) -> Result<Endpoint> {
+        let addr = "https://".to_string() + &SCHEME_REG.replace(addr, "");
+        let builder = self.endpoint(addr.to_string())?;
+        let tls = ClientTlsConfig::new()
+            .ca_certificate(Certificate::from_pem(&self.ca))
+            .identity(Identity::from_pem(
+                &self.cert,
+                load_pem_file("private key", &self.key)?,
+            ));
+        let builder = builder.tls_config(tls)?;
+        Ok(builder)
+    }
+
+    async fn default_channel(&self, addr: &str) -> Result<Endpoint> {
+        let addr = "http://".to_string() + &SCHEME_REG.replace(addr, "");
+        self.endpoint(addr)
+    }
+
+    fn endpoint(&self, addr: String) -> Result<Endpoint> {
+        let endpoint = Channel::from_shared(addr)?
+            .tcp_keepalive(Some(Duration::from_secs(10)))
+            .keep_alive_timeout(Duration::from_secs(3));
+        Ok(endpoint)
     }
 }
 

--- a/src/common/security.rs
+++ b/src/common/security.rs
@@ -74,8 +74,8 @@ impl SecurityManager {
         addr: &str,
         factory: Factory,
     ) -> Result<Client>
-        where
-            Factory: FnOnce(Channel) -> Client,
+    where
+        Factory: FnOnce(Channel) -> Client,
     {
         info!("connect to rpc server at endpoint: {:?}", addr);
         let channel = if !self.ca.is_empty() {

--- a/src/kv/key.rs
+++ b/src/kv/key.rs
@@ -2,7 +2,6 @@
 
 use std::fmt;
 use std::ops::Bound;
-use std::u8;
 
 #[allow(unused_imports)]
 #[cfg(test)]

--- a/src/kv/mod.rs
+++ b/src/kv/mod.rs
@@ -1,6 +1,5 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 use std::fmt;
-use std::u8;
 
 mod bound_range;
 pub mod codec;

--- a/src/raw/client.rs
+++ b/src/raw/client.rs
@@ -3,7 +3,6 @@
 use core::ops::Range;
 use std::str::FromStr;
 use std::sync::Arc;
-use std::u32;
 
 use futures::StreamExt;
 use log::debug;

--- a/src/transaction/requests.rs
+++ b/src/transaction/requests.rs
@@ -252,7 +252,7 @@ pub fn new_prewrite_request(
     req.start_version = start_version;
     req.lock_ttl = lock_ttl;
     // FIXME: Lite resolve lock is currently disabled
-    req.txn_size = std::u64::MAX;
+    req.txn_size = u64::MAX;
 
     req
 }


### PR DESCRIPTION
While running the client we are running into issues where the client fails to connect to a TLS enabled PD endpoint with the error:

[WARN] [config_logging.go:287] ["rejected connection"] [remote-addr="[addr]:port"] [server-name=] [error="tls: first record does not look like a TLS handshake"] 

Digging into the code, the problem seems to stem from the following logic in the client (

[client-rust/src/common/security.rs](https://github.com/tikv/client-rust/blob/c6110dd8087a4d9e7bf48da77bbbfafa79614b10/src/common/security.rs#L80)

Line 80 in [c6110dd](https://github.com/tikv/client-rust/commit/c6110dd8087a4d9e7bf48da77bbbfafa79614b10)

```
 let addr = "http://".to_string() + &SCHEME_REG.replace(addr, ""); 
)
let addr = "http://".to_string() + &SCHEME_REG.replace(addr, "");

info!("connect to rpc server at endpoint: {:?}", addr);

let mut builder = Channel::from_shared(addr)?
    .tcp_keepalive(Some(Duration::from_secs(10)))
    .keep_alive_timeout(Duration::from_secs(3));
```

Here SCHEME_REG is the regex to find "https" in the prefix of the address (

[client-rust/src/common/security.rs](https://github.com/tikv/client-rust/blob/c6110dd8087a4d9e7bf48da77bbbfafa79614b10/src/common/security.rs#L19)

Line 19 in [c6110dd](https://github.com/tikv/client-rust/commit/c6110dd8087a4d9e7bf48da77bbbfafa79614b10)

```
 lazy_static::lazy_static! { 
).
lazy_static::lazy_static! {
    static ref SCHEME_REG: Regex = Regex::new(r"^\s*(https?://)").unwrap();
}

```
This is a problem during the ssl handshake since the server is not acknowledging the requests sent to an addressed prefixed with "http" instead of "https". Adding the logic to handle these variations.