### PR TITLE
chore: Upgrade to rust 1.84.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ clap = "2"
 env_logger = "0.10"
 fail = { version = "0.4", features = ["failpoints"] }
 proptest = "1"
-proptest-derive = "0.3"
+proptest-derive = "0.5.1"
 reqwest = { version = "0.11", features = ["json", "native-tls-vendored"] }
 rstest = "0.18.2"
 serde_json = "1"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "stable"
+channel = "1.84.1"
 components = ["rustfmt", "clippy"]

--- a/src/kv/mod.rs
+++ b/src/kv/mod.rs
@@ -16,7 +16,7 @@ pub use value::Value;
 
 struct HexRepr<'a>(pub &'a [u8]);
 
-impl<'a> fmt::Display for HexRepr<'a> {
+impl fmt::Display for HexRepr<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         for byte in self.0 {
             write!(f, "{byte:02X}")?;

--- a/src/kv/value.rs
+++ b/src/kv/value.rs
@@ -11,5 +11,4 @@ const _PROPTEST_VALUE_MAX: usize = 1024 * 16; // 16 KB
 /// Since `Value` is just an alias for `Vec<u8>`, conversions to and from it are easy.
 ///
 /// Many functions which accept a `Value` accept an `Into<Value>`.
-
 pub type Value = Vec<u8>;


### PR DESCRIPTION
### Changes

- Upgrade to toolchain `1.84.1`.
- Change toolchain from `stable` to specified stable version to ensure the compatibility and reproducibility of CI.
  - Bump to next stable version will be done periodically manually.
- Fix errors found by new toolchain.