### PR TITLE
tests: Improve integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,8 +52,13 @@ jobs:
 
   integration-test:
     name: integration test
+    strategy:
+      fail-fast: false
+      matrix:
+        case: ["integration-test-txn", "integration-test-raw"]
     env:
       CARGO_INCREMENTAL: 0
+      TIKV_VERSION: v8.5.1
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -69,8 +74,8 @@ jobs:
       - name: start tiup playground
         run: |
           # use latest stable version
-          ~/.tiup/bin/tiup install tikv pd
-          ~/.tiup/bin/tiup playground --mode tikv-slim --kv 3 --without-monitor --kv.config config/tikv.toml --pd.config config/pd.toml &
+          ~/.tiup/bin/tiup install tikv:${{ env.TIKV_VERSION }} pd:${{ env.TIKV_VERSION }}
+          ~/.tiup/bin/tiup playground ${{ env.TIKV_VERSION }} --mode tikv-slim --kv 3 --tag cluster --without-monitor --kv.config config/tikv.toml --pd.config config/pd.toml &
           while :; do
             echo "waiting cluster to be ready"
             [[ "$(curl -I http://127.0.0.1:2379/pd/api/v1/regions 2>/dev/null | head -n 1 | cut -d$' ' -f2)" -ne "405" ]] || break
@@ -78,5 +83,13 @@ jobs:
           done
       - name: Install latest nextest release
         uses: taiki-e/install-action@nextest
-      - name: integration test
-        run: MULTI_REGION=1 make integration-test
+      - name: Integration test
+        run: MULTI_REGION=1 make ${{ matrix.case }}
+      - name: Upload logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: cluster-logs
+          path: |
+            ~/.tiup/data/cluster/tikv*/*.log
+            ~/.tiup/data/cluster/pd*/*.log

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
     name: unit test
     env:
       CARGO_INCREMENTAL: 0
-      NEXTEST_PROFILE: "CI"
+      NEXTEST_PROFILE: ci
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -59,7 +59,7 @@ jobs:
         case: ["integration-test-txn", "integration-test-raw"]
     env:
       CARGO_INCREMENTAL: 0
-      NEXTEST_PROFILE: "CI"
+      NEXTEST_PROFILE: ci
       TIKV_VERSION: v8.5.1
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
     name: unit test
     env:
       CARGO_INCREMENTAL: 0
+      NEXTEST_PROFILE: "CI"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -58,6 +59,7 @@ jobs:
         case: ["integration-test-txn", "integration-test-raw"]
     env:
       CARGO_INCREMENTAL: 0
+      NEXTEST_PROFILE: "CI"
       TIKV_VERSION: v8.5.1
     runs-on: ubuntu-latest
     steps:

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ export MULTI_REGION ?= 1
 
 ALL_FEATURES := integration-tests
 
-NEXTEST_ARGS := --config-file $(shell pwd)/config/nextest.toml -P ci
+NEXTEST_ARGS := --config-file $(shell pwd)/config/nextest.toml
 
 INTEGRATION_TEST_ARGS := --features "integration-tests" --test-threads 1
 

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,17 @@
 export RUSTFLAGS=-Dwarnings
 
-.PHONY: default check unit-test integration-tests test doc docker-pd docker-kv docker all
+.PHONY: default check unit-test generate integration-tests integration-tests-txn integration-tests-raw test doc docker-pd docker-kv docker all
 
 export PD_ADDRS     ?= 127.0.0.1:2379
 export MULTI_REGION ?= 1
 
 ALL_FEATURES := integration-tests
 
-INTEGRATION_TEST_ARGS := --features "integration-tests"
+NEXTEST_ARGS := --config-file $(shell pwd)/config/nextest.toml -P ci
+
+INTEGRATION_TEST_ARGS := --features "integration-tests" --test-threads 1
+
+RUN_INTEGRATION_TEST := cargo nextest run ${NEXTEST_ARGS} --all ${INTEGRATION_TEST_ARGS}
 
 default: check
 
@@ -20,12 +24,15 @@ check: generate
 	cargo clippy --all-targets --features "${ALL_FEATURES}" -- -D clippy::all
 
 unit-test: generate
-	cargo nextest run --all --no-default-features
+	cargo nextest run ${NEXTEST_ARGS} --all --no-default-features
 
-integration-test: generate
-	cargo test txn_ --all ${INTEGRATION_TEST_ARGS} -- --nocapture
-	cargo test raw_ --all ${INTEGRATION_TEST_ARGS} -- --nocapture
-	cargo test misc_ --all ${INTEGRATION_TEST_ARGS} -- --nocapture
+integration-test: integration-test-txn integration-test-raw
+
+integration-test-txn: generate
+	$(RUN_INTEGRATION_TEST) txn_
+
+integration-test-raw: generate
+	$(RUN_INTEGRATION_TEST) raw_
 
 test: unit-test integration-test
 

--- a/config/nextest.toml
+++ b/config/nextest.toml
@@ -1,7 +1,7 @@
 [profile.ci]
 retries = 0
 fail-fast = false
-slow-timeout = { period = "60s", terminate-after = 3 } # Timeout 3m.
+slow-timeout = { period = "60s", terminate-after = 10 } # Timeout 10m. TODO: speed up the slow tests.
 failure-output = "final"
 
 [profile.ci.junit]

--- a/config/nextest.toml
+++ b/config/nextest.toml
@@ -1,0 +1,8 @@
+[profile.ci]
+retries = 0
+fail-fast = false
+slow-timeout = { period = "60s", terminate-after = 3 } # Timeout 3m.
+failure-output = "final"
+
+[profile.ci.junit]
+path = "junit.xml"

--- a/config/tikv.toml
+++ b/config/tikv.toml
@@ -19,3 +19,4 @@ max-open-files = 10000
 [storage]
 api-version = 2
 enable-ttl = true
+reserve-space = "0MiB"

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -5,7 +5,6 @@
 //! Test names should begin with one of the following:
 //! 1. txn_
 //! 2. raw_
-//! 3. misc_
 //!
 //! We make use of the convention to control the order of tests in CI, to allow
 //! transactional and raw tests to coexist, since transactional requests have


### PR DESCRIPTION
### Changes

- Use `nextest` to run integration tests for better output of test result.
- Use fixed version of TiKV cluster to make test reproducible.
- Run `txn_` & `raw_` in parallel.
- Upload cluster logs on failure for troubleshooting.

*(Manual pick from #478)*