### PR TITLE
Implement AsRef<[u8]>, Borrow<[u8]>, and Deref<Target=[u8]> for Key

### DIFF
--- a/src/kv/key.rs
+++ b/src/kv/key.rs
@@ -1,7 +1,8 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
+use std::borrow::Borrow;
 use std::fmt;
-use std::ops::Bound;
+use std::ops::{Bound, Deref};
 
 #[allow(unused_imports)]
 #[cfg(test)]
@@ -156,6 +157,26 @@ impl Key {
     }
 }
 
+impl AsRef<[u8]> for Key {
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_ref()
+    }
+}
+
+impl Borrow<[u8]> for Key {
+    fn borrow(&self) -> &[u8] {
+        self.0.borrow()
+    }
+}
+
+impl Deref for Key {
+    type Target = [u8];
+
+    fn deref(&self) -> &Self::Target {
+        self.0.deref()
+    }
+}
+
 impl From<Vec<u8>> for Key {
     fn from(v: Vec<u8>) -> Self {
         Key(v)
@@ -185,6 +206,7 @@ impl<'a> From<&'a Vec<u8>> for &'a Key {
         unsafe { &*(key as *const Vec<u8> as *const Key) }
     }
 }
+
 impl AsRef<Key> for Key {
     fn as_ref(&self) -> &Key {
         self

--- a/src/region_cache.rs
+++ b/src/region_cache.rs
@@ -74,7 +74,7 @@ impl<C: RetryClientTrait> RegionCache<C> {
         let res = {
             region_cache_guard
                 .key_to_ver_id
-                .range(..=key)
+                .range::<Key, _>(..=key)
                 .next_back()
                 .map(|(x, y)| (x.clone(), y.clone()))
         };
@@ -180,9 +180,9 @@ impl<C: RetryClientTrait> RegionCache<C> {
 
         let mut search_range = {
             if end_key.is_empty() {
-                cache.key_to_ver_id.range(..)
+                cache.key_to_ver_id.range::<Key, _>(..)
             } else {
-                cache.key_to_ver_id.range(..end_key)
+                cache.key_to_ver_id.range::<Key, _>(..end_key)
             }
         };
         while let Some((_, ver_id_in_cache)) = search_range.next_back() {

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1155,8 +1155,8 @@ async fn txn_get_for_update() -> Result<()> {
         .map(From::from)
         .collect();
     t2.commit().await?;
-    assert!(res.get(&key1.clone().into()).unwrap() == &value1);
-    assert!(res.get(&key2.into()).unwrap() == &value2);
+    assert!(res.get(key1.as_bytes()).unwrap() == &value1);
+    assert!(res.get(key2.as_bytes()).unwrap() == &value2);
 
     assert!(t3.get_for_update(key1).await?.is_none());
     assert!(t3.commit().await.is_err());


### PR DESCRIPTION
These trait implementations make it easier to work with `Key` instances outputted by operations like `scan` and `scan_keys` without making unnecessary clones.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Expanded the key type’s interoperability by supporting more standard Rust borrowing/access patterns (e.g., treating it directly as a byte slice).
  * Improved clarity in region lookup behavior by making key range selection more explicit, without changing results.
* **Tests**
  * Updated integration test lookups to use the underlying byte representations directly for result verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->