### PR TITLE
fix: replace panic unwrap with error check in cluster.rs (#504)

### DIFF
--- a/src/pd/cluster.rs
+++ b/src/pd/cluster.rs
@@ -319,9 +319,11 @@ impl Connection {
 
         // Then try to connect the PD cluster leader.
         if let Some(resp) = resp {
-            let leader = resp.leader.as_ref()
-                .ok_or_else(|| internal_err!("no leader found in GetMembersResponse"))?; 
-        
+            let leader = resp
+                .leader
+                .as_ref()
+                .ok_or_else(|| internal_err!("no leader found in GetMembersResponse"))?;
+
             for ep in &leader.client_urls {
                 if let Ok((client, keyspace_client, members)) =
                     self.try_connect(ep.as_str(), cluster_id, timeout).await


### PR DESCRIPTION
### What is changed and how it works?
Replaced a panic-inducing `.unwrap()` on `resp.leader` with `ok_or_else` in `src/pd/cluster.rs`.

If `resp.leader` is `None`, the client will now return a proper error instead of crashing the entire application.

### Issue reference
Closes #504

### Check List
- [x] Code is formatted (ran `cargo fmt`? If not, run it locally now!)
- [x] This PR is signed-off