### PR TITLE
transaction: Handle commit_ts expired error

### DIFF
--- a/src/common/errors.rs
+++ b/src/common/errors.rs
@@ -104,7 +104,7 @@ pub enum Error {
     #[error("{}", message)]
     InternalError { message: String },
     #[error("{0}")]
-    OtherError(String),
+    StringError(String),
     #[error("PessimisticLock error: {:?}", inner)]
     PessimisticLockError {
         inner: Box<Error>,

--- a/src/region_cache.rs
+++ b/src/region_cache.rs
@@ -117,7 +117,7 @@ impl<C: RetryClientTrait> RegionCache<C> {
                 return self.read_through_region_by_id(id).await;
             }
         }
-        Err(Error::OtherError(format!(
+        Err(Error::StringError(format!(
             "Concurrent PD requests failed for {MAX_RETRY_WAITING_CONCURRENT_REQUEST} times"
         )))
     }
@@ -316,7 +316,7 @@ mod test {
                 .filter(|(_, r)| r.contains(&key.clone().into()))
                 .map(|(_, r)| r.clone())
                 .next()
-                .ok_or_else(|| Error::OtherError("MockRetryClient: region not found".to_owned()))
+                .ok_or_else(|| Error::StringError("MockRetryClient: region not found".to_owned()))
         }
 
         async fn get_region_by_id(
@@ -331,7 +331,7 @@ mod test {
                 .filter(|(id, _)| id == &&region_id)
                 .map(|(_, r)| r.clone())
                 .next()
-                .ok_or_else(|| Error::OtherError("MockRetryClient: region not found".to_owned()))
+                .ok_or_else(|| Error::StringError("MockRetryClient: region not found".to_owned()))
         }
 
         async fn get_store(

--- a/src/store/errors.rs
+++ b/src/store/errors.rs
@@ -169,7 +169,7 @@ impl<T: HasKeyErrors> HasKeyErrors for Result<T, Error> {
             Err(Error::MultipleKeyErrors(errs)) => Some(std::mem::take(errs)),
             Err(e) => Some(vec![std::mem::replace(
                 e,
-                Error::OtherError("".to_string()), // placeholder, no use.
+                Error::StringError("".to_string()), // placeholder, no use.
             )]),
         }
     }

--- a/src/transaction/transaction.rs
+++ b/src/transaction/transaction.rs
@@ -1271,7 +1271,7 @@ impl<PdC: PdClient> Committer<PdC> {
         let min_commit_ts = self.prewrite().await?;
 
         fail_point!("after-prewrite", |_| {
-            Err(Error::OtherError(
+            Err(Error::StringError(
                 "failpoint: after-prewrite return error".to_owned(),
             ))
         });
@@ -1420,7 +1420,7 @@ impl<PdC: PdClient> Committer<PdC> {
                             if primary_key != expired.key.as_ref() {
                                 error!("2PC commit_ts rejected by TiKV, but the key is not the primary key, start_ts: {}, key: {}, primary: {:?}",
                                     self.start_version.version(), HexRepr(&expired.key), primary_key);
-                                return Err(Error::OtherError("2PC commitTS rejected by TiKV, but the key is not the primary key".to_string()));
+                                return Err(Error::StringError("2PC commitTS rejected by TiKV, but the key is not the primary key".to_string()));
                             }
 
                             // Do not retry for a txn which has a too large min_commit_ts.
@@ -1432,7 +1432,7 @@ impl<PdC: PdClient> Committer<PdC> {
                             {
                                 let msg = format!("2PC min_commit_ts is too large, we got min_commit_ts: {}, and attempted_commit_ts: {}",
                                                      expired.min_commit_ts, expired.attempted_commit_ts);
-                                return Err(Error::OtherError(msg));
+                                return Err(Error::StringError(msg));
                             }
                             continue;
                         } else {
@@ -1464,7 +1464,7 @@ impl<PdC: PdClient> Committer<PdC> {
                     let percent = percent.unwrap().parse::<usize>().unwrap();
                     new_len = mutations_len * percent / 100;
                     if new_len == 0 {
-                        Err(Error::OtherError(
+                        Err(Error::StringError(
                             "failpoint: before-commit-secondary return error".to_owned(),
                         ))
                     } else {

--- a/tests/common/ctl.rs
+++ b/tests/common/ctl.rs
@@ -10,16 +10,16 @@ use crate::common::Result;
 pub async fn get_region_count() -> Result<u64> {
     let res = reqwest::get(format!("http://{}/pd/api/v1/regions", pd_addrs()[0]))
         .await
-        .map_err(|e| Error::OtherError(e.to_string()))?;
+        .map_err(|e| Error::StringError(e.to_string()))?;
 
     let body = res
         .text()
         .await
-        .map_err(|e| Error::OtherError(e.to_string()))?;
+        .map_err(|e| Error::StringError(e.to_string()))?;
     let value: serde_json::Value = serde_json::from_str(body.as_ref()).unwrap_or_else(|err| {
         panic!("invalid body: {:?}, error: {:?}", body, err);
     });
     value["count"]
         .as_u64()
-        .ok_or_else(|| Error::OtherError("pd region count does not return an integer".to_owned()))
+        .ok_or_else(|| Error::StringError("pd region count does not return an integer".to_owned()))
 }


### PR DESCRIPTION
Cherry pick #491

### Changes

  - Add retry loop for `KeyError::commit_ts_expired` when committing the primary key, mirroring client-go’s actionCommit::handleSingleBatch logic (src/transaction/transaction.rs).
  - Improve error visibility/logging for primary commit failures and key mismatch (uses HexRepr) (src/transaction/transaction.rs, src/kv/mod.rs).
  - Fix HasKeyErrors for Result<T, Error> to preserve structured errors (especially MultipleKeyErrors) instead of stringifying, enabling correct extraction/matching (src/store/errors.rs).
  - Improve test helper error message when PD HTTP response body isn’t valid JSON (tests/common/ctl.rs).
 
Compare with Go implementation (https://github.com/tikv/client-go/blob/tidb-8.5/txnkv/transaction/commit.go) by LLM:

  - commit_ts_expired handling: Committer::commit_primary_with_retry in src/transaction/transaction.rs:1408 matches actionCommit::handleSingleBatch’s CommitTsExpired branch—logs, verifies the rejected key is the
    primary (:1419-1424), rejects “too large min_commit_ts” (:1426-1436), and retries (:1437). Rust retries by re-running commit_primary() which re-fetches a fresh TSO and rebuilds the commit request (:1372-1406),
    which is equivalent to Go’s “update commitTS + update request + continue”.
