### PR TITLE
flaky test wait for lock cleanup

### DIFF
--- a/tests/failpoint_tests.rs
+++ b/tests/failpoint_tests.rs
@@ -337,7 +337,8 @@ async fn txn_cleanup_2pc_locks() -> Result<()> {
         )
         .await?;
         let keys = write_data(&client, false, false).await?;
-        assert_eq!(count_locks(&client).await?, 0);
+        let remaining = wait_for_locks_count(&client, 0).await?;
+        assert_eq!(remaining, 0);
 
         let safepoint = client.current_timestamp().await?;
         let options = ResolveLocksOptions {


### PR DESCRIPTION
Related to issue #516 . I experienced different types of symptoms: Sometimes an assertion failed (assertion that remaining locks == 0), sometimes the assertion passed but there was panic or slowness elsewhere, most times the test passed fine.

My knowledge of the projects techniques is still a bit limited, so I consulted AI, but I try to use my best judgement in evaluating whether its suggestions make sense. It suggested that the test may experience a race condition regarding to how quickly the locks are cleaned up in a 2PC, and that we could wait for the lock cleanup process to let the background process finish and then check the assertions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved lock count verification test assertions to enhance test reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->