### PR TITLE
*: Re-export protobuf types (LockInfo, Error, and KeyError)

### DIFF
--- a/src/common/errors.rs
+++ b/src/common/errors.rs
@@ -8,6 +8,20 @@ use crate::proto::kvrpcpb;
 use crate::region::RegionVerId;
 use crate::BoundRange;
 
+/// Protobuf-generated region-level error returned by TiKV.
+///
+/// This type is generated from TiKV's protobuf definitions and may change in a
+/// future release even if the wire format is compatible.
+#[doc(inline)]
+pub use crate::proto::errorpb::Error as ProtoRegionError;
+
+/// Protobuf-generated per-key error returned by TiKV.
+///
+/// This type is generated from TiKV's protobuf definitions and may change in a
+/// future release even if the wire format is compatible.
+#[doc(inline)]
+pub use crate::proto::kvrpcpb::KeyError as ProtoKeyError;
+
 /// An error originating from the TiKV client or dependencies.
 #[derive(Debug, Error)]
 #[allow(clippy::large_enum_variant)]
@@ -63,13 +77,13 @@ pub enum Error {
     Canceled(#[from] futures::channel::oneshot::Canceled),
     /// Errors caused by changes of region information
     #[error("Region error: {0:?}")]
-    RegionError(Box<crate::proto::errorpb::Error>),
+    RegionError(Box<ProtoRegionError>),
     /// Whether the transaction is committed or not is undetermined
     #[error("Whether the transaction is committed or not is undetermined")]
     UndeterminedError(Box<Error>),
-    /// Wraps `crate::proto::kvrpcpb::KeyError`
+    /// Wraps a per-key error returned by TiKV.
     #[error("{0:?}")]
-    KeyError(Box<crate::proto::kvrpcpb::KeyError>),
+    KeyError(Box<ProtoKeyError>),
     /// Multiple errors generated from the ExtractError plan.
     #[error("Multiple errors: {0:?}")]
     ExtractedErrors(Vec<Error>),
@@ -116,14 +130,14 @@ pub enum Error {
     TxnNotFound(kvrpcpb::TxnNotFound),
 }
 
-impl From<crate::proto::errorpb::Error> for Error {
-    fn from(e: crate::proto::errorpb::Error) -> Error {
+impl From<ProtoRegionError> for Error {
+    fn from(e: ProtoRegionError) -> Error {
         Error::RegionError(Box::new(e))
     }
 }
 
-impl From<crate::proto::kvrpcpb::KeyError> for Error {
-    fn from(e: crate::proto::kvrpcpb::KeyError) -> Error {
+impl From<ProtoKeyError> for Error {
+    fn from(e: ProtoKeyError) -> Error {
         Error::KeyError(Box::new(e))
     }
 }

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -4,4 +4,6 @@ mod errors;
 pub mod security;
 
 pub use self::errors::Error;
+pub use self::errors::ProtoKeyError;
+pub use self::errors::ProtoRegionError;
 pub use self::errors::Result;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,6 +122,10 @@ pub use common::security::SecurityManager;
 #[doc(inline)]
 pub use common::Error;
 #[doc(inline)]
+pub use common::ProtoKeyError;
+#[doc(inline)]
+pub use common::ProtoRegionError;
+#[doc(inline)]
 pub use common::Result;
 #[doc(inline)]
 pub use config::Config;
@@ -156,6 +160,8 @@ pub use crate::transaction::lowering as transaction_lowering;
 pub use crate::transaction::CheckLevel;
 #[doc(inline)]
 pub use crate::transaction::Client as TransactionClient;
+#[doc(inline)]
+pub use crate::transaction::ProtoLockInfo;
 #[doc(inline)]
 pub use crate::transaction::Snapshot;
 #[doc(inline)]

--- a/src/transaction/client.rs
+++ b/src/transaction/client.rs
@@ -9,7 +9,6 @@ use crate::backoff::{DEFAULT_REGION_BACKOFF, DEFAULT_STORE_BACKOFF};
 use crate::config::Config;
 use crate::pd::PdClient;
 use crate::pd::PdRpcClient;
-use crate::proto::kvrpcpb;
 use crate::proto::pdpb::Timestamp;
 use crate::request::plan::CleanupLocksResult;
 use crate::request::EncodeKeyspace;
@@ -28,6 +27,9 @@ use crate::transaction::TransactionOptions;
 use crate::Backoff;
 use crate::BoundRange;
 use crate::Result;
+
+#[doc(inline)]
+pub use crate::proto::kvrpcpb::LockInfo;
 
 // FIXME: cargo-culted value
 const SCAN_LOCK_BATCH_SIZE: u32 = 1024;
@@ -302,7 +304,7 @@ impl Client {
         safepoint: &Timestamp,
         range: impl Into<BoundRange>,
         batch_size: u32,
-    ) -> Result<Vec<crate::proto::kvrpcpb::LockInfo>> {
+    ) -> Result<Vec<LockInfo>> {
         use crate::request::TruncateKeyspace;
 
         let range = range.into().encode_keyspace(self.keyspace, KeyMode::Txn);
@@ -321,10 +323,10 @@ impl Client {
     /// timestamp when checking transaction status.
     pub async fn resolve_locks(
         &self,
-        locks: Vec<kvrpcpb::LockInfo>,
+        locks: Vec<LockInfo>,
         timestamp: Timestamp,
         mut backoff: Backoff,
-    ) -> Result<Vec<kvrpcpb::LockInfo>> {
+    ) -> Result<Vec<LockInfo>> {
         use crate::request::TruncateKeyspace;
 
         let mut live_locks = locks;

--- a/src/transaction/client.rs
+++ b/src/transaction/client.rs
@@ -28,8 +28,12 @@ use crate::Backoff;
 use crate::BoundRange;
 use crate::Result;
 
+/// Protobuf-generated lock information returned by TiKV.
+///
+/// This type is generated from TiKV's protobuf definitions and may change in a
+/// future release even if the wire format is compatible.
 #[doc(inline)]
-pub use crate::proto::kvrpcpb::LockInfo;
+pub use crate::proto::kvrpcpb::LockInfo as ProtoLockInfo;
 
 // FIXME: cargo-culted value
 const SCAN_LOCK_BATCH_SIZE: u32 = 1024;
@@ -304,7 +308,7 @@ impl Client {
         safepoint: &Timestamp,
         range: impl Into<BoundRange>,
         batch_size: u32,
-    ) -> Result<Vec<LockInfo>> {
+    ) -> Result<Vec<ProtoLockInfo>> {
         use crate::request::TruncateKeyspace;
 
         let range = range.into().encode_keyspace(self.keyspace, KeyMode::Txn);
@@ -323,10 +327,10 @@ impl Client {
     /// timestamp when checking transaction status.
     pub async fn resolve_locks(
         &self,
-        locks: Vec<LockInfo>,
+        locks: Vec<ProtoLockInfo>,
         timestamp: Timestamp,
         mut backoff: Backoff,
-    ) -> Result<Vec<LockInfo>> {
+    ) -> Result<Vec<ProtoLockInfo>> {
         use crate::request::TruncateKeyspace;
 
         let mut live_locks = locks;

--- a/src/transaction/mod.rs
+++ b/src/transaction/mod.rs
@@ -9,7 +9,7 @@
 //! **Warning:** It is not advisable to use both raw and transactional functionality in the same keyspace.
 
 pub use client::Client;
-pub use client::LockInfo;
+pub use client::ProtoLockInfo;
 pub(crate) use lock::resolve_locks;
 pub(crate) use lock::HasLocks;
 pub use snapshot::Snapshot;

--- a/src/transaction/mod.rs
+++ b/src/transaction/mod.rs
@@ -9,6 +9,7 @@
 //! **Warning:** It is not advisable to use both raw and transactional functionality in the same keyspace.
 
 pub use client::Client;
+pub use client::LockInfo;
 pub(crate) use lock::resolve_locks;
 pub(crate) use lock::HasLocks;
 pub use snapshot::Snapshot;


### PR DESCRIPTION
### Changes

  - Publicly re-export protobuf-generated types from the crate to provide a stable, ergonomic API surface.
  - Update internal function signatures to use the re-exported type names.
  - Adjust From/conversion implementations to match the new public type names.
  - No behavioral or wire-format changes; underlying protobuf types remain the same.