### PR TITLE
build: pin tempfile to 3.14.0 for rust-toolchain 1.84.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ reqwest = { version = "0.11", features = ["json", "native-tls-vendored"] }
 rstest = "0.18.2"
 serde_json = "1"
 serial_test = "0.5.0"
-tempfile = "3.6"
+tempfile = "=3.14.0"
 tokio = { version = "1", features = ["sync", "rt-multi-thread", "macros"] }
 
 [[test]]

--- a/proto-build/Cargo.toml
+++ b/proto-build/Cargo.toml
@@ -13,3 +13,5 @@ edition = "2021"
 [dependencies]
 glob = "0.3"
 tonic-build = { version = "0.10", features = ["cleanup-markdown"] }
+# Keep this compatible with rust-toolchain 1.84.1.
+tempfile = "=3.14.0"


### PR DESCRIPTION
## Problem
`make` fails on toolchain `1.84.1` during `cargo run -p tikv-client-proto-build` because dependency resolution can pick `tempfile 3.25.0`, which pulls `getrandom 0.4.1` (requires Cargo support for edition2024).

## Fix
- Pin `tempfile` to `=3.14.0` in `Cargo.toml` dev-dependencies.
- Add the same pin in `proto-build/Cargo.toml` so `generate` is constrained even when `Cargo.lock` is ignored.

This keeps compatibility with the repository's pinned `rust-toolchain.toml` (`1.84.1`) and avoids the `edition2024` parse failure.

## Verification
- `make`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development dependency versions for compatibility with the latest Rust toolchain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->