### PR TITLE
request: replace try_join_all with JoinSet in plan handlers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,13 +45,23 @@ serde_json = "1"
 take_mut = "0.2.2"
 thiserror = "1"
 tokio = { version = "1", features = ["sync", "rt-multi-thread", "macros"] }
+# Keep these compatible with rust-toolchain 1.84.1.
+indexmap = "=2.13.1"
+icu_collections = "<2.2"
+icu_locale_core = "<2.2"
+icu_normalizer = "<2.2"
+icu_normalizer_data = "<2.2"
+icu_properties = "<2.2"
+icu_properties_data = "<2.2"
+icu_provider = "<2.2"
+
 tonic = { version = "0.10", features = ["tls", "gzip"] }
 
 [dev-dependencies]
 clap = "2"
 env_logger = "0.10"
 fail = { version = "0.4", features = ["failpoints"] }
-proptest = "1"
+proptest = "<1.11"
 proptest-derive = "0.5.1"
 reqwest = { version = "0.11", features = ["json", "native-tls-vendored"] }
 rstest = "0.18.2"

--- a/proto-build/Cargo.toml
+++ b/proto-build/Cargo.toml
@@ -13,5 +13,6 @@ edition = "2021"
 [dependencies]
 glob = "0.3"
 tonic-build = { version = "0.10", features = ["cleanup-markdown"] }
-# Keep this compatible with rust-toolchain 1.84.1.
+# Keep these compatible with rust-toolchain 1.84.1.
+indexmap = "=2.13.1"
 tempfile = "=3.14.0"

--- a/src/request/plan.rs
+++ b/src/request/plan.rs
@@ -5,12 +5,12 @@ use std::sync::Arc;
 
 use async_recursion::async_recursion;
 use async_trait::async_trait;
-use tokio::task::JoinSet;
 use futures::prelude::*;
 use log::debug;
 use log::error;
 use log::info;
 use tokio::sync::Semaphore;
+use tokio::task::JoinSet;
 use tokio::time::sleep;
 
 use crate::backoff::Backoff;

--- a/src/request/plan.rs
+++ b/src/request/plan.rs
@@ -93,6 +93,35 @@ pub(crate) fn is_grpc_error(e: &Error) -> bool {
     matches!(e, Error::GrpcAPI(_) | Error::Grpc(_))
 }
 
+async fn collect_join_set_results<T>(
+    mut join_set: JoinSet<(usize, T)>,
+    task_count: usize,
+    handler_name: &str,
+) -> Result<Vec<T>>
+where
+    T: Send + 'static,
+{
+    let mut results = (0..task_count).map(|_| None).collect::<Vec<_>>();
+    while let Some(join_result) = join_set.join_next().await {
+        match join_result {
+            Ok((idx, val)) => results[idx] = Some(val),
+            Err(e) => {
+                error!(
+                    "{}: failed to join task ({} tasks): {}",
+                    handler_name, task_count, e
+                );
+                join_set.shutdown().await;
+                return Err(Error::JoinError(e));
+            }
+        }
+    }
+
+    Ok(results
+        .into_iter()
+        .map(|result| result.expect("all spawned tasks should return a result"))
+        .collect())
+}
+
 pub struct RetryableMultiRegion<P: Plan, PdC: PdClient> {
     pub(super) inner: P,
     pub pd_client: Arc<PdC>,
@@ -121,29 +150,35 @@ where
         let shards_len = shards.len();
         debug!("single_plan_handler, shards: {}", shards_len);
         let mut join_set = JoinSet::new();
-        for shard in shards {
-            let (shard, region) = shard?;
+        for (idx, shard) in shards.into_iter().enumerate() {
+            let (shard, region) = match shard {
+                Ok(shard) => shard,
+                Err(e) => {
+                    join_set.shutdown().await;
+                    return Err(e);
+                }
+            };
             let clone = current_plan.clone_then_apply_shard(shard);
-            join_set.spawn(Self::single_shard_handler(
-                pd_client.clone(),
-                clone,
-                region,
-                backoff.clone(),
-                permits.clone(),
-                preserve_region_results,
-            ));
+            let pd_client = pd_client.clone();
+            let backoff = backoff.clone();
+            let permits = permits.clone();
+            join_set.spawn(async move {
+                (
+                    idx,
+                    Self::single_shard_handler(
+                        pd_client,
+                        clone,
+                        region,
+                        backoff,
+                        permits,
+                        preserve_region_results,
+                    )
+                    .await,
+                )
+            });
         }
 
-        let mut results = Vec::with_capacity(shards_len);
-        while let Some(join_result) = join_set.join_next().await {
-            match join_result {
-                Ok(val) => results.push(val),
-                Err(e) => {
-                    error!("failed to join task: {}", e);
-                    return Err(Error::JoinError(e));
-                }
-            }
-        }
+        let results = collect_join_set_results(join_set, shards_len, "single_plan_handler").await?;
 
         if preserve_region_results {
             Ok(results
@@ -462,27 +497,22 @@ where
         let stores = self.pd_client.clone().all_stores().await?;
         let stores_len = stores.len();
         let mut join_set = JoinSet::new();
-        for store in stores {
+        for (idx, store) in stores.into_iter().enumerate() {
             let mut clone = self.inner.clone();
             clone.apply_store(&store);
-            join_set.spawn(Self::single_store_handler(
-                clone,
-                self.backoff.clone(),
-                concurrency_permits.clone(),
-            ));
+            let backoff = self.backoff.clone();
+            let concurrency_permits = concurrency_permits.clone();
+            join_set.spawn(async move {
+                (
+                    idx,
+                    Self::single_store_handler(clone, backoff, concurrency_permits).await,
+                )
+            });
         }
 
-        let mut results = Vec::with_capacity(stores_len);
-        while let Some(join_result) = join_set.join_next().await {
-            match join_result {
-                Ok(val) => results.push(val),
-                Err(e) => {
-                    error!("failed to join task: {}", e);
-                    return Err(Error::JoinError(e));
-                }
-            }
-        }
-        Ok(results.into_iter().collect::<Vec<_>>())
+        let results =
+            collect_join_set_results(join_set, stores_len, "single_store_handler").await?;
+        Ok(results)
     }
 }
 
@@ -942,6 +972,8 @@ impl<Resp: HasRegionError, Shard> HasRegionError for ResponseWithShard<Resp, Sha
 
 #[cfg(test)]
 mod test {
+    use std::time::Duration;
+
     use futures::stream::BoxStream;
     use futures::stream::{self};
 
@@ -993,5 +1025,22 @@ mod test {
             preserve_region_results: false,
         };
         assert!(plan.execute().await.is_err())
+    }
+
+    #[tokio::test]
+    async fn test_join_set_results_keep_spawn_order() {
+        let mut join_set = JoinSet::new();
+        for (idx, delay_ms) in [(0, 30), (1, 10), (2, 20)] {
+            join_set.spawn(async move {
+                sleep(Duration::from_millis(delay_ms)).await;
+                (idx, idx)
+            });
+        }
+
+        let results = collect_join_set_results(join_set, 3, "test_handler")
+            .await
+            .unwrap();
+
+        assert_eq!(results, vec![0, 1, 2]);
     }
 }

--- a/src/request/plan.rs
+++ b/src/request/plan.rs
@@ -5,9 +5,10 @@ use std::sync::Arc;
 
 use async_recursion::async_recursion;
 use async_trait::async_trait;
-use futures::future::try_join_all;
+use tokio::task::JoinSet;
 use futures::prelude::*;
 use log::debug;
+use log::error;
 use log::info;
 use tokio::sync::Semaphore;
 use tokio::time::sleep;
@@ -117,12 +118,13 @@ where
         preserve_region_results: bool,
     ) -> Result<<Self as Plan>::Result> {
         let shards = current_plan.shards(&pd_client).collect::<Vec<_>>().await;
-        debug!("single_plan_handler, shards: {}", shards.len());
-        let mut handles = Vec::with_capacity(shards.len());
+        let shards_len = shards.len();
+        debug!("single_plan_handler, shards: {}", shards_len);
+        let mut join_set = JoinSet::new();
         for shard in shards {
             let (shard, region) = shard?;
             let clone = current_plan.clone_then_apply_shard(shard);
-            let handle = tokio::spawn(Self::single_shard_handler(
+            join_set.spawn(Self::single_shard_handler(
                 pd_client.clone(),
                 clone,
                 region,
@@ -130,10 +132,19 @@ where
                 permits.clone(),
                 preserve_region_results,
             ));
-            handles.push(handle);
         }
 
-        let results = try_join_all(handles).await?;
+        let mut results = Vec::with_capacity(shards_len);
+        while let Some(join_result) = join_set.join_next().await {
+            match join_result {
+                Ok(val) => results.push(val),
+                Err(e) => {
+                    error!("failed to join task: {}", e);
+                    return Err(Error::JoinError(e));
+                }
+            }
+        }
+
         if preserve_region_results {
             Ok(results
                 .into_iter()
@@ -449,18 +460,28 @@ where
     async fn execute(&self) -> Result<Self::Result> {
         let concurrency_permits = Arc::new(Semaphore::new(MULTI_STORES_CONCURRENCY));
         let stores = self.pd_client.clone().all_stores().await?;
-        let mut handles = Vec::with_capacity(stores.len());
+        let stores_len = stores.len();
+        let mut join_set = JoinSet::new();
         for store in stores {
             let mut clone = self.inner.clone();
             clone.apply_store(&store);
-            let handle = tokio::spawn(Self::single_store_handler(
+            join_set.spawn(Self::single_store_handler(
                 clone,
                 self.backoff.clone(),
                 concurrency_permits.clone(),
             ));
-            handles.push(handle);
         }
-        let results = try_join_all(handles).await?;
+
+        let mut results = Vec::with_capacity(stores_len);
+        while let Some(join_result) = join_set.join_next().await {
+            match join_result {
+                Ok(val) => results.push(val),
+                Err(e) => {
+                    error!("failed to join task: {}", e);
+                    return Err(Error::JoinError(e));
+                }
+            }
+        }
         Ok(results.into_iter().collect::<Vec<_>>())
     }
 }


### PR DESCRIPTION
## Summary

- Replace `futures::future::try_join_all` with `tokio::task::JoinSet` in `single_plan_handler` and `single_store_handler`
- Extract result collection into a reusable `collect_join_set_results` helper that:
  - Preserves spawn order via index tagging
  - Logs and propagates `JoinError` with structured context
  - Calls `shutdown().await` on the `JoinSet` before returning on error
- On shard iteration failure in `single_plan_handler`: abort already-spawned tasks via `shutdown().await`
- Pin dependency versions (`indexmap`, `icu_*`, `proptest`) for `rust-toolchain 1.84.1` compatibility

## Changes

- `src/request/plan.rs`:
  - Added `tokio::task::JoinSet` import; removed `futures::future::try_join_all`
  - Added `log::error` import for join failure logging
  - Introduced `collect_join_set_results()` — generic ordered result collector for `JoinSet<(usize, T)>`
  - Both `single_plan_handler` and `single_store_handler` now spawn index-tagged tasks via `JoinSet`
  - On `JoinError`: logs handler name and task count, shuts down remaining tasks, returns `Error::JoinError`
  - On shard stream `Err`: calls `shutdown().await` before returning, aborting in-flight tasks
  - Added unit test `test_join_set_results_keep_spawn_order` verifying result ordering
- `Cargo.toml` / `proto-build/Cargo.toml`: pinned `indexmap`, `icu_*` crates, and `proptest` for Rust 1.84.1 compatibility

## Review Findings

- https://github.com/pingyu/client-rust/blob/join-all-handles/src/request/plan.rs#L113-L114 and https://github.com/pingyu/client-rust/blob/join-all-handles/src/request/plan.rs#L157-L158: 🟡 risk: `join_set.shutdown().await` changes the old error path from "drop `JoinHandle`s and let already-spawned tasks continue detached" to "abort remaining shard/store tasks immediately." If any caller relies on in-flight fanout requests finishing after a later sharding/join failure, this is now a behavior change. Add a regression test for cancellation semantics or document that the new contract is intentional.

Validation: `cargo check --lib` passed, `cargo test --lib` passed (59 tests), and the new `test_join_set_results_keep_spawn_order` also passed. No other concrete correctness issues stood out in the final branch state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal async task handling for multi-region and all-stores execution with stronger error handling and ordered result collection.
* **Tests**
  * Added a unit test ensuring results are returned in the original task order even when tasks finish out of order.
* **Chores**
  * Tightened several dependency version constraints for build and runtime stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->