### PR TITLE
Upgrade tonic TLS stack

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ lazy_static = "1"
 log = "0.4"
 pin-project = "1"
 prometheus = { version = "0.13", default-features = false }
-prost = "0.12"
+prost = "0.13"
 rand = "0.8"
 regex = "1"
 semver = "1.0"
@@ -45,7 +45,7 @@ serde_json = "1"
 take_mut = "0.2.2"
 thiserror = "1"
 tokio = { version = "1", features = ["sync", "rt-multi-thread", "macros"] }
-tonic = { version = "0.10", features = ["tls", "gzip"] }
+tonic = { version = "0.12", features = ["tls", "gzip"] }
 
 [dev-dependencies]
 clap = "2"


### PR DESCRIPTION
Upgrade `tonic` from `0.10` to `0.12` while keeping TLS enabled.

`tonic 0.10`'s `tls` feature pulls in the older `rustls 0.21` / `rustls-webpki 0.101` TLS stack, which is affected by RustSec advisories such as `RUSTSEC-2026-0098`, `RUSTSEC-2026-0099`, and `RUSTSEC-2026-0104`.

`tonic 0.12` keeps the existing `tls` feature API but moves TLS to `tokio-rustls 0.26` / `rustls 0.23`, which uses patched `rustls-webpki` versions. This keeps TLS support working while removing the vulnerable old TLS dependency path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated core framework dependencies to their latest stable versions. These updates deliver important bug fixes, security patches, and performance optimizations from upstream libraries. The enhancements improve application stability, ensure better compatibility with modern production environments, and strengthen overall system reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->