### PR TITLE
request: replace try_join_all with JoinSet in plan handlers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ serde_derive = "1.0"
 serde_json = "1"
 take_mut = "0.2.2"
 thiserror = "1"
-tokio = { version = "1", features = ["sync", "rt-multi-thread", "macros"] }
+tokio = { version = "1.21", features = ["sync", "rt-multi-thread", "macros"] }
 tonic = { version = "0.12", features = ["tls", "gzip"] }
 
 [dev-dependencies]

--- a/src/request/plan.rs
+++ b/src/request/plan.rs
@@ -94,6 +94,35 @@ pub(crate) fn is_grpc_error(e: &Error) -> bool {
     matches!(e, Error::GrpcAPI(_) | Error::Grpc(_))
 }
 
+async fn collect_join_set_results<T>(
+    mut join_set: JoinSet<(usize, T)>,
+    task_count: usize,
+    handler_name: &str,
+) -> Result<Vec<T>>
+where
+    T: Send + 'static,
+{
+    let mut results = (0..task_count).map(|_| None).collect::<Vec<_>>();
+    while let Some(join_result) = join_set.join_next().await {
+        match join_result {
+            Ok((idx, val)) => results[idx] = Some(val),
+            Err(e) => {
+                error!(
+                    "{}: failed to join task ({} tasks): {}",
+                    handler_name, task_count, e
+                );
+                join_set.shutdown().await;
+                return Err(Error::JoinError(e));
+            }
+        }
+    }
+
+    Ok(results
+        .into_iter()
+        .map(|result| result.expect("all spawned tasks should return a result"))
+        .collect())
+}
+
 pub struct RetryableMultiRegion<P: Plan, PdC: PdClient> {
     pub(super) inner: P,
     pub pd_client: Arc<PdC>,
@@ -122,29 +151,35 @@ where
         let shards_len = shards.len();
         debug!("single_plan_handler, shards: {}", shards_len);
         let mut join_set = JoinSet::new();
-        for shard in shards {
-            let (shard, region) = shard?;
+        for (idx, shard) in shards.into_iter().enumerate() {
+            let (shard, region) = match shard {
+                Ok(shard) => shard,
+                Err(e) => {
+                    join_set.shutdown().await;
+                    return Err(e);
+                }
+            };
             let clone = current_plan.clone_then_apply_shard(shard);
-            join_set.spawn(Self::single_shard_handler(
-                pd_client.clone(),
-                clone,
-                region,
-                backoff.clone(),
-                permits.clone(),
-                preserve_region_results,
-            ));
+            let pd_client = pd_client.clone();
+            let backoff = backoff.clone();
+            let permits = permits.clone();
+            join_set.spawn(async move {
+                (
+                    idx,
+                    Self::single_shard_handler(
+                        pd_client,
+                        clone,
+                        region,
+                        backoff,
+                        permits,
+                        preserve_region_results,
+                    )
+                    .await,
+                )
+            });
         }
 
-        let mut results = Vec::with_capacity(shards_len);
-        while let Some(join_result) = join_set.join_next().await {
-            match join_result {
-                Ok(val) => results.push(val),
-                Err(e) => {
-                    error!("failed to join task: {}", e);
-                    return Err(Error::JoinError(e));
-                }
-            }
-        }
+        let results = collect_join_set_results(join_set, shards_len, "single_plan_handler").await?;
 
         if preserve_region_results {
             Ok(results
@@ -472,27 +507,22 @@ where
         let stores = self.pd_client.clone().all_stores().await?;
         let stores_len = stores.len();
         let mut join_set = JoinSet::new();
-        for store in stores {
+        for (idx, store) in stores.into_iter().enumerate() {
             let mut clone = self.inner.clone();
             clone.apply_store(&store);
-            join_set.spawn(Self::single_store_handler(
-                clone,
-                self.backoff.clone(),
-                concurrency_permits.clone(),
-            ));
+            let backoff = self.backoff.clone();
+            let concurrency_permits = concurrency_permits.clone();
+            join_set.spawn(async move {
+                (
+                    idx,
+                    Self::single_store_handler(clone, backoff, concurrency_permits).await,
+                )
+            });
         }
 
-        let mut results = Vec::with_capacity(stores_len);
-        while let Some(join_result) = join_set.join_next().await {
-            match join_result {
-                Ok(val) => results.push(val),
-                Err(e) => {
-                    error!("failed to join task: {}", e);
-                    return Err(Error::JoinError(e));
-                }
-            }
-        }
-        Ok(results.into_iter().collect::<Vec<_>>())
+        let results =
+            collect_join_set_results(join_set, stores_len, "single_store_handler").await?;
+        Ok(results)
     }
 }
 
@@ -952,6 +982,8 @@ impl<Resp: HasRegionError, Shard> HasRegionError for ResponseWithShard<Resp, Sha
 
 #[cfg(test)]
 mod test {
+    use std::time::Duration;
+
     use futures::stream::BoxStream;
     use futures::stream::{self};
 
@@ -1003,5 +1035,22 @@ mod test {
             preserve_region_results: false,
         };
         assert!(plan.execute().await.is_err())
+    }
+
+    #[tokio::test]
+    async fn test_join_set_results_keep_spawn_order() {
+        let mut join_set = JoinSet::new();
+        for (idx, delay_ms) in [(0, 30), (1, 10), (2, 20)] {
+            join_set.spawn(async move {
+                sleep(Duration::from_millis(delay_ms)).await;
+                (idx, idx)
+            });
+        }
+
+        let results = collect_join_set_results(join_set, 3, "test_handler")
+            .await
+            .unwrap();
+
+        assert_eq!(results, vec![0, 1, 2]);
     }
 }

--- a/src/request/plan.rs
+++ b/src/request/plan.rs
@@ -5,9 +5,10 @@ use std::sync::Arc;
 
 use async_recursion::async_recursion;
 use async_trait::async_trait;
-use futures::future::try_join_all;
+use tokio::task::JoinSet;
 use futures::prelude::*;
 use log::debug;
+use log::error;
 use log::info;
 use log::warn;
 use tokio::sync::Semaphore;
@@ -118,12 +119,13 @@ where
         preserve_region_results: bool,
     ) -> Result<<Self as Plan>::Result> {
         let shards = current_plan.shards(&pd_client).collect::<Vec<_>>().await;
-        debug!("single_plan_handler, shards: {}", shards.len());
-        let mut handles = Vec::with_capacity(shards.len());
+        let shards_len = shards.len();
+        debug!("single_plan_handler, shards: {}", shards_len);
+        let mut join_set = JoinSet::new();
         for shard in shards {
             let (shard, region) = shard?;
             let clone = current_plan.clone_then_apply_shard(shard);
-            let handle = tokio::spawn(Self::single_shard_handler(
+            join_set.spawn(Self::single_shard_handler(
                 pd_client.clone(),
                 clone,
                 region,
@@ -131,10 +133,19 @@ where
                 permits.clone(),
                 preserve_region_results,
             ));
-            handles.push(handle);
         }
 
-        let results = try_join_all(handles).await?;
+        let mut results = Vec::with_capacity(shards_len);
+        while let Some(join_result) = join_set.join_next().await {
+            match join_result {
+                Ok(val) => results.push(val),
+                Err(e) => {
+                    error!("failed to join task: {}", e);
+                    return Err(Error::JoinError(e));
+                }
+            }
+        }
+
         if preserve_region_results {
             Ok(results
                 .into_iter()
@@ -459,18 +470,28 @@ where
     async fn execute(&self) -> Result<Self::Result> {
         let concurrency_permits = Arc::new(Semaphore::new(MULTI_STORES_CONCURRENCY));
         let stores = self.pd_client.clone().all_stores().await?;
-        let mut handles = Vec::with_capacity(stores.len());
+        let stores_len = stores.len();
+        let mut join_set = JoinSet::new();
         for store in stores {
             let mut clone = self.inner.clone();
             clone.apply_store(&store);
-            let handle = tokio::spawn(Self::single_store_handler(
+            join_set.spawn(Self::single_store_handler(
                 clone,
                 self.backoff.clone(),
                 concurrency_permits.clone(),
             ));
-            handles.push(handle);
         }
-        let results = try_join_all(handles).await?;
+
+        let mut results = Vec::with_capacity(stores_len);
+        while let Some(join_result) = join_set.join_next().await {
+            match join_result {
+                Ok(val) => results.push(val),
+                Err(e) => {
+                    error!("failed to join task: {}", e);
+                    return Err(Error::JoinError(e));
+                }
+            }
+        }
         Ok(results.into_iter().collect::<Vec<_>>())
     }
 }

--- a/src/request/plan.rs
+++ b/src/request/plan.rs
@@ -5,13 +5,13 @@ use std::sync::Arc;
 
 use async_recursion::async_recursion;
 use async_trait::async_trait;
-use tokio::task::JoinSet;
 use futures::prelude::*;
 use log::debug;
 use log::error;
 use log::info;
 use log::warn;
 use tokio::sync::Semaphore;
+use tokio::task::JoinSet;
 use tokio::time::sleep;
 
 use crate::backoff::Backoff;
@@ -94,6 +94,15 @@ pub(crate) fn is_grpc_error(e: &Error) -> bool {
     matches!(e, Error::GrpcAPI(_) | Error::Grpc(_))
 }
 
+/// Await every task in `join_set`, reassembling the results in spawn order.
+///
+/// Contract: on any join failure (a panicked or cancelled task) the remaining tasks
+/// are aborted via [`JoinSet::shutdown`] before the error is returned — an error from
+/// the surrounding handler therefore means *no further effects from this call*. The
+/// previous `try_join_all`-over-`JoinHandle`s code instead **detached** in-flight
+/// tasks on early return, which let them race on after the caller had already
+/// observed the failure and panicked the runtime's timer driver when a short-lived
+/// runtime shut down underneath them (#534).
 async fn collect_join_set_results<T>(
     mut join_set: JoinSet<(usize, T)>,
     task_count: usize,


### PR DESCRIPTION
Closes #534. Supersedes #535 — offered so the fix isn't blocked on rebase logistics. It carries @pingyu's two commits **unchanged, authorship and sign-off preserved**, plus one follow-up commit.

**Why superseding:** #535's merge conflict consists entirely of its dependency-pin commit for rust-toolchain 1.84.1, obsolete since #530 moved the toolchain to 1.93. With that commit dropped, the change rebases onto master with no conflicts. @pingyu — if you'd rather rebase #535 itself, say the word and I'll close this one.

**The follow-up commit:** raises tokio's floor to 1.21 (`JoinSet` stabilized there; `tokio = "1"` permitted resolutions that can't compile this crate), applies `cargo fmt`, and adds the doc comment the #535 review asked for — stating the contract that an error return means no further effects: remaining tasks are aborted, never detached (the old detach-on-error could complete stray writes after an observed failure, beyond the #534 panic).

**Verification:** `cargo test --lib` 67/67 (including the spawn-order test); clippy + fmt clean at 1.93; and a differential parity harness ([getwyrd/client-rust-test](https://github.com/getwyrd/client-rust-test)) driving client-go and client-rust through identical multi-region scenarios shows no wire-visible behavior change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability for concurrent execution across multiple shards or stores.
  * Ensured results are returned in the same order as tasks were started.
  * Added safer handling for task failures, cancellations, and panics, preventing partial/incorrect aggregation.

* **Chores**
  * Updated the Tokio runtime dependency to 1.21.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->