### PR TITLE
request: treat an undetermined apply outcome as terminal at commit points

### DIFF
--- a/src/raw/client.rs
+++ b/src/raw/client.rs
@@ -697,7 +697,13 @@ impl<PdC: PdClient> Client<PdC> {
             self.cf.clone(),
         );
         let plan = crate::request::PlanBuilder::new(self.rpc.clone(), self.keyspace, req)
-            .retry_multi_region(self.backoff.clone())
+            // CAS is not replay-safe once the outcome is unknown: if the first attempt
+            // applied, a retry would compare against the swapped-in value and report
+            // `succeed = false` for a write that HAPPENED. Terminal on first sight —
+            // and the outcome is unknown BOTH when the server says so
+            // (errorpb.UndeterminedResult) and when the dispatch fails after the
+            // request may have been sent (a gRPC error), so both are terminal here.
+            .retry_multi_region_terminal_on_ambiguous_outcome(self.backoff.clone())
             .merge(CollectSingle)
             .post_process_default()
             .plan();

--- a/src/request/plan.rs
+++ b/src/request/plan.rs
@@ -132,6 +132,14 @@ where
         .collect())
 }
 
+/// Did the server say the request's outcome is UNKNOWN — e.g. a raft timeout where the
+/// apply result was never observed (`errorpb.UndeterminedResult`)? A commit receiving
+/// this must be reported as undetermined: reporting plain failure would invite the
+/// caller to retry effects that may already be durable.
+pub(crate) fn is_undetermined_region_error(e: &Error) -> bool {
+    matches!(e, Error::RegionError(re) if re.undetermined_result.is_some())
+}
+
 pub struct RetryableMultiRegion<P: Plan, PdC: PdClient> {
     pub(super) inner: P,
     pub pd_client: Arc<PdC>,
@@ -141,6 +149,30 @@ pub struct RetryableMultiRegion<P: Plan, PdC: PdClient> {
     /// If true, return Ok and preserve all regions' results, even if some of them are Err.
     /// Otherwise, return the first Err if there is any.
     pub preserve_region_results: bool,
+
+    /// Terminal treatment of `errorpb.UndeterminedResult` (an unknown raft apply
+    /// outcome). client-go's transport never retries it and each ACTION decides
+    /// (region_request.go: "should not retry ... processed by the caller"); its one
+    /// terminal action is the primary non-async commit (commit.go: returns
+    /// ErrResultUndetermined). Plans opt in when a replay could produce a WRONG
+    /// RESULT (raw CAS replaying against its own effect) or when the request is a
+    /// commit point and a later, different retry error must not overwrite the
+    /// uncertainty (primary commit; async/1PC prewrite — stricter than client-go,
+    /// in the safe direction). Everything else retries: re-applying an idempotent
+    /// request resolves the uncertainty, and on backoff exhaustion the error
+    /// escapes UNCHANGED for the caller to classify.
+    pub terminal_on_undetermined: bool,
+
+    /// Terminal treatment of a DISPATCH-stage gRPC error, for the request whose
+    /// replay is not idempotent with respect to its own result: raw CAS. Once the
+    /// request may have been sent, a lost response is as ambiguous as
+    /// `errorpb.UndeterminedResult` — a replay would compare against the first
+    /// attempt's own write and could report `succeed = false` for a write that
+    /// happened. Sharding/connection errors still retry (the request was never
+    /// sent), and commit points do NOT set this: replaying a commit is idempotent —
+    /// it can only resolve the uncertainty — and client-go's transport likewise
+    /// retries RPC errors there (region_request.go, onSendFail).
+    pub terminal_on_dispatch_error: bool,
 }
 
 impl<P: Plan + Shardable, PdC: PdClient> RetryableMultiRegion<P, PdC>
@@ -155,6 +187,8 @@ where
         backoff: Backoff,
         permits: Arc<Semaphore>,
         preserve_region_results: bool,
+        terminal_on_undetermined: bool,
+        terminal_on_dispatch_error: bool,
     ) -> Result<<Self as Plan>::Result> {
         let shards = current_plan.shards(&pd_client).collect::<Vec<_>>().await;
         let shards_len = shards.len();
@@ -182,6 +216,8 @@ where
                         backoff,
                         permits,
                         preserve_region_results,
+                        terminal_on_undetermined,
+                        terminal_on_dispatch_error,
                     )
                     .await,
                 )
@@ -200,15 +236,34 @@ where
                 })
                 .collect())
         } else {
-            Ok(results
-                .into_iter()
-                .collect::<Result<Vec<_>>>()?
-                .into_iter()
-                .flatten()
-                .collect())
+            // A terminal undetermined outcome must never be masked by another shard's
+            // determinate error. `collect::<Result<_>>()` would return the first error
+            // by shard index, so if a lower-index shard failed with (say) a gRPC error
+            // while a higher-index shard reported `UndeterminedResult`, the caller would
+            // be told the request definitely failed — and might replay a transaction
+            // that may already be durable. So an undetermined error
+            // from ANY shard wins over a determinate one.
+            let mut oks = Vec::with_capacity(results.len());
+            let mut first_err: Option<Error> = None;
+            let mut undetermined: Option<Error> = None;
+            for r in results {
+                match r {
+                    Ok(v) => oks.push(v),
+                    Err(e) if undetermined.is_none() && is_undetermined_region_error(&e) => {
+                        undetermined = Some(e)
+                    }
+                    Err(e) if first_err.is_none() => first_err = Some(e),
+                    Err(_) => {}
+                }
+            }
+            if let Some(e) = undetermined.or(first_err) {
+                return Err(e);
+            }
+            Ok(oks.into_iter().flatten().collect())
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     #[async_recursion]
     async fn single_shard_handler(
         pd_client: Arc<PdC>,
@@ -217,6 +272,8 @@ where
         mut backoff: Backoff,
         permits: Arc<Semaphore>,
         preserve_region_results: bool,
+        terminal_on_undetermined: bool,
+        terminal_on_dispatch_error: bool,
     ) -> Result<<Self as Plan>::Result> {
         let region_ver_id = region.ver_id();
         let store_id = region.get_store_id().ok();
@@ -243,6 +300,8 @@ where
                     backoff,
                     permits,
                     preserve_region_results,
+                    terminal_on_undetermined,
+                    terminal_on_dispatch_error,
                     err,
                 )
                 .await;
@@ -258,6 +317,21 @@ where
             Ok(resp) => resp,
             Err(e) if is_grpc_error(&e) => {
                 debug!("single_shard_handler:execute: grpc error: {:?}", e);
+                // See `terminal_on_dispatch_error`: a non-idempotent request (raw
+                // CAS) that may have reached the server must not be replayed — the
+                // error surfaces UNCHANGED for the caller to handle. Only the REPLAY
+                // is skipped: routing is refreshed exactly as `handle_other_error`
+                // would, because the failure may be a dead cached leader/store and
+                // later requests must not keep selecting it.
+                if terminal_on_dispatch_error {
+                    pd_client
+                        .invalidate_region_cache(region_store.region_with_leader.ver_id())
+                        .await;
+                    if let Ok(store_id) = region_store.region_with_leader.get_store_id() {
+                        pd_client.invalidate_store_cache(store_id).await;
+                    }
+                    return Err(e);
+                }
                 return Self::handle_other_error(
                     pd_client,
                     plan,
@@ -266,6 +340,8 @@ where
                     backoff,
                     permits,
                     preserve_region_results,
+                    terminal_on_undetermined,
+                    terminal_on_dispatch_error,
                     e,
                 )
                 .await;
@@ -284,6 +360,13 @@ where
                 "single_shard_handler:execute: region error: {:?}, region: {:?}",
                 e, region_ver_id
             );
+            // See `terminal_on_undetermined`: for CAS and commit points, an unknown
+            // apply outcome must surface on FIRST sight — a replay could contradict
+            // its own effect, and a later different error must not overwrite the
+            // uncertainty. The caller classifies (commit maps it to UndeterminedError).
+            if terminal_on_undetermined && e.undetermined_result.is_some() {
+                return Err(Error::RegionError(Box::new(e)));
+            }
             match backoff.next_delay_duration() {
                 Some(duration) => {
                     let region_error_resolved =
@@ -298,6 +381,8 @@ where
                         backoff,
                         permits,
                         preserve_region_results,
+                        terminal_on_undetermined,
+                        terminal_on_dispatch_error,
                     )
                     .await
                 }
@@ -323,6 +408,8 @@ where
         mut backoff: Backoff,
         permits: Arc<Semaphore>,
         preserve_region_results: bool,
+        terminal_on_undetermined: bool,
+        terminal_on_dispatch_error: bool,
         e: Error,
     ) -> Result<<Self as Plan>::Result> {
         debug!("handle_other_error: {:?}", e);
@@ -341,6 +428,8 @@ where
                     backoff,
                     permits,
                     preserve_region_results,
+                    terminal_on_undetermined,
+                    terminal_on_dispatch_error,
                 )
                 .await
             }
@@ -391,6 +480,15 @@ pub(crate) async fn handle_region_error<PdC: PdClient>(
         on_region_epoch_not_match(pd_client.clone(), region_store, e.epoch_not_match.unwrap()).await
     } else if e.stale_command.is_some() || e.region_not_found.is_some() {
         pd_client.invalidate_region_cache(ver_id).await;
+        Ok(false)
+    } else if e.undetermined_result.is_some() {
+        // The apply outcome is UNKNOWN (a raft timeout, errorpb.UndeterminedResult).
+        // Default: retry — matching client-go's ACTION layers (ordinary prewrites and
+        // secondary commits back off and re-send; re-applying an idempotent request
+        // resolves the uncertainty). Routing is not suspect, so nothing is
+        // invalidated. On backoff exhaustion the error escapes UNCHANGED, and commit
+        // paths classify it via `is_undetermined_region_error`. Plans for which a
+        // replay is unsafe never reach this arm — see `terminal_on_undetermined`.
         Ok(false)
     } else if e.server_is_busy.is_some()
         || e.raft_entry_too_large.is_some()
@@ -457,6 +555,8 @@ impl<P: Plan, PdC: PdClient> Clone for RetryableMultiRegion<P, PdC> {
             pd_client: self.pd_client.clone(),
             backoff: self.backoff.clone(),
             preserve_region_results: self.preserve_region_results,
+            terminal_on_undetermined: self.terminal_on_undetermined,
+            terminal_on_dispatch_error: self.terminal_on_dispatch_error,
         }
     }
 }
@@ -479,6 +579,8 @@ where
             self.backoff.clone(),
             concurrency_permits.clone(),
             self.preserve_region_results,
+            self.terminal_on_undetermined,
+            self.terminal_on_dispatch_error,
         )
         .await
     }
@@ -995,6 +1097,8 @@ impl<Resp: HasRegionError, Shard> HasRegionError for ResponseWithShard<Resp, Sha
 
 #[cfg(test)]
 mod test {
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::atomic::Ordering;
     use std::time::Duration;
 
     use futures::stream::BoxStream;
@@ -1046,6 +1150,8 @@ mod test {
             pd_client: Arc::new(MockPdClient::default()),
             backoff: Backoff::no_backoff(),
             preserve_region_results: false,
+            terminal_on_undetermined: false,
+            terminal_on_dispatch_error: false,
         };
         assert!(plan.execute().await.is_err())
     }
@@ -1065,5 +1171,294 @@ mod test {
             .unwrap();
 
         assert_eq!(results, vec![0, 1, 2]);
+    }
+
+    /// Always answers with an undetermined apply outcome, and counts how many times
+    /// it is dispatched. The retry loop re-shards a CLONE per attempt, so the count
+    /// lives behind an `Arc` the clones share.
+    #[derive(Clone, Default)]
+    struct UndeterminedPlan {
+        dispatches: Arc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl Plan for UndeterminedPlan {
+        type Result = BatchGetResponse;
+
+        async fn execute(&self) -> Result<Self::Result> {
+            self.dispatches.fetch_add(1, Ordering::SeqCst);
+            // The server says the apply outcome is UNKNOWN.
+            Ok(BatchGetResponse {
+                region_error: Some(errorpb::Error {
+                    undetermined_result: Some(errorpb::UndeterminedResult::default()),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            })
+        }
+    }
+
+    impl Shardable for UndeterminedPlan {
+        type Shard = ();
+
+        fn shards(
+            &self,
+            _: &Arc<impl crate::pd::PdClient>,
+        ) -> BoxStream<'static, crate::Result<(Self::Shard, RegionWithLeader)>> {
+            Box::pin(stream::iter(vec![Ok(((), MockPdClient::region1()))])).boxed()
+        }
+
+        fn apply_shard(&mut self, _: Self::Shard) {}
+
+        fn apply_store(&mut self, _: &crate::store::RegionStore) -> Result<()> {
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn an_undetermined_result_is_terminal_on_first_sight_for_optedin_plans() {
+        // CAS and commit points: a replay could contradict its own effect, and a
+        // later different error must not overwrite the uncertainty. The error alone
+        // cannot prove terminality — retrying to exhaustion resurfaces the SAME
+        // error — so the proof is the dispatch count: a generous backoff that WOULD
+        // allow 10 retries, and exactly one dispatch anyway.
+        let inner = UndeterminedPlan::default();
+        let dispatches = inner.dispatches.clone();
+        let plan = RetryableMultiRegion {
+            inner,
+            pd_client: Arc::new(MockPdClient::default()),
+            backoff: Backoff::no_jitter_backoff(1, 2, 10),
+            preserve_region_results: false,
+            terminal_on_undetermined: true,
+            terminal_on_dispatch_error: false,
+        };
+        let err = plan.execute().await.unwrap_err();
+        assert!(
+            is_undetermined_region_error(&err),
+            "want the undetermined region error surfaced unchanged, got {err:?}"
+        );
+        assert_eq!(
+            dispatches.load(Ordering::SeqCst),
+            1,
+            "terminal means the first sight is the last: no replay may follow"
+        );
+    }
+
+    #[tokio::test]
+    async fn an_undetermined_result_stays_recognizable_when_retries_exhaust() {
+        // Everything else retries (client-go's action-layer behavior for ordinary
+        // prewrites and secondary commits); when the backoff exhausts, the error
+        // must escape UNCHANGED so commit paths can still classify it as undetermined.
+        // The dispatch count proves the retries actually happened — the complement
+        // of the terminal test above.
+        const RETRIES: u32 = 3;
+        let inner = UndeterminedPlan::default();
+        let dispatches = inner.dispatches.clone();
+        let plan = RetryableMultiRegion {
+            inner,
+            pd_client: Arc::new(MockPdClient::default()),
+            backoff: Backoff::no_jitter_backoff(1, 2, RETRIES),
+            preserve_region_results: false,
+            terminal_on_undetermined: false,
+            terminal_on_dispatch_error: false,
+        };
+        let err = plan.execute().await.unwrap_err();
+        assert!(
+            is_undetermined_region_error(&err),
+            "want the undetermined region error preserved, got {err:?}"
+        );
+        assert_eq!(
+            dispatches.load(Ordering::SeqCst),
+            RETRIES as usize + 1,
+            "the default path retries: one initial dispatch plus one per backoff attempt"
+        );
+    }
+
+    /// Always fails DISPATCH with a gRPC status error (the shape of a lost response:
+    /// the request may have reached the server), counting dispatches like
+    /// [`UndeterminedPlan`].
+    #[derive(Clone, Default)]
+    struct GrpcErrPlan {
+        dispatches: Arc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl Plan for GrpcErrPlan {
+        type Result = BatchGetResponse;
+
+        async fn execute(&self) -> Result<Self::Result> {
+            self.dispatches.fetch_add(1, Ordering::SeqCst);
+            Err(Error::GrpcAPI(tonic::Status::unavailable("response lost")))
+        }
+    }
+
+    impl Shardable for GrpcErrPlan {
+        type Shard = ();
+
+        fn shards(
+            &self,
+            _: &Arc<impl crate::pd::PdClient>,
+        ) -> BoxStream<'static, crate::Result<(Self::Shard, RegionWithLeader)>> {
+            Box::pin(stream::iter(vec![Ok(((), MockPdClient::region1()))])).boxed()
+        }
+
+        fn apply_shard(&mut self, _: Self::Shard) {}
+
+        fn apply_store(&mut self, _: &crate::store::RegionStore) -> Result<()> {
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn a_dispatch_error_is_terminal_on_first_sight_for_nonidempotent_plans() {
+        // Raw CAS: a dispatch that may have reached the server is as ambiguous as
+        // UndeterminedResult — a replay would compare against its own effect. Same
+        // proof shape as the terminal-on-undetermined test: a backoff that WOULD
+        // allow 10 retries, and exactly one dispatch anyway.
+        let inner = GrpcErrPlan::default();
+        let dispatches = inner.dispatches.clone();
+        let plan = RetryableMultiRegion {
+            inner,
+            pd_client: Arc::new(MockPdClient::default()),
+            backoff: Backoff::no_jitter_backoff(1, 2, 10),
+            preserve_region_results: false,
+            terminal_on_undetermined: true,
+            terminal_on_dispatch_error: true,
+        };
+        let err = plan.execute().await.unwrap_err();
+        assert!(
+            is_grpc_error(&err),
+            "want the gRPC error surfaced unchanged, got {err:?}"
+        );
+        assert_eq!(
+            dispatches.load(Ordering::SeqCst),
+            1,
+            "a non-idempotent request must never be replayed once it may have been sent"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_dispatch_error_still_retries_for_commit_points() {
+        // Commit points set only `terminal_on_undetermined`: replaying a commit is
+        // idempotent — it can only resolve the uncertainty — and client-go's
+        // transport likewise retries RPC errors there (region_request.go,
+        // onSendFail). On exhaustion the error escapes unchanged for the commit
+        // path to classify as undetermined.
+        const RETRIES: u32 = 3;
+        let inner = GrpcErrPlan::default();
+        let dispatches = inner.dispatches.clone();
+        let plan = RetryableMultiRegion {
+            inner,
+            pd_client: Arc::new(MockPdClient::default()),
+            backoff: Backoff::no_jitter_backoff(1, 2, RETRIES),
+            preserve_region_results: false,
+            terminal_on_undetermined: true,
+            terminal_on_dispatch_error: false,
+        };
+        let err = plan.execute().await.unwrap_err();
+        assert!(
+            is_grpc_error(&err),
+            "want the gRPC error preserved for the caller to classify, got {err:?}"
+        );
+        assert_eq!(
+            dispatches.load(Ordering::SeqCst),
+            RETRIES as usize + 1,
+            "commit dispatches retry gRPC errors: one initial plus one per backoff attempt"
+        );
+    }
+
+    #[test]
+    fn undetermined_region_errors_are_recognized() {
+        // errorpb.UndeterminedResult: the apply outcome is UNKNOWN. The commit path
+        // must map this to UndeterminedError — a plain failure would invite the caller
+        // to retry effects that may already be durable.
+        let undetermined = Error::RegionError(Box::new(errorpb::Error {
+            undetermined_result: Some(errorpb::UndeterminedResult::default()),
+            ..Default::default()
+        }));
+        assert!(is_undetermined_region_error(&undetermined));
+
+        let busy = Error::RegionError(Box::new(errorpb::Error {
+            server_is_busy: Some(errorpb::ServerIsBusy::default()),
+            ..Default::default()
+        }));
+        assert!(!is_undetermined_region_error(&busy));
+        assert!(!is_undetermined_region_error(&Error::StringError(
+            "x".to_owned()
+        )));
+    }
+
+    /// A two-shard plan: the LOWER-index shard fails determinately, the HIGHER-index
+    /// shard reports `UndeterminedResult`. Reproduces the masking hazard the shard
+    /// aggregation guards against.
+    #[derive(Clone)]
+    struct MaskingPlan {
+        idx: usize,
+    }
+
+    #[async_trait]
+    impl Plan for MaskingPlan {
+        type Result = BatchGetResponse;
+
+        async fn execute(&self) -> Result<Self::Result> {
+            if self.idx == 0 {
+                // Determinate, lower index — the error that MUST NOT win.
+                Err(Error::Unimplemented)
+            } else {
+                // Undetermined, higher index.
+                Ok(BatchGetResponse {
+                    region_error: Some(errorpb::Error {
+                        undetermined_result: Some(errorpb::UndeterminedResult::default()),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                })
+            }
+        }
+    }
+
+    impl Shardable for MaskingPlan {
+        type Shard = usize;
+
+        fn shards(
+            &self,
+            _: &Arc<impl crate::pd::PdClient>,
+        ) -> BoxStream<'static, crate::Result<(Self::Shard, RegionWithLeader)>> {
+            Box::pin(stream::iter(vec![
+                Ok((0usize, MockPdClient::region1())),
+                Ok((1usize, MockPdClient::region2())),
+            ]))
+            .boxed()
+        }
+
+        fn apply_shard(&mut self, shard: Self::Shard) {
+            self.idx = shard;
+        }
+
+        fn apply_store(&mut self, _: &crate::store::RegionStore) -> Result<()> {
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn an_undetermined_shard_is_not_masked_by_another_shards_error() {
+        // THE MASKING HAZARD. Shard 0 fails determinately (lower index); shard 1 is
+        // undetermined. First-error-by-index would report shard 0's determinate
+        // failure and hide the fact that shard 1 may have applied — claiming clean
+        // failure for a write that may be durable.
+        // The aggregation must surface the undetermined error instead.
+        let plan = RetryableMultiRegion {
+            inner: MaskingPlan { idx: 0 },
+            pd_client: Arc::new(MockPdClient::default()),
+            backoff: Backoff::no_backoff(),
+            preserve_region_results: false,
+            terminal_on_undetermined: true,
+            terminal_on_dispatch_error: false,
+        };
+        let err = plan.execute().await.unwrap_err();
+        assert!(
+            is_undetermined_region_error(&err),
+            "the undetermined shard must win over the determinate one, got {err:?}"
+        );
     }
 }

--- a/src/request/plan_builder.rs
+++ b/src/request/plan_builder.rs
@@ -156,6 +156,15 @@ impl<PdC: PdClient, P: Plan, Ph: PlanBuilderPhase> PlanBuilder<PdC, P, Ph> {
     }
 }
 
+/// Named flags for [`PlanBuilder::make_retry_multi_region`]: passed positionally,
+/// three same-typed bools would let a transposed call site compile silently.
+#[derive(Default)]
+struct RetryFlags {
+    preserve_region_results: bool,
+    terminal_on_undetermined: bool,
+    terminal_on_dispatch_error: bool,
+}
+
 impl<PdC: PdClient, P: Plan + Shardable> PlanBuilder<PdC, P, NoTarget>
 where
     P::Result: HasKeyErrors + HasRegionError,
@@ -165,7 +174,7 @@ where
         self,
         backoff: Backoff,
     ) -> PlanBuilder<PdC, RetryableMultiRegion<P, PdC>, Targetted> {
-        self.make_retry_multi_region(backoff, false)
+        self.make_retry_multi_region(backoff, RetryFlags::default())
     }
 
     /// Preserve all results, even some of them are Err.
@@ -174,13 +183,55 @@ where
         self,
         backoff: Backoff,
     ) -> PlanBuilder<PdC, RetryableMultiRegion<P, PdC>, Targetted> {
-        self.make_retry_multi_region(backoff, true)
+        self.make_retry_multi_region(
+            backoff,
+            RetryFlags {
+                preserve_region_results: true,
+                ..Default::default()
+            },
+        )
+    }
+
+    /// Like [`Self::retry_multi_region`], but an `errorpb.UndeterminedResult` is
+    /// terminal on first sight. For commit points (primary commit; async/1PC
+    /// prewrite) — see `RetryableMultiRegion::terminal_on_undetermined`.
+    pub fn retry_multi_region_terminal_on_undetermined(
+        self,
+        backoff: Backoff,
+    ) -> PlanBuilder<PdC, RetryableMultiRegion<P, PdC>, Targetted> {
+        self.make_retry_multi_region(
+            backoff,
+            RetryFlags {
+                terminal_on_undetermined: true,
+                ..Default::default()
+            },
+        )
+    }
+
+    /// Like [`Self::retry_multi_region_terminal_on_undetermined`], and additionally
+    /// a DISPATCH-stage gRPC error is terminal. For the request whose replay is not
+    /// idempotent with respect to its own result (raw CAS): a lost response is as
+    /// ambiguous as an undetermined apply outcome, and a replay could contradict the
+    /// first attempt's own effect. Sharding/connection errors still retry — see
+    /// `RetryableMultiRegion::terminal_on_dispatch_error`.
+    pub fn retry_multi_region_terminal_on_ambiguous_outcome(
+        self,
+        backoff: Backoff,
+    ) -> PlanBuilder<PdC, RetryableMultiRegion<P, PdC>, Targetted> {
+        self.make_retry_multi_region(
+            backoff,
+            RetryFlags {
+                terminal_on_undetermined: true,
+                terminal_on_dispatch_error: true,
+                ..Default::default()
+            },
+        )
     }
 
     fn make_retry_multi_region(
         self,
         backoff: Backoff,
-        preserve_region_results: bool,
+        flags: RetryFlags,
     ) -> PlanBuilder<PdC, RetryableMultiRegion<P, PdC>, Targetted> {
         PlanBuilder {
             pd_client: self.pd_client.clone(),
@@ -188,7 +239,9 @@ where
                 inner: self.plan,
                 pd_client: self.pd_client,
                 backoff,
-                preserve_region_results,
+                preserve_region_results: flags.preserve_region_results,
+                terminal_on_undetermined: flags.terminal_on_undetermined,
+                terminal_on_dispatch_error: flags.terminal_on_dispatch_error,
             },
             phantom: PhantomData,
         }

--- a/src/transaction/transaction.rs
+++ b/src/transaction/transaction.rs
@@ -1340,7 +1340,34 @@ impl<PdC: PdClient> Committer<PdC> {
             self.start_version.version()
         );
 
-        let min_commit_ts = self.prewrite().await?;
+        let min_commit_ts = match self.prewrite().await {
+            Ok(ts) => ts,
+            Err(e) => {
+                // With async commit or 1PC the PREWRITE is the commit point: when the
+                // server reports the outcome as unknown (errorpb.UndeterminedResult),
+                // or we never received its answer at all (a gRPC error), the
+                // transaction may already be durable, and a plain error would invite
+                // the caller to replay it. client-go marks undetermined the same way
+                // (prewrite.go, prewrite1BatchReqHandler.drop: any RPC error on an
+                // async-commit/1PC prewrite sets the committer's undetermined error).
+                //
+                // PRECISION NOTE: if 1PC was configured but sharding disabled it on
+                // the actual requests (multi-region transactions), this is
+                // conservative — it can report UNDETERMINED for a prewrite that could
+                // not have committed. That is the safe direction: the caller verifies
+                // instead of replaying. The per-request 1PC state is not observable
+                // on the error path; precise gating belongs to the upfront
+                // single-region 1PC decision (client-go's checkOnePC shape) that full
+                // 1PC support will introduce.
+                return if (self.options.async_commit || self.options.try_one_pc)
+                    && is_commit_outcome_unknown(&e)
+                {
+                    Err(Error::UndeterminedError(Box::new(e)))
+                } else {
+                    Err(e)
+                };
+            }
+        };
 
         fail_point!("after-prewrite", |_| {
             Err(Error::StringError(
@@ -1411,16 +1438,23 @@ impl<PdC: PdClient> Committer<PdC> {
             .collect();
         // FIXME set max_commit_ts and min_commit_ts
 
-        let plan = PlanBuilder::new(self.rpc.clone(), self.keyspace, request)
-            .resolve_lock(
-                self.start_version.clone(),
-                self.options.retry_options.lock_backoff.clone(),
-                self.keyspace,
+        let builder = PlanBuilder::new(self.rpc.clone(), self.keyspace, request).resolve_lock(
+            self.start_version.clone(),
+            self.options.retry_options.lock_backoff.clone(),
+            self.keyspace,
+        );
+        // With async commit or 1PC this prewrite IS the commit point, so an unknown
+        // apply outcome must not be retried away or overwritten by a later error
+        // (stricter than client-go, in the safe direction; commit() classifies it).
+        // An ordinary 2PC prewrite retries, as client-go's does.
+        let builder = if self.options.async_commit || self.options.try_one_pc {
+            builder.retry_multi_region_terminal_on_undetermined(
+                self.options.retry_options.region_backoff.clone(),
             )
-            .retry_multi_region(self.options.retry_options.region_backoff.clone())
-            .merge(CollectError)
-            .extract_error()
-            .plan();
+        } else {
+            builder.retry_multi_region(self.options.retry_options.region_backoff.clone())
+        };
+        let plan = builder.merge(CollectError).extract_error().plan();
         let response = plan.execute().await?;
 
         if self.options.try_one_pc && response.len() == 1 {
@@ -1464,7 +1498,12 @@ impl<PdC: PdClient> Committer<PdC> {
                 self.options.retry_options.lock_backoff.clone(),
                 self.keyspace,
             )
-            .retry_multi_region(self.options.retry_options.region_backoff.clone())
+            // The primary commit is THE commit point: client-go returns
+            // ErrResultUndetermined here rather than retrying (commit.go), so an
+            // unknown outcome can never be overwritten by a later retry error.
+            .retry_multi_region_terminal_on_undetermined(
+                self.options.retry_options.region_backoff.clone(),
+            )
             .extract_error()
             .plan();
         plan.execute()
@@ -1475,9 +1514,22 @@ impl<PdC: PdClient> Committer<PdC> {
                     self.start_version.version()
                 );
                 // We don't know whether the transaction is committed or not if we fail to receive
-                // the response. Then, we mark the transaction as undetermined and propagate the
-                // error to the user.
-                if let Error::Grpc(_) = e {
+                // the response — or if the server itself reports the raft outcome as unknown
+                // (errorpb.UndeterminedResult). Then, we mark the transaction as undetermined
+                // and propagate the error to the user. Failing-to-receive means ANY gRPC error:
+                // dispatch failures are `Error::GrpcAPI` since the tonic migration (the old
+                // `Error::Grpc`-only match here was a grpcio-era leftover that no longer caught
+                // them), and client-go's equivalent (sender.GetRPCError(), commit.go) likewise
+                // covers status errors and connection failures alike.
+                //
+                // PROVENANCE NOTE: this plan wraps the commit in `resolve_lock`, so an
+                // undetermined error could in principle originate from an auxiliary
+                // CheckTxnStatus/ResolveLock RPC rather than the commit dispatch itself. That
+                // only over-reports (marks undetermined when the commit was actually rejected),
+                // which is the SAFE direction — the caller verifies instead of assuming a clean
+                // outcome. Distinguishing per-layer error provenance is a precision improvement,
+                // not a safety fix, and is left as follow-up.
+                if is_commit_outcome_unknown(e) {
                     self.undetermined = true;
                 }
             })
@@ -1662,6 +1714,19 @@ impl<PdC: PdClient> Committer<PdC> {
         }
         lock_ttl
     }
+}
+
+/// Is the outcome of a commit-point request unknown?
+///
+/// Two ways to lose certainty: we failed to receive a response (a gRPC error — the
+/// analogue of client-go's `sender.GetRPCError()`, which records *any* error from the
+/// RPC call: status errors and connection failures alike), or we received one and the
+/// server itself reported the raft apply outcome unknown
+/// (`errorpb.UndeterminedResult`). Note `Error::GrpcAPI` is the variant every KV RPC
+/// dispatch failure takes since the tonic migration; `Error::Grpc` is only connection
+/// establishment.
+fn is_commit_outcome_unknown(e: &Error) -> bool {
+    crate::request::plan::is_grpc_error(e) || crate::request::plan::is_undetermined_region_error(e)
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
@@ -1869,5 +1934,33 @@ mod tests {
                 .any(|line| line.contains("start_ts") && line.contains(&start_ts.to_string())),
             "expected a lifecycle log carrying start_ts {start_ts}; captured: {logs:?}"
         );
+    }
+
+    #[test]
+    fn commit_outcome_unknown_errors_are_recognized() {
+        use super::is_commit_outcome_unknown;
+
+        // The case an `Error::Grpc`-only match would miss: every KV RPC dispatch
+        // failure is `Error::GrpcAPI` since the tonic migration.
+        assert!(is_commit_outcome_unknown(&crate::Error::GrpcAPI(
+            tonic::Status::unavailable("no response received")
+        )));
+        // The server received the request but reports the raft apply outcome unknown.
+        assert!(is_commit_outcome_unknown(&crate::Error::RegionError(
+            Box::new(crate::proto::errorpb::Error {
+                undetermined_result: Some(crate::proto::errorpb::UndeterminedResult::default()),
+                ..Default::default()
+            })
+        )));
+        // Determinate failures stay plain failures.
+        assert!(!is_commit_outcome_unknown(&crate::Error::StringError(
+            "rejected".to_owned()
+        )));
+        assert!(!is_commit_outcome_unknown(&crate::Error::RegionError(
+            Box::new(crate::proto::errorpb::Error {
+                server_is_busy: Some(crate::proto::errorpb::ServerIsBusy::default()),
+                ..Default::default()
+            })
+        )));
     }
 }


### PR DESCRIPTION
> Stacked on #550 — please review the second commit only. Until #550 merges, the diff below also
> contains its re-vendor.

**Why:** the re-vendored kvproto exposes `errorpb.UndeterminedResult` — the server telling us the
raft apply outcome is UNKNOWN. Today it falls through to the generic region-error arm and is retried
like any transient failure. For most requests that's right; for a commit point it isn't. "Failed"
must never be claimed for a transaction that may already be durable.

**What:** follow client-go's shape. Its transport never retries `UndeterminedResult` ("should not
retry … processed by the caller", `region_request.go`) and each *action* decides. So the plan layer
keeps **retry as the default** — replaying an idempotent request resolves the uncertainty, and on
backoff exhaustion the error escapes *unchanged* so callers can still classify it — while plans for
which a replay is unsafe opt in to terminal-on-first-sight:

- **raw CAS** — a replay would compare against its *own* effect and report `succeed = false` for a
  write that happened.
- **the primary commit** — client-go returns `ErrResultUndetermined` here (`commit.go`) rather than
  retrying.
- **async-commit / 1PC prewrites** — the prewrite *is* the commit point. Stricter than client-go, in
  the safe direction.

**Shard aggregation is fixed alongside:** `collect::<Result<_>>()` returns the first error *by shard
index*, so a lower-index shard's determinate error could mask a higher-index shard's
`UndeterminedResult` and tell the caller the request definitely failed. An undetermined error from
any shard now wins.

Commit paths classify the surfaced error as `UndeterminedError`. Two places are deliberately
conservative and say so in comments: a 1PC prewrite that sharding downgraded to 2PC, and an
undetermined error arriving from the commit plan's `resolve_lock` layer rather than the commit
dispatch. Both only *over*-report uncertainty, which makes the caller verify instead of replay.

**Verification:** 4 new tests — terminal for opted-in plans under a *generous* backoff (proving
terminal, not merely retry-exhausted), preserved unchanged on retry exhaustion, recognizer
positive/negative, and the shard-masking hazard. 71 lib tests; `make check` green; txn/raw/failpoint
integration suites green against a local api-v2 cluster.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved transaction commit handling when the final outcome cannot be determined.
  - Prevented unsafe retries after requests may already have been sent.
  - Preserved and surfaced undetermined-region and dispatch errors.
  - Improved error prioritization when multiple regions report failures.

- **New Features**
  - Added configurable multi-region retry behavior for undetermined results and ambiguous outcomes.
  - Operations can now stop immediately when outcomes are uncertain, providing clearer transaction results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->